### PR TITLE
Decouple Lights from Toggleable Visuals (and headphone music notes bugfix)

### DIFF
--- a/Content.Client/Light/HandheldLightSystem.cs
+++ b/Content.Client/Light/HandheldLightSystem.cs
@@ -44,7 +44,7 @@ public sealed class HandheldLightSystem : SharedHandheldLightSystem
             return;
         }
 
-        if (!_appearance.TryGetData<bool>(uid, ToggleableLightVisuals.Enabled, out var enabled, args.Component))
+        if (!_appearance.TryGetData<bool>(uid, ToggleVisuals.Toggled, out var enabled, args.Component)) // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
         {
             return;
         }

--- a/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
+++ b/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
@@ -8,9 +8,16 @@ using Content.Shared.Toggleable;
 using Robust.Client.GameObjects;
 using Robust.Shared.Utility;
 using System.Linq;
+using Content.Shared.Light.Components; // Moffstation
 
 namespace Content.Client.Toggleable;
 
+/// <summary>
+/// Implements the behavior of <see cref="ToggleableLightVisualsComponent"/> by reacting to
+/// <see cref="AppearanceChangeEvent"/>, for the sprite directly; <see cref="OnGetHeldVisuals"/> for the
+/// in-hand visuals; and <see cref="OnGetEquipmentVisuals"/> for the clothing visuals.
+/// </summary>
+/// <see cref="ToggleableLightVisualsComponent"/>
 public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLightVisualsComponent>
 {
     [Dependency] private readonly SharedItemSystem _itemSys = default!;
@@ -25,10 +32,10 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
 
     protected override void OnAppearanceChange(EntityUid uid, ToggleableLightVisualsComponent component, ref AppearanceChangeEvent args)
     {
-        if (!AppearanceSystem.TryGetData<bool>(uid, ToggleableLightVisuals.Enabled, out var enabled, args.Component))
+        if (!AppearanceSystem.TryGetData<bool>(uid, ToggleVisuals.Toggled, out var enabled, args.Component)) // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
             return;
 
-        var modulate = AppearanceSystem.TryGetData<Color>(uid, ToggleableLightVisuals.Color, out var color, args.Component);
+        var modulate = AppearanceSystem.TryGetData<Color>(uid, ToggleVisuals.Color, out var color, args.Component); // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
 
         // Update the item's sprite
         if (args.Sprite != null && component.SpriteLayer != null && args.Sprite.LayerMapTryGet(component.SpriteLayer, out var layer))
@@ -39,11 +46,12 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
         }
 
         // Update any point-lights
-        if (TryComp(uid, out PointLightComponent? light))
+        if (TryComp(uid, out PointLightComponent? light) &&
+            TryComp<ItemTogglePointLightComponent>(uid, out var toggleLights)) // Moffstation - Use `ItemTogglePointLightComponent`
         {
-            DebugTools.Assert(!light.NetSyncEnabled, "light visualizers require point lights without net-sync");
+            DebugTools.Assert(!light.NetSyncEnabled, $"{typeof(ItemTogglePointLightComponent)} requires point lights without net-sync"); // Moffstation - Use `ItemTogglePointLightComponent`
             _lights.SetEnabled(uid, enabled, light);
-            if (enabled && modulate)
+            if (toggleLights.ToggleVisualsColorModulatesLights && modulate) // Moffstation - Use `ItemTogglePointLightComponent`
             {
                 _lights.SetColor(uid, color, light);
             }
@@ -59,7 +67,7 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
     private void OnGetEquipmentVisuals(EntityUid uid, ToggleableLightVisualsComponent component, GetEquipmentVisualsEvent args)
     {
         if (!TryComp(uid, out AppearanceComponent? appearance)
-            || !AppearanceSystem.TryGetData<bool>(uid, ToggleableLightVisuals.Enabled, out var enabled, appearance)
+            || !AppearanceSystem.TryGetData<bool>(uid, ToggleVisuals.Toggled, out var enabled, appearance) // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
             || !enabled)
             return;
 
@@ -75,7 +83,7 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
         if (layers == null && !component.ClothingVisuals.TryGetValue(args.Slot, out layers))
             return;
 
-        var modulate = AppearanceSystem.TryGetData<Color>(uid, ToggleableLightVisuals.Color, out var color, appearance);
+        var modulate = AppearanceSystem.TryGetData<Color>(uid, ToggleVisuals.Color, out var color, appearance); // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
 
         var i = 0;
         foreach (var layer in layers)
@@ -97,14 +105,14 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
     private void OnGetHeldVisuals(EntityUid uid, ToggleableLightVisualsComponent component, GetInhandVisualsEvent args)
     {
         if (!TryComp(uid, out AppearanceComponent? appearance)
-            || !AppearanceSystem.TryGetData<bool>(uid, ToggleableLightVisuals.Enabled, out var enabled, appearance)
+            || !AppearanceSystem.TryGetData<bool>(uid, ToggleVisuals.Toggled, out var enabled, appearance) // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
             || !enabled)
             return;
 
         if (!component.InhandVisuals.TryGetValue(args.Location, out var layers))
             return;
 
-        var modulate = AppearanceSystem.TryGetData<Color>(uid, ToggleableLightVisuals.Color, out var color, appearance);
+        var modulate = AppearanceSystem.TryGetData<Color>(uid, ToggleVisuals.Color, out var color, appearance); // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
 
         var i = 0;
         var defaultKey = $"inhand-{args.Location.ToString().ToLowerInvariant()}-toggle";

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -272,7 +272,7 @@ namespace Content.Server.Atmos.EntitySystems
             // This is intended so that matches & candles can re-use code for un-shaded layers on in-hand sprites.
             // However, this could cause conflicts if something is ACTUALLY both a toggleable light and flammable.
             // if that ever happens, then fire visuals will need to implement their own in-hand sprite management.
-            _appearance.SetData(uid, ToggleableLightVisuals.Enabled, flammable.OnFire, appearance);
+            _appearance.SetData(uid, ToggleVisuals.Toggled, flammable.OnFire, appearance); // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
         }
 
         public void AdjustFireStacks(EntityUid uid, float relativeFireStacks, FlammableComponent? flammable = null, bool ignite = false)

--- a/Content.Shared/Light/Components/ItemTogglePointLightComponent.cs
+++ b/Content.Shared/Light/Components/ItemTogglePointLightComponent.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.GameStates;
+using Content.Shared.Toggleable; // Moffstation
 
 namespace Content.Shared.Light.Components;
 
@@ -8,5 +9,11 @@ namespace Content.Shared.Light.Components;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class ItemTogglePointLightComponent : Component
 {
-
+    // Moffstation
+    /// <summary>
+    /// When true, causes the color specified in <see cref="ToggleVisuals.Color"/>
+    /// be used to modulate the color of lights on this entity.
+    /// </summary>
+    [DataField("Moffstation_ToggleVisualsColorModulatesLights")]
+    public bool ToggleVisualsColorModulatesLights = false;
 }

--- a/Content.Shared/Light/EntitySystems/ItemTogglePointLightSystem.cs
+++ b/Content.Shared/Light/EntitySystems/ItemTogglePointLightSystem.cs
@@ -25,7 +25,7 @@ public sealed class ItemTogglePointLightSystem : EntitySystem
         if (!_light.TryGetLight(ent.Owner, out var light))
             return;
 
-        _appearance.SetData(ent, ToggleableLightVisuals.Enabled, args.Activated);
+        // Moffstation - Handled by ToggleableLightVisualsSystem // _appearance.SetData(ent, ToggleableLightVisuals.Enabled, args.Activated);
         _light.SetEnabled(ent.Owner, args.Activated, comp: light);
         if (TryComp<HandheldLightComponent>(ent.Owner, out var handheldLight))
         {

--- a/Content.Shared/Light/SharedHandheldLightSystem.cs
+++ b/Content.Shared/Light/SharedHandheldLightSystem.cs
@@ -80,7 +80,7 @@ public abstract class SharedHandheldLightSystem : EntitySystem
         if (component.ToggleActionEntity != null)
             _actionSystem.SetToggled(component.ToggleActionEntity, component.Activated);
 
-        _appearance.SetData(uid, ToggleableLightVisuals.Enabled, component.Activated, appearance);
+        _appearance.SetData(uid, ToggleVisuals.Toggled, component.Activated, appearance); // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
     }
 
     private void AddToggleLightVerb(Entity<HandheldLightComponent> ent, ref GetVerbsEvent<ActivationVerb> args)

--- a/Content.Shared/Toggleable/ToggleActionEvent.cs
+++ b/Content.Shared/Toggleable/ToggleActionEvent.cs
@@ -18,5 +18,6 @@ public sealed partial class ToggleActionEvent : InstantActionEvent;
 public enum ToggleVisuals : byte
 {
     Toggled,
-    Layer
+    Layer,
+    Color, // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
 }

--- a/Content.Shared/Toggleable/ToggleableLightVisuals.cs
+++ b/Content.Shared/Toggleable/ToggleableLightVisuals.cs
@@ -2,13 +2,14 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Toggleable;
 
-// Appearance Data key
-[Serializable, NetSerializable]
-public enum ToggleableLightVisuals : byte
-{
-    Enabled,
-    Color
-}
+// Moffstation - Merged into `Content.Shared.Toggleable.ToggleVisuals`
+// // Appearance Data key
+// [Serializable, NetSerializable]
+// public enum ToggleableLightVisuals : byte
+// {
+//     Enabled,
+//     Color
+// }
 
 /// <summary>
 ///     Generic sprite layer keys.
@@ -20,7 +21,7 @@ public enum LightLayers : byte
 
     /// <summary>
     ///     Used as a key for generic unshaded layers. Not necessarily related to an entity with an actual light source.
-    ///     Use this instead of creating a unique single-purpose "unshaded" enum for every visualizer. 
+    ///     Use this instead of creating a unique single-purpose "unshaded" enum for every visualizer.
     /// </summary>
     Unshaded,
 }

--- a/Content.Shared/Weapons/Melee/EnergySword/EnergySwordSystem.cs
+++ b/Content.Shared/Weapons/Melee/EnergySword/EnergySwordSystem.cs
@@ -33,7 +33,7 @@ public sealed class EnergySwordSystem : EntitySystem
         if (!TryComp(entity, out AppearanceComponent? appearanceComponent))
             return;
 
-        _appearance.SetData(entity, ToggleableLightVisuals.Color, entity.Comp.ActivatedColor, appearanceComponent);
+        _appearance.SetData(entity, ToggleVisuals.Color, entity.Comp.ActivatedColor, appearanceComponent); // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
     }
 
     // Used to make the blade multicolored when using a multitool on it.

--- a/Content.Shared/Weapons/Misc/SharedTetherGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedTetherGunSystem.cs
@@ -204,7 +204,7 @@ public abstract partial class SharedTetherGunSystem : EntitySystem
 
         TryComp<AppearanceComponent>(gunUid, out var appearance);
         _appearance.SetData(gunUid, TetherVisualsStatus.Key, true, appearance);
-        _appearance.SetData(gunUid, ToggleableLightVisuals.Enabled, true, appearance);
+        _appearance.SetData(gunUid, ToggleVisuals.Toggled, true, appearance); // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
 
         // Target updates
         TransformSystem.Unanchor(target, targetXform);
@@ -280,7 +280,7 @@ public abstract partial class SharedTetherGunSystem : EntitySystem
 
         TryComp<AppearanceComponent>(gunUid, out var appearance);
         _appearance.SetData(gunUid, TetherVisualsStatus.Key, false, appearance);
-        _appearance.SetData(gunUid, ToggleableLightVisuals.Enabled, false, appearance);
+        _appearance.SetData(gunUid, ToggleVisuals.Toggled, false, appearance); // Moffstation - ToggleableLightVisuals enum merged into ToggleVisuals
 
         RemComp<TetheredComponent>(component.Tethered.Value);
         _blocker.UpdateCanMove(component.Tethered.Value);

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -59,6 +59,7 @@
     heldPrefix: off
     size: Normal
   - type: ToggleableLightVisuals
+  - type: ItemTogglePointLight # Moffstation
   - type: PointLight
     enabled: false
     radius: 3
@@ -195,6 +196,7 @@
   - type: Clothing
     equippedPrefix: off
   - type: ToggleableLightVisuals
+  - type: ItemTogglePointLight # Moffstation
   - type: PointLight
     enabled: false
     radius: 3

--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -50,6 +50,7 @@
     clothingVisuals:
       head:
       - state: on-equipped-HELMET
+  - type: ItemTogglePointLight # Moffstation
   - type: PowerCellSlot
     cellSlotId: cell_slot
   - type: ItemSlots

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -46,6 +46,7 @@
     energy: 2
     netsync: false
   - type: ToggleableLightVisuals
+  - type: ItemTogglePointLight # Moffstation
   - type: Appearance
   - type: Physics
     canCollide: false

--- a/Resources/Prototypes/Entities/Objects/Tools/decoys.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/decoys.yml
@@ -36,6 +36,7 @@
   - type: Damageable
     damageContainer: Inorganic
   - type: ToggleableLightVisuals
+  - type: ItemTogglePointLight # Moffstation
   - type: Foldable
     folded: true
   - type: PowerCellSlot

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -36,6 +36,7 @@
       right:
       - state: inhand-right-light
         shader: unshaded
+  - type: ItemTogglePointLight # Moffstation
   - type: PowerCellSlot
     cellSlotId: cell_slot
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
@@ -43,6 +43,7 @@
       netsync: false
     - type: Appearance
     - type: ToggleableLightVisuals
+    - type: ItemTogglePointLight # Moffstation
     - type: PowerCellSlot
       cellSlotId: cell_slot
     - type: ItemSlots

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -23,6 +23,7 @@
   - type: ItemToggleSize
     activatedSize: Huge
   - type: ItemTogglePointLight
+    Moffstation_ToggleVisualsColorModulatesLights: true # Moffstation
   - type: ItemToggleMeleeWeapon
     activatedSoundOnHit:
       path: /Audio/Weapons/eblade1.ogg


### PR DESCRIPTION
Moffstation port of https://github.com/space-wizards/space-station-14/pull/35341 . Original PR is changed quite a bit to minimize code changes compared to upstream.

:cl:
- fix: Headphones show animated music notes when activated again.