### PR TITLE
Disable warops player limit

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -81,7 +81,7 @@ public sealed partial class NukeopsRuleComponent : Component
     ///     Minimal operatives count for war declaration
     /// </summary>
     [DataField]
-    public int WarDeclarationMinOps = 4;
+    public int WarDeclarationMinOps = 0; // Moffstation - Remove warops min player limit as warops is admin only, original value 4
 
     [DataField]
     public WinType WinType = WinType.Neutral;


### PR DESCRIPTION
Disables the warops playerlimit, now warops can be executed for any number of players.

Admins tried to start warops at request (as we've made warops admin only) and got blocked because there's a mimimum playercount required.