### PR TITLE
Loadout Slot Overrides

### DIFF
--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -393,9 +393,10 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
                     foreach (var slot in slots)
                     {
                         // Try startinggear first
+                        // TODO CENT There's a toooon of shared code between these
                         if (_prototypeManager.TryIndex(loadoutProto.StartingGear, out var loadoutGear))
                         {
-                            var itemType = ((IEquipmentLoadout) loadoutGear).GetGear(slot.Name);
+                            var itemType = ((IEquipmentLoadout) loadoutGear).GetGear(slot.Name, out _);
 
                             if (_inventory.TryUnequip(dummy, slot.Name, out var unequippedItem, silent: true, force: true, reparent: false))
                             {
@@ -410,7 +411,7 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
                         }
                         else
                         {
-                            var itemType = ((IEquipmentLoadout) loadoutProto).GetGear(slot.Name);
+                            var itemType = ((IEquipmentLoadout) loadoutProto).GetGear(slot.Name, out _);
 
                             if (_inventory.TryUnequip(dummy, slot.Name, out var unequippedItem, silent: true, force: true, reparent: false))
                             {
@@ -433,7 +434,8 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
 
         foreach (var slot in slots)
         {
-            var itemType = ((IEquipmentLoadout) gear).GetGear(slot.Name);
+            // TODO CENT and this one
+            var itemType = ((IEquipmentLoadout) gear).GetGear(slot.Name, out _);
 
             if (_inventory.TryUnequip(dummy, slot.Name, out var unequippedItem, silent: true, force: true, reparent: false))
             {

--- a/Content.IntegrationTests/Tests/Roles/StartingGearStorageTests.cs
+++ b/Content.IntegrationTests/Tests/Roles/StartingGearStorageTests.cs
@@ -39,7 +39,7 @@ public sealed class StartingGearPrototypeStorageTest
                 foreach (var (slot, entProtos) in gearProto.Storage)
                 {
                     ents.Clear();
-                    var storageProto = ((IEquipmentLoadout)gearProto).GetGear(slot);
+                    var storageProto = ((IEquipmentLoadout)gearProto).GetGear(slot, out _);
                     if (storageProto == string.Empty)
                         continue;
 

--- a/Content.Server/Administration/Commands/SetOutfitCommand.cs
+++ b/Content.Server/Administration/Commands/SetOutfitCommand.cs
@@ -103,7 +103,7 @@ namespace Content.Server.Administration.Commands
                 foreach (var slot in slots)
                 {
                     invSystem.TryUnequip(target, slot.Name, true, true, false, inventoryComponent);
-                    var gearStr = ((IEquipmentLoadout) startingGear).GetGear(slot.Name);
+                    var gearStr = ((IEquipmentLoadout) startingGear).GetGear(slot.Name, out _);
                     if (gearStr == string.Empty)
                     {
                         continue;

--- a/Content.Shared/Clothing/LoadoutSystem.cs
+++ b/Content.Shared/Clothing/LoadoutSystem.cs
@@ -61,11 +61,16 @@ public sealed class LoadoutSystem : EntitySystem
         if (gear == null)
             return null;
 
-        var count = gear.Equipment.Count + gear.Inhand.Count + gear.Storage.Values.Sum(x => x.Count);
+        var count = gear.Equipment.Count + gear.OverridingEquipment.Count + gear.Inhand.Count + gear.Storage.Values.Sum(x => x.Count);
 
         if (count == 1)
         {
             if (gear.Equipment.Count == 1 && _protoMan.TryIndex<EntityPrototype>(gear.Equipment.Values.First(), out var proto))
+            {
+                return proto.ID;
+            }
+
+            if (gear.OverridingEquipment.Count == 1 && _protoMan.TryIndex<EntityPrototype>(gear.OverridingEquipment.Values.First(), out proto))
             {
                 return proto.ID;
             }
@@ -109,11 +114,16 @@ public sealed class LoadoutSystem : EntitySystem
         if (gear == null)
             return string.Empty;
 
-        var count = gear.Equipment.Count + gear.Storage.Values.Sum(o => o.Count) + gear.Inhand.Count;
+        var count = gear.Equipment.Count + gear.OverridingEquipment.Count + gear.Storage.Values.Sum(o => o.Count) + gear.Inhand.Count;
 
         if (count == 1)
         {
             if (gear.Equipment.Count == 1 && _protoMan.TryIndex<EntityPrototype>(gear.Equipment.Values.First(), out var proto))
+            {
+                return proto.Name;
+            }
+
+            if (gear.OverridingEquipment.Count == 1 && _protoMan.TryIndex<EntityPrototype>(gear.OverridingEquipment.Values.First(), out proto))
             {
                 return proto.Name;
             }

--- a/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
@@ -39,6 +39,10 @@ public sealed partial class LoadoutPrototype : IPrototype, IEquipmentLoadout
 
     /// <inheritdoc />
     [DataField]
+    public Dictionary<string, EntProtoId> OverridingEquipment { get; set; } = new();
+
+    /// <inheritdoc />
+    [DataField]
     public List<EntProtoId> Inhand { get; set; } = new();
 
     /// <inheritdoc />

--- a/Content.Shared/Roles/StartingGearPrototype.cs
+++ b/Content.Shared/Roles/StartingGearPrototype.cs
@@ -25,6 +25,9 @@ public sealed partial class StartingGearPrototype : IPrototype, IInheritingProto
     public Dictionary<string, EntProtoId> Equipment { get; set; } = new();
 
     /// <inheritdoc />
+    public Dictionary<string, EntProtoId> OverridingEquipment { get; set; } = new();
+
+    /// <inheritdoc />
     [DataField]
     [AlwaysPushInheritance]
     public List<EntProtoId> Inhand { get; set; } = new();
@@ -46,6 +49,11 @@ public interface IEquipmentLoadout
     public Dictionary<string, EntProtoId> Equipment { get; set; }
 
     /// <summary>
+    /// TODO
+    /// </summary>
+    public Dictionary<string, EntProtoId> OverridingEquipment { get; set; }
+
+    /// <summary>
     /// The inhand items that are equipped when this starting gear is equipped onto an entity.
     /// </summary>
     public List<EntProtoId> Inhand { get; set; }
@@ -58,8 +66,17 @@ public interface IEquipmentLoadout
     /// <summary>
     /// Gets the entity prototype ID of a slot in this starting gear.
     /// </summary>
-    public string GetGear(string slot)
+    public string GetGear(string slot, out bool overriding)
     {
-        return Equipment.TryGetValue(slot, out var equipment) ? equipment : string.Empty;
+        if (OverridingEquipment.TryGetValue(slot, out var equipment))
+        {
+            overriding = true;
+            return equipment;
+        }
+
+        overriding = false;
+        return Equipment.TryGetValue(slot, out equipment) || false
+            ? equipment
+            : string.Empty;
     }
 }

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -124,10 +124,16 @@ public abstract class SharedStationSpawningSystem : EntitySystem
         {
             foreach (var slot in slotDefinitions)
             {
-                var equipmentStr = startingGear.GetGear(slot.Name);
+                var equipmentStr = startingGear.GetGear(slot.Name, out var overriding);
                 if (!string.IsNullOrEmpty(equipmentStr))
                 {
                     var equipmentEntity = EntityManager.SpawnEntity(equipmentStr, xform.Coordinates);
+                    if (overriding &&
+                        InventorySystem.TryUnequip(entity, slot.Name, out var removed, silent: true, force: true))
+                    {
+                        Del(removed);
+                    }
+
                     InventorySystem.TryEquip(entity, equipmentEntity, slot.Name, silent: true, force: true);
                 }
             }


### PR DESCRIPTION
Handles part of #41 , the part that would make it so that, eg., Frost's medical webbing replaces the paramedic belt on character initialization.

Idea is that in a loadout would be
```yaml
- type: loadout
  id: PersonalItemFrostMedicalWebbing
  overridingEquipment:
    belt: PersonalItemFrostMedicalWebbing
  effects:
  - !type:PersonalItemLoadoutEffect
    character:
    - Frost Winters
```
, where anything under `overridingEquipment` would replace any other equipment yet provisioned by any loadout.
It does this by first unequiping and deleting anything in the specified slot, then filling the slot like normal.

This'd likely run into some confusion if lots of overrides are layered as whichever is evaluated last would "win", but eh.

Draft because:
- need better comments
- need moffstation modification indicators
- need to smooth out the stuff around automagically getting the icon loadout and name (ie. actually look at the places I jammed in `var _` and see how I should actually use them)

BUT I believe it works in the happy path right now, so it's promising.