### PR TITLE
Update PR guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,10 @@
-<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
+<!--
+You are making this pull request for the Moffstation fork of Space Station 14.
+
+Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
+Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
+See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
+-->
 
 ## About the PR
 <!-- What did you change? -->
@@ -10,12 +16,13 @@
 <!-- Summary of code changes for easier review. -->
 
 ## Media
-<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
+<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
 Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
 
 ## Requirements
 <!-- Confirm the following by placing an X in the brackets [X]: -->
 - [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
+- [ ] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
 - [ ] I have added media to this PR or it does not require an ingame showcase.
 <!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
 


### PR DESCRIPTION
## About the PR
Update PR guidelines.

The guidelines now:
- Explicitly warn that you're contributing to Moffstation.
- Outline the contributing guidelines for what we want to see, by linking Harmony's PR guidelines.
- Have another checkmark asking the PR author to confirm that they've properly sectioned their code appropriately.

## Why / Balance
We'd like to start enforcing some sectioning so that we can do upstream merges and content ports with minimal pain and suffering.