### PR TITLE
Revert low pressure damage

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -318,7 +318,7 @@ namespace Content.Shared.Atmos
         ///     so it just applies this flat value).
         /// </summary>
         // Original value is 4, buff back when we have proper ways for players to deal with breaches.
-        public const int LowPressureDamage = 1;
+        public const int LowPressureDamage = 4; // Moffstation change - Revert to original value for a better MRP experience
 
         public const float WindowHeatTransferCoefficient = 0.1f;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Revert atmospheric barotrauma damage to the original pre-nerf value.

## Why / Balance
This is something that a lot of MRP forks do. It usually leads to players taking logical decisions based on the constraints placed upon them. If spacing damage is 1/4, then players won't treat it as much of a threat.

## Technical details
Just changes the constant.

**Changelog**
N/A for now.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->