### PR TITLE
Port CD's Height Slider from Umbra

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -1,3 +1,4 @@
+using System.Numerics; // Moffstation
 using Content.Shared.CCVar;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
@@ -44,6 +45,13 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
     {
         UpdateLayers(component, sprite);
         ApplyMarkingSet(component, sprite);
+
+        // Moffstation Start - CD Height
+        var speciesPrototype = _prototypeManager.Index(component.Species);
+        var height = Math.Clamp(MathF.Round(component.Height, 2), speciesPrototype.MinHeight, speciesPrototype.MaxHeight); // should NOT be locked, at all
+
+        sprite.Scale = new Vector2(speciesPrototype.ScaleHeight ? height : 1f, height);
+        // Moffstation End
 
         sprite[sprite.LayerMapReserveBlank(HumanoidVisualLayers.Eyes)].Color = component.EyeColor;
     }
@@ -212,6 +220,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
         humanoid.Species = profile.Species;
         humanoid.SkinColor = profile.Appearance.SkinColor;
         humanoid.EyeColor = profile.Appearance.EyeColor;
+        humanoid.Height = profile.Height; // Moffstation - CD Height
 
         UpdateSprite(humanoid, Comp<SpriteComponent>(uid));
     }

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -67,6 +67,14 @@
                                     <Control HorizontalExpand="True"/>
                                     <LineEdit Name="AgeEdit" MinSize="40 0" HorizontalAlignment="Right" />
                                 </BoxContainer>
+                                <!-- CD Height -->
+                                <BoxContainer HorizontalExpand="True">
+                                    <Label Text="{Loc 'humanoid-profile-editor-height-label'}" />
+                                    <Control HorizontalExpand="True" />
+                                    <Slider Name="CDHeightSlider" HorizontalAlignment="Right" SetWidth="300" MinValue="0.0" MaxValue="1.0"/>
+                                    <LineEdit HorizontalAlignment="Right" Name="CDHeight" MinSize="60 0" Text="1.0" />
+                                    <Button Name="CDHeightReset" Text="{Loc 'humanoid-profile-editor-reset-height-button'}" HorizontalAlignment="Right"/>
+                                </BoxContainer>
                                 <!-- Sex -->
                                 <BoxContainer HorizontalExpand="True">
                                     <Label Text="{Loc 'humanoid-profile-editor-sex-label'}" />

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+using System.Globalization; // Moffstation
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -1293,12 +1293,14 @@ namespace Content.Client.Lobby.UI
             _entManager.System<MetaDataSystem>().SetEntityName(PreviewDummy, newName);
         }
 
+        // Moffstation Start - CD Height
         private void SetProfileHeight(float height)
         {
             Profile = Profile?.WithHeight(height);
             SetDirty();
             ReloadProfilePreview();
         }
+        // Moffstation End
 
         private void SetSpawnPriority(SpawnPriorityPreference newSpawnPriority)
         {

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -237,6 +237,41 @@ namespace Content.Client.Lobby.UI
             // Umbra re-added this.
             #endregion Species
 
+            #region CDHeight
+
+            CDHeight.OnTextChanged += args =>
+            {
+                if (Profile is null || !float.TryParse(args.Text, out var newHeight))
+                    return;
+
+                var prototype = _prototypeManager.Index(Profile.Species);
+                newHeight = MathF.Round(Math.Clamp(newHeight, prototype.MinHeight, prototype.MaxHeight), 2);
+
+                // The percentage between the start and end numbers, aka "inverse lerp"
+                var sliderPercent = (newHeight - prototype.MinHeight) /
+                                    (prototype.MaxHeight - prototype.MinHeight);
+                CDHeightSlider.Value = sliderPercent;
+
+                SetProfileHeight(newHeight);
+            };
+
+            CDHeightReset.OnPressed += _ =>
+            {
+                CDHeight.SetText(_defaultHeight.ToString(CultureInfo.InvariantCulture), true);
+            };
+
+            CDHeightSlider.OnValueChanged += _ =>
+            {
+                if (Profile is null)
+                    return;
+                var prototype = _prototypeManager.Index(Profile.Species);
+                var newHeight = MathF.Round(MathHelper.Lerp(prototype.MinHeight, prototype.MaxHeight, CDHeightSlider.Value), 2);
+                CDHeight.Text = newHeight.ToString(CultureInfo.InvariantCulture);
+                SetProfileHeight(newHeight);
+            };
+
+            #endregion CDHeight
+
             #region Skin
 
             Skin.OnValueChanged += _ =>
@@ -1450,6 +1485,7 @@ namespace Content.Client.Lobby.UI
             PronounsButton.SelectId((int) Profile.Gender);
         }
 
+        // Moffstation Start - CD Height
         private void UpdateHeightControls()
         {
             if (Profile == null)
@@ -1461,10 +1497,13 @@ namespace Content.Client.Lobby.UI
             if (species != null)
                 _defaultHeight = species.DefaultHeight;
 
-            var prototype = _prototypeManager.Index<SpeciesPrototype>(Profile.Species);
+            var prototype = _prototypeManager.Index(Profile.Species);
             var sliderPercent = (Profile.Height - prototype.MinHeight) /
                                 (prototype.MaxHeight - prototype.MinHeight);
+            CDHeightSlider.Value = sliderPercent;
+            CDHeight.Text = Profile.Height.ToString(CultureInfo.InvariantCulture);
         }
+        // Moffstation End
 
         private void UpdateSpawnPriorityControls()
         {

--- a/Content.IntegrationTests/Tests/Preferences/ServerDbSqliteTests.cs
+++ b/Content.IntegrationTests/Tests/Preferences/ServerDbSqliteTests.cs
@@ -39,6 +39,7 @@ namespace Content.IntegrationTests.Tests.Preferences
                 Name = "Charlie Charlieson",
                 FlavorText = "The biggest boy around.",
                 Species = "Human",
+                Height = 1, // Moffstation - CD Height
                 Age = 21,
                 Appearance = new(
                     "Afro",

--- a/Content.Server.Database/Model.cs
+++ b/Content.Server.Database/Model.cs
@@ -438,7 +438,7 @@ namespace Content.Server.Database
         public int PreferenceId { get; set; }
         public Preference Preference { get; set; } = null!;
 
-        public CDModel.CDProfile? CDProfile { get; set; }
+        public CDModel.CDProfile? CDProfile { get; set; } // Moffstation - Add CD Profile
     }
 
     public class Job

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -104,8 +104,10 @@ namespace Content.Server.Database
             }
 
             var oldProfile = db.DbContext.Profile
+                // Moffstation Start - Add CD Profile
                 .Include(p => p.CDProfile) // CD: Store CD info
                     .ThenInclude(cd => cd != null ? cd.CharacterRecordEntries : null)
+                // Moffstation End
                 .Include(p => p.Preference)
                 .Where(p => p.Preference.UserId == userId.UserId)
                 .Include(p => p.Jobs)
@@ -260,7 +262,7 @@ namespace Content.Server.Database
                 profile.CharacterName,
                 profile.FlavorText,
                 profile.Species,
-                profile.CDProfile?.Height ?? 1.0f,
+                profile.CDProfile?.Height ?? 1.0f, // Moffstation - CD Height
                 profile.Age,
                 sex,
                 gender,
@@ -280,7 +282,7 @@ namespace Content.Server.Database
                 antags.ToHashSet(),
                 traits.ToHashSet(),
                 loadouts,
-                cdRecords
+                cdRecords // Moffstation - Add CD Profile
             );
         }
 

--- a/Content.Shared/Humanoid/HumanoidAppearanceComponent.cs
+++ b/Content.Shared/Humanoid/HumanoidAppearanceComponent.cs
@@ -99,6 +99,14 @@ public sealed partial class HumanoidAppearanceComponent : Component
 
     [DataField]
     public ProtoId<MarkingPrototype>? UndergarmentBottom = new ProtoId<MarkingPrototype>("UndergarmentBottomBoxers");
+
+    // Moffstation Start - CD Height
+    /// <summary>
+    ///     The height of this humanoid.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Height = 1f;
+    // Moffstation End
 }
 
 [DataDefinition]

--- a/Content.Shared/Humanoid/NamingSystem.cs
+++ b/Content.Shared/Humanoid/NamingSystem.cs
@@ -48,20 +48,20 @@ namespace Content.Shared.Humanoid
             switch (gender)
             {
                 case Gender.Male:
-                    return _random.Pick(_prototypeManager.Index<LocalizedDatasetPrototype>(speciesProto.MaleFirstNames));
+                    return _random.Pick(_prototypeManager.Index(speciesProto.MaleFirstNames));
                 case Gender.Female:
-                    return _random.Pick(_prototypeManager.Index<LocalizedDatasetPrototype>(speciesProto.FemaleFirstNames));
+                    return _random.Pick(_prototypeManager.Index(speciesProto.FemaleFirstNames));
                 default:
                     if (_random.Prob(0.5f))
-                        return _random.Pick(_prototypeManager.Index<LocalizedDatasetPrototype>(speciesProto.MaleFirstNames));
+                        return _random.Pick(_prototypeManager.Index(speciesProto.MaleFirstNames));
                     else
-                        return _random.Pick(_prototypeManager.Index<LocalizedDatasetPrototype>(speciesProto.FemaleFirstNames));
+                        return _random.Pick(_prototypeManager.Index(speciesProto.FemaleFirstNames));
             }
         }
 
         public string GetLastName(SpeciesPrototype speciesProto)
         {
-            return _random.Pick(_prototypeManager.Index<LocalizedDatasetPrototype>(speciesProto.LastNames));
+            return _random.Pick(_prototypeManager.Index(speciesProto.LastNames));
         }
     }
 }

--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -127,13 +127,13 @@ public sealed partial class SpeciesPrototype : IPrototype
     /// The minimum height for this species
     /// </summary>
     [DataField("minHeight")]
-    public float MinHeight = 0.7f;
+    public float MinHeight = 0.8f; // Moffstation - Narrow height customization range
 
     /// <summary>
     /// The maximum height for this species
     /// </summary>
     [DataField("maxHeight")]
-    public float MaxHeight = 1.4f;
+    public float MaxHeight = 1.2f; // Moffstation - Narrow height customization range
 
     /// <summary>
     /// The default height for this species

--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Humanoid.Prototypes;
 
-[Prototype("species")]
+[Prototype]
 public sealed partial class SpeciesPrototype : IPrototype
 {
     /// <summary>
@@ -123,6 +123,7 @@ public sealed partial class SpeciesPrototype : IPrototype
     [DataField]
     public int MaxAge = 120;
 
+    // Moffstation Start - CD Height Sprite Scaling
     /// <summary>
     /// The minimum height for this species
     /// </summary>
@@ -158,6 +159,7 @@ public sealed partial class SpeciesPrototype : IPrototype
     /// </summary>
     [DataField("scaleHeight")]
     public bool ScaleHeight = true;
+    // Moffstation End
 }
 
 public enum SpeciesNaming : byte

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -151,6 +151,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
         targetHumanoid.SkinColor = sourceHumanoid.SkinColor;
         targetHumanoid.EyeColor = sourceHumanoid.EyeColor;
         targetHumanoid.Age = sourceHumanoid.Age;
+        targetHumanoid.Height = sourceHumanoid.Height; // Moffstation - CD Height
         SetSex(target, sourceHumanoid.Sex, false, targetHumanoid);
         targetHumanoid.CustomBaseLayers = new(sourceHumanoid.CustomBaseLayers);
         targetHumanoid.MarkingSet = new(sourceHumanoid.MarkingSet);
@@ -442,6 +443,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
         }
 
         humanoid.Age = profile.Age;
+		humanoid.Height = profile.Height; // Moffstation - CD Height
 
         Dirty(uid, humanoid);
     }

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -129,17 +129,19 @@ namespace Content.Shared.Preferences
         public PreferenceUnavailableMode PreferenceUnavailable { get; private set; } =
             PreferenceUnavailableMode.SpawnAsOverflow;
 
+        // Moffstation Start - CD Profile
         [DataField("cosmaticDriftCharacterHeight")]
         public float Height = 1f;
 
         [DataField("cosmaticDriftCharacterRecords")]
         public PlayerProvidedCharacterRecords? CDCharacterRecords;
+        // Moffstation End
 
         public HumanoidCharacterProfile(
             string name,
             string flavortext,
             string species,
-            float height,
+            float height, // Moffstation - CD Height
             int age,
             Sex sex,
             Gender gender,
@@ -150,12 +152,12 @@ namespace Content.Shared.Preferences
             HashSet<ProtoId<AntagPrototype>> antagPreferences,
             HashSet<ProtoId<TraitPrototype>> traitPreferences,
             Dictionary<string, RoleLoadout> loadouts,
-            PlayerProvidedCharacterRecords? cdCharacterRecords)
+            PlayerProvidedCharacterRecords? cdCharacterRecords) // Moffstation - CD Profile
         {
             Name = name;
             FlavorText = flavortext;
             Species = species;
-            Height = height;
+            Height = height; // Moffstation - CD Height
             Age = age;
             Sex = sex;
             Gender = gender;
@@ -166,7 +168,7 @@ namespace Content.Shared.Preferences
             _antagPreferences = antagPreferences;
             _traitPreferences = traitPreferences;
             _loadouts = loadouts;
-            CDCharacterRecords = cdCharacterRecords;
+            CDCharacterRecords = cdCharacterRecords; // Moffstation - CD Profile
 
             var hasHighPrority = false;
             foreach (var (key, value) in _jobPriorities)
@@ -188,7 +190,7 @@ namespace Content.Shared.Preferences
             : this(other.Name,
                 other.FlavorText,
                 other.Species,
-                other.Height,
+                other.Height, // Moffstation - CD Height
                 other.Age,
                 other.Sex,
                 other.Gender,
@@ -199,7 +201,7 @@ namespace Content.Shared.Preferences
                 new HashSet<ProtoId<AntagPrototype>>(other.AntagPreferences),
                 new HashSet<ProtoId<TraitPrototype>>(other.TraitPreferences),
                 new Dictionary<string, RoleLoadout>(other.Loadouts),
-                other.CDCharacterRecords)
+                other.CDCharacterRecords) // Moffstation - CD Profile
         {
         }
 
@@ -247,7 +249,7 @@ namespace Content.Shared.Preferences
 
             var sex = Sex.Unsexed;
             var age = 18;
-            var height = 1f;
+            var height = 1f; // Moffstation - CD Height
             if (prototypeManager.TryIndex<SpeciesPrototype>(species, out var speciesPrototype))
             {
                 sex = random.Pick(speciesPrototype.Sexes);
@@ -277,6 +279,7 @@ namespace Content.Shared.Preferences
                 Age = age,
                 Gender = gender,
                 Species = species,
+                Height = height, // Moffstation - CD Height
                 Appearance = HumanoidCharacterAppearance.Random(species, sex),
             };
         }
@@ -311,10 +314,12 @@ namespace Content.Shared.Preferences
             return new(this) { Species = species };
         }
 
+        // Moffstation Start - CD Height
         public HumanoidCharacterProfile WithHeight(float height)
         {
             return new(this) { Height = height };
         }
+        // Moffstation End
 
         public HumanoidCharacterProfile WithCharacterAppearance(HumanoidCharacterAppearance appearance)
         {
@@ -469,10 +474,12 @@ namespace Content.Shared.Preferences
             };
         }
 
+        // Moffstation Start - CD Profile
         public HumanoidCharacterProfile WithCDCharacterRecords(PlayerProvidedCharacterRecords records)
         {
             return new HumanoidCharacterProfile(this) { CDCharacterRecords = records };
         }
+        // Moffstation End
 
         public string Summary =>
             Loc.GetString(
@@ -487,7 +494,7 @@ namespace Content.Shared.Preferences
             if (maybeOther is not HumanoidCharacterProfile other) return false;
             if (Name != other.Name) return false;
             if (Age != other.Age) return false;
-            if (Height != other.Height) return false;
+            if (Height != other.Height) return false; // Moffstation - CD Height
             if (Sex != other.Sex) return false;
             if (Gender != other.Gender) return false;
             if (Species != other.Species) return false;
@@ -498,8 +505,10 @@ namespace Content.Shared.Preferences
             if (!_traitPreferences.SequenceEqual(other._traitPreferences)) return false;
             if (!Loadouts.SequenceEqual(other.Loadouts)) return false;
             if (FlavorText != other.FlavorText) return false;
+            // Moffstation Start - CD Profile
             if (CDCharacterRecords != null && other.CDCharacterRecords != null &&
                 !CDCharacterRecords.MemberwiseEquals(other.CDCharacterRecords)) return false;
+            // Moffstation End
             return Appearance.MemberwiseEquals(other.Appearance);
         }
 
@@ -579,9 +588,7 @@ namespace Content.Shared.Preferences
                 flavortext = FormattedMessage.RemoveMarkupOrThrow(FlavorText);
             }
 
-            var height = Height;
-            if (speciesPrototype != null)
-                height = Math.Clamp(MathF.Round(Height, 2), speciesPrototype.MinHeight, speciesPrototype.MaxHeight);
+            var height = Math.Clamp(MathF.Round(Height, 2), speciesPrototype.MinHeight, speciesPrototype.MaxHeight); // Moffstation - CD Height
 
             var appearance = HumanoidCharacterAppearance.EnsureValid(Appearance, Species, Sex);
 
@@ -632,7 +639,7 @@ namespace Content.Shared.Preferences
             Name = name;
             FlavorText = flavortext;
             Age = age;
-            Height = height;
+            Height = height; // Moffstation - CD Height
             Sex = sex;
             Gender = gender;
             Appearance = appearance;
@@ -653,6 +660,7 @@ namespace Content.Shared.Preferences
             _traitPreferences.Clear();
             _traitPreferences.UnionWith(GetValidTraits(traits, prototypeManager));
 
+            // Moffstation Start - CD Profile
             if (CDCharacterRecords == null)
             {
                 CDCharacterRecords = PlayerProvidedCharacterRecords.DefaultRecords();
@@ -661,6 +669,7 @@ namespace Content.Shared.Preferences
             {
                 CDCharacterRecords!.EnsureValid();
             }
+            // Moffstation End
 
             // Checks prototypes exist for all loadouts and dump / set to default if not.
             var toRemove = new ValueList<string>();

--- a/Resources/Locale/en-US/_Moffstation/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/_Moffstation/preferences/ui/humanoid-profile-editor.ftl
@@ -1,0 +1,3 @@
+# CD Height
+humanoid-profile-editor-height-label = Height:
+humanoid-profile-editor-reset-height-button = Reset


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Added the height slider to character profiles

As per @DuckManZach 's request, the range of allowed scales has been narrowed from Umbra's `[0.7, 1.4]` to `[0.8, 1.2]`.

I also went back and added `// Moffstation` comments around the stuff that added the CD Height and CD Profile changes before.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People want to be smol

## Technical details
<!-- Summary of code changes for easier review. -->
- Slider in the UI
- Slider sets a height scale float on the CD profile (persisted to the character in the DB)
- HumanoidAppearanceComponent / System stuff to propagate the height scale to actually scale the sprite

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/dbc0d413-aa74-45fb-bec1-c340f1b84033)
Smallest on the left, default in the middle, largest on the right.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Shouldn't be any.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: The height slider to character customization