### PR TITLE
Allow clown, mime, and borg loadouts to have customized names

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -162,6 +162,19 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
             profile = HumanoidCharacterProfile.RandomWithSpecies(speciesId);
         }
 
+        // Moffstation - Start - Clown/Borg/Mime loadout names (Moved from lower in file, separated from ID processing)
+        if (profile != null)
+        {
+            _humanoidSystem.LoadProfile(entity.Value, profile);
+            _metaSystem.SetEntityName(entity.Value, profile.Name);
+
+            if (profile.FlavorText != "" && _configurationManager.GetCVar(CCVars.FlavorText))
+            {
+                AddComp<DetailExaminableComponent>(entity.Value).Content = profile.FlavorText;
+            }
+        }
+        // Moffstation - End - Clown/Borg/Mime loadout names
+
         if (loadout != null)
         {
             EquipRoleLoadout(entity.Value, loadout, roleProto!);
@@ -176,18 +189,12 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
         var gearEquippedEv = new StartingGearEquippedEvent(entity.Value);
         RaiseLocalEvent(entity.Value, ref gearEquippedEv);
 
-        if (profile != null)
+        // Moffstation - Start - Clown/Borg/Mime loadout names (Portions moved higher in file, separated from this)
+        if (prototype != null && TryComp(entity.Value, out MetaDataComponent? metaData))
         {
-            if (prototype != null)
-                SetPdaAndIdCardData(entity.Value, profile.Name, prototype, station);
-
-            _humanoidSystem.LoadProfile(entity.Value, profile);
-            _metaSystem.SetEntityName(entity.Value, profile.Name);
-            if (profile.FlavorText != "" && _configurationManager.GetCVar(CCVars.FlavorText))
-            {
-                AddComp<DetailExaminableComponent>(entity.Value).Content = profile.FlavorText;
-            }
+            SetPdaAndIdCardData(entity.Value, metaData.EntityName, prototype, station);
         }
+        // Moffstation - end - Clown/Borg/Mime loadout names
 
         DoJobSpecials(job, entity.Value);
         _identity.QueueIdentityUpdate(entity.Value);

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -25,11 +25,13 @@
   - Trinkets
   - GroupSpeciesBreathTool
 
+# Moffstation - Start - Clown/Borg/Mime loadout names
 # Silicons
-#- type: roleLoadout
-#  id: JobBorg
-#  nameDataset: roleloadout doesn't support both so need to update that first.
-#  canCustomizeName: true
+- type: roleLoadout
+  id: JobBorg
+  nameDataset: NamesBorg
+  canCustomizeName: true
+# Moffstation - End - Clown/Borg/Mime loadout names
 
 - type: roleLoadout
   id: JobStationAi
@@ -159,6 +161,7 @@
 
 - type: roleLoadout
   id: JobClown
+  canCustomizeName: true # Moffstation - Clown/Borg/Mime loadout names
   groups:
   - GroupTankHarness
   - ClownHead
@@ -172,6 +175,7 @@
 
 - type: roleLoadout
   id: JobMime
+  canCustomizeName: true # Moffstation - Clown/Borg/Mime loadout names
   groups:
   - GroupTankHarness
   - MimeHead


### PR DESCRIPTION
Port of https://github.com/space-wizards/space-station-14/pull/35170 by Izk228

As of writing, that PR mentions a bug regarding borg names, but I wasn't able to replicate it @shrugs.

:cl:
- add: Clown, Mime and Cyborgs may now set their names in the character loadout, similar to the Station AI.