### PR TITLE
Musicians can set their names in loadouts now.

### DIFF
--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -214,6 +214,7 @@
   - Instruments
   - GroupSpeciesBreathTool
   - PersonalItemsJobAgnostic # Umbra
+  canCustomizeName: true # Moffstation - Musicians can select a name in loadout
 
 # Cargo
 - type: roleLoadout


### PR DESCRIPTION
:cl: Centronias
- add: Musicians can change their names in loadouts, similar to mimes and clowns.