### PR TITLE
Make warops admin-only

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -72,8 +72,10 @@
   equipment:
     neck: SyndicateWhistle
     outerClothing: ClothingOuterHardsuitSyndieCommander
-  inhand:
-  - NukeOpsDeclarationOfWar
+# Moffstation - Begin - Make warops admin only
+#  inhand:
+#  - NukeOpsDeclarationOfWar
+# Moffstation - End
 
 #Nuclear Operative Medic Gear
 - type: startingGear


### PR DESCRIPTION
Removes the warops remote from the nukie commander loadout, effectively making it admin-only.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

- tweak: Made warops admin-only.

<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
