### PR TITLE
Post-Departmental Economy Telepad Research Adjustment

### DIFF
--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -176,6 +176,7 @@
   - WeaponSprayNozzle
   - ClothingBackpackWaterTank
 
+# Begin Moffstation object structure movement
 - type: technology
   id: BluespaceChemistry
   name: research-technology-bluespace-chemistry
@@ -183,11 +184,12 @@
     sprite: Objects/Specific/Chemistry/beaker_bluespace.rsi
     state: beakerbluespace
   discipline: CivilianServices
-  tier: 2
+  tier: 2 # Moffstation
   cost: 10000
   recipeUnlocks:
   - BluespaceBeaker
   - SyringeBluespace
+# End Moffstation object structure movement
 
 # Tier 3
 
@@ -203,6 +205,7 @@
   recipeUnlocks:
   - ClothingShoesBootsSpeed
 
+# Begin Moffstation object structure movement
 - type: technology
   id: BluespaceCargoTransport
   name: research-technology-bluespace-cargo-transport
@@ -210,7 +213,8 @@
     sprite: Structures/cargo_telepad.rsi
     state: display
   discipline: CivilianServices
-  tier: 3
+  tier: 3 # Moffstation
   cost: 15000
   recipeUnlocks:
   - CargoTelepadMachineCircuitboard
+# End Moffstation object structure movement

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -177,16 +177,17 @@
   - ClothingBackpackWaterTank
 
 - type: technology
-  id: BluespaceCargoTransport
-  name: research-technology-bluespace-cargo-transport
+  id: BluespaceChemistry
+  name: research-technology-bluespace-chemistry
   icon:
-    sprite: Structures/cargo_telepad.rsi
-    state: display
+    sprite: Objects/Specific/Chemistry/beaker_bluespace.rsi
+    state: beakerbluespace
   discipline: CivilianServices
   tier: 2
-  cost: 15000
+  cost: 10000
   recipeUnlocks:
-  - CargoTelepadMachineCircuitboard
+  - BluespaceBeaker
+  - SyringeBluespace
 
 # Tier 3
 
@@ -203,14 +204,13 @@
   - ClothingShoesBootsSpeed
 
 - type: technology
-  id: BluespaceChemistry
-  name: research-technology-bluespace-chemistry
+  id: BluespaceCargoTransport
+  name: research-technology-bluespace-cargo-transport
   icon:
-    sprite: Objects/Specific/Chemistry/beaker_bluespace.rsi
-    state: beakerbluespace
+    sprite: Structures/cargo_telepad.rsi
+    state: display
   discipline: CivilianServices
   tier: 3
-  cost: 10000
+  cost: 15000
   recipeUnlocks:
-  - BluespaceBeaker
-  - SyringeBluespace
+  - CargoTelepadMachineCircuitboard

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -176,20 +176,17 @@
   - WeaponSprayNozzle
   - ClothingBackpackWaterTank
 
-# Begin Moffstation object structure movement
 - type: technology
-  id: BluespaceChemistry
-  name: research-technology-bluespace-chemistry
+  id: BluespaceCargoTransport
+  name: research-technology-bluespace-cargo-transport
   icon:
-    sprite: Objects/Specific/Chemistry/beaker_bluespace.rsi
-    state: beakerbluespace
+    sprite: Structures/cargo_telepad.rsi
+    state: display
   discipline: CivilianServices
-  tier: 2 # Moffstation
-  cost: 10000
+  tier: 3 # Moffstation
+  cost: 15000
   recipeUnlocks:
-  - BluespaceBeaker
-  - SyringeBluespace
-# End Moffstation object structure movement
+  - CargoTelepadMachineCircuitboard
 
 # Tier 3
 
@@ -205,16 +202,15 @@
   recipeUnlocks:
   - ClothingShoesBootsSpeed
 
-# Begin Moffstation object structure movement
 - type: technology
-  id: BluespaceCargoTransport
-  name: research-technology-bluespace-cargo-transport
+  id: BluespaceChemistry
+  name: research-technology-bluespace-chemistry
   icon:
-    sprite: Structures/cargo_telepad.rsi
-    state: display
+    sprite: Objects/Specific/Chemistry/beaker_bluespace.rsi
+    state: beakerbluespace
   discipline: CivilianServices
-  tier: 3 # Moffstation
-  cost: 15000
+  tier: 2 # Moffstation
+  cost: 10000
   recipeUnlocks:
-  - CargoTelepadMachineCircuitboard
-# End Moffstation object structure movement
+  - BluespaceBeaker
+  - SyringeBluespace


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
Moved 'bluespace cargo transport' to tier 3 Civilian Services, and moved 'bluespace chemistry' to tier 2 Civilian Services.

## Why / Balance
With the recent addition to departmental economy, 'bluespace cargo transport' research has become a staple overperformer in the station environment, rendering the cargo department overshadowed. Additionally, 'bluespace chemistry' has often been desired by various station departments, however is often obtained too late in the research cycle to be of use of the station. This Pull Request seeks to address both of these issues by opening up 'bluespace chemistry' earlier, while also locking 'bluespace cargo transport' behind meaningful choice of tier 3 research.

## Technical details

[root]/Resources/Prototypes/Research/civillianservices.yml
```
- type: technology
  id: BluespaceCargoTransport
  name: research-technology-bluespace-cargo-transport
  icon:
    sprite: Structures/cargo_telepad.rsi
    state: display
  discipline: CivilianServices
  tier: 3 <<<<<
  cost: 15000
  recipeUnlocks:
  - CargoTelepadMachineCircuitboard
```
```
- type: technology
  id: BluespaceChemistry
  name: research-technology-bluespace-chemistry
  icon:
    sprite: Objects/Specific/Chemistry/beaker_bluespace.rsi
    state: beakerbluespace
  discipline: CivilianServices
  tier: 2 <<<<<
  cost: 10000
  recipeUnlocks:
  - BluespaceBeaker
  - SyringeBluespace
```

## Media

![image](https://github.com/user-attachments/assets/697b9652-8590-4aed-bd1a-361dfaee4d53)


![image](https://github.com/user-attachments/assets/d23a858e-a685-4358-b907-a1f0ff498ae7)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Swapped "Bluespace Cargo Transport" and "Bluespace Chemistry" researches within Civilian Services.
