### PR TITLE
upd changelog manually

### DIFF
--- a/Resources/Changelog/Mofflog.yml
+++ b/Resources/Changelog/Mofflog.yml
@@ -7,3 +7,33 @@ Entries:
     type: Add
   id: 1
   time: '2025-03-22T01:29:24.112Z'
+- author: Southbridge
+  changes:
+  - message: Added colorful light boxes! They're available to purchase from cargo.
+    type: Add
+  id: 2
+  time: '2025-03-22T01:29:24.112Z'
+- author: Centronias
+  changes:
+  - message: Added station records! You can now create custom records for your character.
+    type: Add
+  id: 3
+  time: '2025-03-22T01:29:24.112Z'
+- author: ArtisticRoomba
+  changes:
+    - message: Barotrauma low pressure damage has been tweaked to its original unnerfed value (previously reduced to 1/4th).
+      type: Tweak
+  id: 4
+  time: '2025-03-22T01:29:24.112Z'
+- author: Centronias
+  changes:
+    - message: Role timers for trinkets have been temporarily disabled.
+      type: Tweak
+  id: 5
+  time: '2025-03-22T01:29:24.112Z'
+- author: DuckManZach
+  changes:
+    - message: Chloral Hydrate has been given a forced sleep threshold of 25u. It also no longer does poison damage.
+      type: Tweak
+  id: 6
+  time: '2025-03-22T01:29:24.112Z'

--- a/Resources/Changelog/MofflogAdmin.yml
+++ b/Resources/Changelog/MofflogAdmin.yml
@@ -8,3 +8,9 @@ Entries:
     type: Add
   id: 1
   time: '2025-03-22T01:29:24.112Z'
+- author: Centronias
+  changes:
+    - message: New CVAR "game.role_loadout_timers" added to enable/disable loadout timers for trinkets and the like.
+      type: Tweak
+  id: 2
+  time: '2025-03-22T01:29:24.112Z'


### PR DESCRIPTION
Me and fred suffer from a between-keyboard-and-chair skill issue so we couldn't get the changelog up in time for next session.

We'd like the changelog to be visible for next playtest tmro though, so I'm manually updating it this time around.