### PR TITLE
Height slider default

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1502,6 +1502,11 @@ namespace Content.Client.Lobby.UI
             if (species != null)
                 _defaultHeight = species.DefaultHeight;
 
+            // This dirty hack deals with "uninitialized" height values. Without this, preexisting or weirdly imported
+            // characters' heights default to the minimum value on the slider.
+            if (Profile.Height == 0.0)
+                Profile.Height = _defaultHeight;
+
             var prototype = _prototypeManager.Index(Profile.Species);
             var sliderPercent = (Profile.Height - prototype.MinHeight) /
                                 (prototype.MaxHeight - prototype.MinHeight);


### PR DESCRIPTION
Hack fix to make it so that people with default `0.0` height in the DB get their species default on first loading the humanoid profile editor, instead of getting a default smol slider value.

Full disclosure, I couldn't test this since I can't get a `0.0` in the db because I ain't got any RDMS software for sqlite on this machine and, no, you can't make me download it.