### PR TITLE
Skip loading character records for silicons

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -14,6 +14,12 @@
   jobEntity: StationAiBrain
   jobPreviewEntity: PlayerStationAiPreview
   applyTraits: false
+  # CD: Skip records
+  special:
+  - !type:AddComponentSpecial
+    components:
+    - type: SkipLoadingCharacterRecords
+  # end CD
 
 - type: job
   id: Borg
@@ -28,3 +34,9 @@
   supervisors: job-supervisors-rd
   jobEntity: PlayerBorgBattery
   applyTraits: false
+  # CD: Skip records
+  special:
+  - !type:AddComponentSpecial
+    components:
+    - type: SkipLoadingCharacterRecords
+  # end CD


### PR DESCRIPTION
(I also did a quick audit and made sure there aren't other instances of CD ported components that're missing from prototypes)

:cl:
- fix: Spawning as Station AI and Cyborgs no longer causes your selected character profile's records to be visible on record consoles