### PR TITLE
Weapon Resizing

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1205,10 +1205,6 @@
     - state: base
       map: ["enum.GunVisualLayers.Base"]
   - type: Item
-    size: Small
-    shape:
-    - 0,0,1,0
-    - 0,1,0,1
     sprite: Objects/Fun/toys.rsi
     heldPrefix: capgun
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1205,6 +1205,10 @@
     - state: base
       map: ["enum.GunVisualLayers.Base"]
   - type: Item
+    size: Small
+    shape:
+    - 0,0,1,0
+    - 0,1,0,1
     sprite: Objects/Fun/toys.rsi
     heldPrefix: capgun
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
@@ -11,6 +11,9 @@
   - type: Item
     sprite: Objects/Weapons/Guns/Pistols/water_pistol.rsi
     size: Small
+    shape:
+    - 0,0,1,0
+    - 0,1,0,1
   - type: Gun
     clumsyProof: true
     cameraRecoilScalar: 0 #no recoil
@@ -95,7 +98,9 @@
       map: [ "enum.DamageStateVisualLayers.Base" ]
   - type: Item
     sprite: Objects/Weapons/Guns/Pistols/soaker.rsi
-    size: Normal
+    size: Large
+    shape:
+    - 0,0,3,1
   - type: RandomSprite
     getAllGroups: true
     available:
@@ -132,7 +137,9 @@
       map: [ "enum.DamageStateVisualLayers.Base" ]
   - type: Item
     sprite: Objects/Weapons/Guns/Pistols/soaker.rsi
-    size: Normal
+    size: Large
+    shape:
+    - 0,0,3,1
   - type: RandomSprite
     getAllGroups: true
     available:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
@@ -11,9 +11,11 @@
   - type: Item
     sprite: Objects/Weapons/Guns/Pistols/water_pistol.rsi
     size: Small
+    # Moffstation - Begin - (Weapon Resizing)
     shape:
     - 0,0,1,0
     - 0,1,0,1
+    # Moffstation - End
   - type: Gun
     clumsyProof: true
     cameraRecoilScalar: 0 #no recoil
@@ -98,9 +100,12 @@
       map: [ "enum.DamageStateVisualLayers.Base" ]
   - type: Item
     sprite: Objects/Weapons/Guns/Pistols/soaker.rsi
+    # Moffstation - Begin (Weapon Resizing)
+    # size: Normal
     size: Large
     shape:
     - 0,0,3,1
+    # Moffstation - End
   - type: RandomSprite
     getAllGroups: true
     available:
@@ -137,9 +142,12 @@
       map: [ "enum.DamageStateVisualLayers.Base" ]
   - type: Item
     sprite: Objects/Weapons/Guns/Pistols/soaker.rsi
+    # Moffstation - Begin (Weapon Resizing)
+    # size: Normal
     size: Large
     shape:
     - 0,0,3,1
+    # Moffstation - End
   - type: RandomSprite
     getAllGroups: true
     available:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -204,7 +204,10 @@
   - type: Appearance
 
 - type: entity
-  name: practice laser rifle
+  # Moffstation - Begin (Weapon Resizing)
+  #name: practice laser rifle
+  name: practice laser carbine
+  # Moffstation - End
   parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponLaserCarbinePractice
   description: This modified laser rifle fires nearly harmless beams in the 40-watt range, for target practice.
@@ -241,7 +244,10 @@
     price: 300
 
 - type: entity
-  name: laser rifle
+  # Moffstation - Begin (Weapon Resizing)
+  #name: laser rifle
+  name: laser carbine
+  # Moffstation - End
   parent: [WeaponLaserCarbinePractice, BaseGunWieldable, BaseSecurityContraband]
   id: WeaponLaserCarbine
   description: Favoured by Nanotrasen Security for being cheap and easy to use.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -112,9 +112,11 @@
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
   - type: Item
+    # Moffstation - Begin (Weapon Resizing)
     shape:
     - 0,0,1,0
     - 0,1,0,1
+    # Moffstation - End
     sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
   - type: MagazineVisuals
     magState: mag
@@ -207,10 +209,12 @@
   id: WeaponLaserCarbinePractice
   description: This modified laser rifle fires nearly harmless beams in the 40-watt range, for target practice.
   components:
+  # Moffstation - Begin (Weapon Resizing)
   - type: Item
     size: Huge
     shape:
     - 0,0,4,1
+  # Moffstation - End
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
     layers:
@@ -288,10 +292,12 @@
   id: WeaponPulseCarbine
   description: A high tech energy carbine favoured by the NT-ERT operatives.
   components:
+  # Moffstation - Begin (Weapon Resizing)
   - type: Item
     size: Huge
     shape:
     - 0,0,4,1
+  # Moffstation - End
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/pulse_carbine.rsi
     layers:
@@ -328,10 +334,12 @@
   id: WeaponPulseRifle
   description: A weapon that is almost as infamous as its users.
   components:
+  # Moffstation - Begin (Weapon Resizing)
   - type: Item
     size: Huge
     shape:
     - 0,0,5,1
+  # Moffstation - End
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/pulse_rifle.rsi
     layers:
@@ -364,10 +372,12 @@
   id: WeaponLaserCannon
   description: A heavy duty, high powered laser weapon.
   components:
+  # Moffstation - Begin (Weapon Resizing)
   - type: Item
     size: Huge
     shape:
     - 0,0,5,1
+  # Moffstation - End
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/laser_cannon.rsi
     layers:
@@ -431,10 +441,12 @@
   id: WeaponXrayCannon
   description: An experimental weapon that uses concentrated x-ray energy against its target.
   components:
+  # Moffstation - Begin (Weapon Resizing)
   - type: Item
     size: Huge
     shape:
     - 0,0,5,1
+  # Moffstation - End
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/xray.rsi
     layers:
@@ -532,8 +544,10 @@
   components:
   - type: Item
     size: Large
+    # Moffstation - Begin (Weapon Resizing)
     shape:
     - 0,0,2,1
+    # Moffstation - End
   - type: Tag
     tags:
       - Taser
@@ -606,9 +620,11 @@
   id: WeaponAntiqueLaser
   description: This is an antique laser pistol. All craftsmanship is of the highest quality. It is decorated with a mahogany grip and chrome filigree. The object menaces with spikes of energy. On the item is an image of a captain and a clown. The clown is dead. The captain is striking a heroic pose.
   components:
+  # Moffstation - Begin (Weapon Resizing)
   - type: Item
     shape:
     - 0,0,1,1
+  # Moffstation - End
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/antiquelasergun.rsi
     layers:
@@ -649,14 +665,16 @@
 
 - type: entity
   name: advanced laser pistol
-  parent: [BaseWeaponBatterySmall, BaseSecurityContraband]
+  parent: [ BaseWeaponBatterySmall, BaseSecurityContraband]
   id: WeaponAdvancedLaser
   description: An experimental high-energy laser pistol with a self-charging nuclear battery.
   components:
   - type: Item
     size: Normal  # Intentionally larger than other pistols
+    # Moffstation - Begin (Weapon Resizing)
     shape:
     - 0,0,1,1
+    # Moffstation - End
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/advancedlasergun.rsi
     layers:
@@ -812,7 +830,10 @@
   - type: Item
     size: Large
     shape:
+    # Moffstation - Begin (Weapon Resizing)
+    #- 0,0,3,1
     - 0,0,4,1
+    # Moffstation - End
     sprite: Objects/Weapons/Guns/Battery/inhands_64x.rsi
     heldPrefix: energy
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -112,6 +112,9 @@
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
   - type: Item
+    shape:
+    - 0,0,1,0
+    - 0,1,0,1
     sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
   - type: MagazineVisuals
     magState: mag
@@ -204,6 +207,10 @@
   id: WeaponLaserCarbinePractice
   description: This modified laser rifle fires nearly harmless beams in the 40-watt range, for target practice.
   components:
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,1
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
     layers:
@@ -281,6 +288,10 @@
   id: WeaponPulseCarbine
   description: A high tech energy carbine favoured by the NT-ERT operatives.
   components:
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,1
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/pulse_carbine.rsi
     layers:
@@ -317,6 +328,10 @@
   id: WeaponPulseRifle
   description: A weapon that is almost as infamous as its users.
   components:
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,5,1
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/pulse_rifle.rsi
     layers:
@@ -349,6 +364,10 @@
   id: WeaponLaserCannon
   description: A heavy duty, high powered laser weapon.
   components:
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,5,1
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/laser_cannon.rsi
     layers:
@@ -412,6 +431,10 @@
   id: WeaponXrayCannon
   description: An experimental weapon that uses concentrated x-ray energy against its target.
   components:
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,5,1
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/xray.rsi
     layers:
@@ -509,6 +532,8 @@
   components:
   - type: Item
     size: Large
+    shape:
+    - 0,0,2,1
   - type: Tag
     tags:
       - Taser
@@ -581,6 +606,9 @@
   id: WeaponAntiqueLaser
   description: This is an antique laser pistol. All craftsmanship is of the highest quality. It is decorated with a mahogany grip and chrome filigree. The object menaces with spikes of energy. On the item is an image of a captain and a clown. The clown is dead. The captain is striking a heroic pose.
   components:
+  - type: Item
+    shape:
+    - 0,0,1,1
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/antiquelasergun.rsi
     layers:
@@ -621,12 +649,14 @@
 
 - type: entity
   name: advanced laser pistol
-  parent: [ BaseWeaponBatterySmall, BaseSecurityContraband]
+  parent: [BaseWeaponBatterySmall, BaseSecurityContraband]
   id: WeaponAdvancedLaser
   description: An experimental high-energy laser pistol with a self-charging nuclear battery.
   components:
   - type: Item
     size: Normal  # Intentionally larger than other pistols
+    shape:
+    - 0,0,1,1
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/advancedlasergun.rsi
     layers:
@@ -782,7 +812,7 @@
   - type: Item
     size: Large
     shape:
-    - 0,0,3,1
+    - 0,0,4,1
     sprite: Objects/Weapons/Guns/Battery/inhands_64x.rsi
     heldPrefix: energy
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -12,7 +12,7 @@
     slots:
     - Back
   - type: Item
-    size: Huge
+    size: Ginormous
   - type: StaticPrice
     price: 500
   - type: ContainerContainer
@@ -36,6 +36,10 @@
     slots:
     - Back
     - suitStorage
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,3
   - type: AmmoCounter
   - type: Gun
     fireRate: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -12,7 +12,10 @@
     slots:
     - Back
   - type: Item
+    # Moffstation - Begin (Weapon Resizing)
+    #size: Huge
     size: Ginormous
+    # Moffstation - End
   - type: StaticPrice
     price: 500
   - type: ContainerContainer
@@ -36,10 +39,12 @@
     slots:
     - Back
     - suitStorage
+  # Moffstation - Begin (Weapon Resizing)
   - type: Item
     size: Huge
     shape:
     - 0,0,4,3
+  # Moffstation - End
   - type: AmmoCounter
   - type: Gun
     fireRate: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -8,8 +8,10 @@
   - type: Sprite
   - type: Item
     size: Huge
+    # Moffstation - Begin (Weapon Resizing)
     shape:
     - 0,0,4,2
+    # Moffstation - End
   - type: Clothing
     sprite: Objects/Weapons/Guns/Rifles/ak.rsi
     quickEquip: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -8,6 +8,8 @@
   - type: Sprite
   - type: Item
     size: Huge
+    shape:
+    - 0,0,4,2
   - type: Clothing
     sprite: Objects/Weapons/Guns/Rifles/ak.rsi
     quickEquip: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -8,6 +8,8 @@
   - type: Sprite
   - type: Item
     size: Large
+    shape:
+    - 0,0,2,1
   - type: Clothing
     sprite: Objects/Weapons/Guns/SMGs/atreides.rsi
     quickEquip: false
@@ -134,6 +136,9 @@
           map: ["enum.GunVisualLayers.Mag"]
     - type: Clothing
       sprite: Objects/Weapons/Guns/SMGs/drozd.rsi
+    - type: Item
+      shape:
+      - 0,0,3,1
     - type: Wieldable
       unwieldOnUse: false
     - type: GunWieldBonus

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -8,8 +8,10 @@
   - type: Sprite
   - type: Item
     size: Large
+    # Moffstation - Begin (Weapon Resizing)
     shape:
     - 0,0,2,1
+    # Moffstation - End
   - type: Clothing
     sprite: Objects/Weapons/Guns/SMGs/atreides.rsi
     quickEquip: false
@@ -136,9 +138,11 @@
           map: ["enum.GunVisualLayers.Mag"]
     - type: Clothing
       sprite: Objects/Weapons/Guns/SMGs/drozd.rsi
+    # Moffstation - Begin (Weapon Resizing)
     - type: Item
       shape:
       - 0,0,3,1
+    # Moffstation - End
     - type: Wieldable
       unwieldOnUse: false
     - type: GunWieldBonus

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -12,6 +12,8 @@
   - type: Item
     # If you update this also update the bulldog's size.
     size: Large
+    shape:
+    - 0,0,4,0
   - type: Clothing
     sprite: Objects/Weapons/Guns/Shotguns/db_shotgun.rsi
     quickEquip: false
@@ -145,6 +147,8 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
   - type: Item
+    shape:
+    - 0,0,4,1
     sprite: Objects/Weapons/Guns/Shotguns/enforcer_inhands_64x.rsi
   - type: BallisticAmmoProvider
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
@@ -164,9 +168,8 @@
   description: An old yet faithful design, and a favorite among irregular forces of many worlds. Uses .50 shotgun shells.
   components: # intend for Kammerer to have tighter choke for slower fire rate and/or manual cycling
   - type: Item
-    size: Normal
     shape:
-    - 0,0,4,0
+    - 0,0,4,1
     sprite: Objects/Weapons/Guns/Shotguns/pump_inhands_64x.rsi
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/pump.rsi
@@ -191,6 +194,8 @@
     sprite: Objects/Weapons/Guns/Shotguns/sawn.rsi
   - type: Item
     size: Small
+    shape:
+    - 0,0,2,0
     sprite: Objects/Weapons/Guns/Shotguns/sawn_inhands_64x.rsi
   - type: Gun
     fireRate: 3
@@ -223,6 +228,8 @@
   components:
   - type: Item
     size: Small
+    shape:
+    - 0,0,0,1
     storedRotation: 90
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/hm_pistol.rsi
@@ -246,10 +253,6 @@
   suffix: Pirate
   description: Deadly at close range.
   components:
-  - type: Item
-    size: Normal
-    shape:
-    - 0,0,4,0
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/blunderbuss.rsi
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
@@ -271,9 +274,6 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Shotguns/improvised_shotgun.rsi
   - type: Item
-    size: Normal
-    shape:
-    - 0,0,4,0
     sprite: Objects/Weapons/Guns/Shotguns/improvised_shotgun_inhands_64x.rsi
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -12,8 +12,10 @@
   - type: Item
     # If you update this also update the bulldog's size.
     size: Large
+    # Moffstation - Begin (Weapon Resizing)
     shape:
     - 0,0,4,0
+    # Moffstation - End
   - type: Clothing
     sprite: Objects/Weapons/Guns/Shotguns/db_shotgun.rsi
     quickEquip: false
@@ -112,9 +114,11 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/db_shotgun.rsi
   - type: Item
-    size: Normal
-    shape:
-    - 0,0,4,0
+    # Moffstation - Begin (Weapon Resizing) (This is covered by the parent)
+    #size: Normal
+    #shape:
+    #- 0,0,4,0
+    # Moffstation - End
     sprite: Objects/Weapons/Guns/Shotguns/db_shotgun_inhands_64x.rsi
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
@@ -147,8 +151,10 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
   - type: Item
+    # Moffstation - Begin (Weapon Resizing)
     shape:
     - 0,0,4,1
+    # Moffstation - End
     sprite: Objects/Weapons/Guns/Shotguns/enforcer_inhands_64x.rsi
   - type: BallisticAmmoProvider
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
@@ -168,8 +174,11 @@
   description: An old yet faithful design, and a favorite among irregular forces of many worlds. Uses .50 shotgun shells.
   components: # intend for Kammerer to have tighter choke for slower fire rate and/or manual cycling
   - type: Item
-    shape:
-    - 0,0,4,1
+    # Moffstation - Begin (Weapon Resizing) (This is covered by the parent)
+    # Size: Normal
+    # shape:
+    # - 0,0,4,0
+    # Moffstation - End
     sprite: Objects/Weapons/Guns/Shotguns/pump_inhands_64x.rsi
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/pump.rsi
@@ -194,8 +203,10 @@
     sprite: Objects/Weapons/Guns/Shotguns/sawn.rsi
   - type: Item
     size: Small
+    # Moffstation - Begin (Weapon Resizing)
     shape:
     - 0,0,2,0
+    # Moffstation - End
     sprite: Objects/Weapons/Guns/Shotguns/sawn_inhands_64x.rsi
   - type: Gun
     fireRate: 3
@@ -228,8 +239,10 @@
   components:
   - type: Item
     size: Small
+    # Moffstation - Begin (Weapon Resizing)
     shape:
     - 0,0,0,1
+    # Moffstation - End
     storedRotation: 90
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/hm_pistol.rsi
@@ -253,6 +266,12 @@
   suffix: Pirate
   description: Deadly at close range.
   components:
+  # Moffstation - Begin (Weapon Resizing) (This is covered by the parent)
+  #-type: Item
+  #size: Normal
+  #shape:
+  #- 0,0,4,0
+  # Moffstation - End
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/blunderbuss.rsi
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
@@ -274,6 +293,11 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Shotguns/improvised_shotgun.rsi
   - type: Item
+    # Moffstation - Begin (Weapon Resizing) (This is covered by the parent)
+    #size: Normal
+    #shape:
+    #- 0,0,4,0
+    # Moffstation - End
     sprite: Objects/Weapons/Guns/Shotguns/improvised_shotgun_inhands_64x.rsi
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -10,7 +10,9 @@
     - state: base
       map: ["enum.GunVisualLayers.Base"]
   - type: Item
-    size: Huge
+    size: Large
+    shape:
+    - 0,0,4,1
   - type: Clothing
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
     quickEquip: false
@@ -53,6 +55,10 @@
   id: WeaponSniperHristov
   description: A portable anti-materiel rifle. Fires armor piercing 14.5mm shells. Uses .60 anti-materiel ammo.
   components:
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi
   - type: Clothing
@@ -128,7 +134,9 @@
     maxAngle: 30 #miss him entirely because the barrel is smoothbore
   - type: Item
     size: Small
-    storedRotation: 90
+    shape:
+    - 0,0,1,0
+    #storedRotation: 90
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/flintlock.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -10,9 +10,12 @@
     - state: base
       map: ["enum.GunVisualLayers.Base"]
   - type: Item
+    # Moffstation - Begin (Weapon Resizing)
+    #size: Huge
     size: Large
     shape:
     - 0,0,4,1
+    # Moffstation - End
   - type: Clothing
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
     quickEquip: false
@@ -55,10 +58,12 @@
   id: WeaponSniperHristov
   description: A portable anti-materiel rifle. Fires armor piercing 14.5mm shells. Uses .60 anti-materiel ammo.
   components:
+  # Moffstation - Begin (Weapon Resizing)
   - type: Item
     size: Huge
     shape:
     - 0,0,3,3
+  # Moffstation - End
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi
   - type: Clothing
@@ -134,9 +139,11 @@
     maxAngle: 30 #miss him entirely because the barrel is smoothbore
   - type: Item
     size: Small
+    # Moffstation - Begin (Weapon Resizing)
+    #storedRotation: 90 (This just makes it sideways, not good.)
     shape:
     - 0,0,1,0
-    #storedRotation: 90
+    #Moffstation - End
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/flintlock.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
@@ -11,6 +11,9 @@
         map: ["enum.GunVisualLayers.Base"]
   - type: Item
     size: Small
+    shape:
+    - 0,0,1,0
+    - 0,1,0,1
     sprite: Objects/Weapons/Guns/Shotguns/flaregun.rsi
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
@@ -11,9 +11,11 @@
         map: ["enum.GunVisualLayers.Base"]
   - type: Item
     size: Small
+    # Moffstation - Begin (Weapon Resizing)
     shape:
     - 0,0,1,0
     - 0,1,0,1
+    # Moffstation - End
     sprite: Objects/Weapons/Guns/Shotguns/flaregun.rsi
   - type: ItemSlots
     slots:


### PR DESCRIPTION
## About the PR
Added custom dimensions to every firearm, for better realism. Slightly nerfs the satchel too, by making it less able to carry a full-length assault rifle. This is a redo of my older PR, since I couldn't figure out how else to fully start from scratch.

## Why / Balance
This started as simply "why isn't the Enforcer 1x5?" and was quickly followed by other strange questions like "why is the assault rifle a square?". This has led me to change every single gun to have a somewhat more realistic and balanced inventory size.

## Technical details
Custom dimensions were added to the item component of every firearm except the cap gun (wouldn't fit in its bundle).

## Media
![image](https://github.com/user-attachments/assets/907c65a9-f981-4a5b-bd67-4b38b301d238)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Nox38
- tweak: Resized every firearm.
