### PR TITLE
Action buttons can be used within the action window.

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -627,12 +627,12 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         QueueWindowUpdate();
     }
 
-    private void OnWindowActionPressed(GUIBoundKeyEventArgs args, ActionButton button)
+    private void OnWindowActionPressed(GUIBoundKeyEventArgs args, ActionButton action)
     {
         if (args.Function != EngineKeyFunctions.UIClick && args.Function != EngineKeyFunctions.Use)
             return;
 
-        HandleActionPressed(args, button);
+        HandleActionPressed(args, action);
     }
 
     private void OnWindowActionUnPressed(GUIBoundKeyEventArgs args, ActionButton button)
@@ -660,11 +660,13 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (args.Function != EngineKeyFunctions.UIClick)
             return;
 
+        // Moffstation Start
         HandleActionPressed(args, button);
     }
-
     private void HandleActionPressed(GUIBoundKeyEventArgs args, ActionButton button)
     {
+        // Moffstation End
+
         args.Handle();
         if (button.ActionId != null)
         {
@@ -680,6 +682,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     private void OnActionUnpressed(GUIBoundKeyEventArgs args, ActionButton button)
     {
+        // Moffstation Start
         if (args.Function != EngineKeyFunctions.UIClick)
             return;
 
@@ -690,6 +693,8 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
     {
         if (_actionsSystem == null)
             return;
+
+        // Moffstation End
 
         args.Handle();
 

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -627,22 +627,20 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         QueueWindowUpdate();
     }
 
-    private void OnWindowActionPressed(GUIBoundKeyEventArgs args, ActionButton action)
+    private void OnWindowActionPressed(GUIBoundKeyEventArgs args, ActionButton button)
     {
         if (args.Function != EngineKeyFunctions.UIClick && args.Function != EngineKeyFunctions.Use)
             return;
 
-        _menuDragHelper.MouseDown(action);
-        args.Handle();
+        HandleActionPressed(args, button);
     }
 
-    private void OnWindowActionUnPressed(GUIBoundKeyEventArgs args, ActionButton dragged)
+    private void OnWindowActionUnPressed(GUIBoundKeyEventArgs args, ActionButton button)
     {
         if (args.Function != EngineKeyFunctions.UIClick && args.Function != EngineKeyFunctions.Use)
             return;
 
-        DragAction();
-        args.Handle();
+        HandleActionUnpressed(args, button);
     }
 
     private void OnWindowActionFocusExisted(ActionButton button)
@@ -662,6 +660,11 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (args.Function != EngineKeyFunctions.UIClick)
             return;
 
+        HandleActionPressed(args, button);
+    }
+
+    private void HandleActionPressed(GUIBoundKeyEventArgs args, ActionButton button)
+    {
         args.Handle();
         if (button.ActionId != null)
         {
@@ -677,7 +680,15 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     private void OnActionUnpressed(GUIBoundKeyEventArgs args, ActionButton button)
     {
-        if (args.Function != EngineKeyFunctions.UIClick || _actionsSystem == null)
+        if (args.Function != EngineKeyFunctions.UIClick)
+            return;
+
+        HandleActionUnpressed(args, button);
+    }
+
+    private void HandleActionUnpressed(GUIBoundKeyEventArgs args, ActionButton button)
+    {
+        if (_actionsSystem == null)
             return;
 
         args.Handle();

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -661,7 +661,6 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             return;
 
         // Moffstation Start
-// Moffstation Start
         HandleActionPressed(args, button);
     }
 // Moffstation End

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -632,8 +632,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (args.Function != EngineKeyFunctions.UIClick && args.Function != EngineKeyFunctions.Use)
             return;
 
-        // Moffstation
-        HandleActionPressed(args, action);
+        HandleActionPressed(args, action); // Moffstation
     }
 
     private void OnWindowActionUnPressed(GUIBoundKeyEventArgs args, ActionButton dragged)
@@ -641,7 +640,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (args.Function != EngineKeyFunctions.UIClick && args.Function != EngineKeyFunctions.Use)
             return;
 
-        HandleActionUnpressed(args, dragged);
+        HandleActionUnpressed(args, dragged); // Moffstation
     }
 
     private void OnWindowActionFocusExisted(ActionButton button)

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -632,15 +632,16 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (args.Function != EngineKeyFunctions.UIClick && args.Function != EngineKeyFunctions.Use)
             return;
 
+        // Moffstation
         HandleActionPressed(args, action);
     }
 
-    private void OnWindowActionUnPressed(GUIBoundKeyEventArgs args, ActionButton button)
+    private void OnWindowActionUnPressed(GUIBoundKeyEventArgs args, ActionButton dragged)
     {
         if (args.Function != EngineKeyFunctions.UIClick && args.Function != EngineKeyFunctions.Use)
             return;
 
-        HandleActionUnpressed(args, button);
+        HandleActionUnpressed(args, dragged);
     }
 
     private void OnWindowActionFocusExisted(ActionButton button)

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -661,8 +661,10 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             return;
 
         // Moffstation Start
+// Moffstation Start
         HandleActionPressed(args, button);
     }
+// Moffstation End
     private void HandleActionPressed(GUIBoundKeyEventArgs args, ActionButton button)
     {
         // Moffstation End

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -660,10 +660,10 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (args.Function != EngineKeyFunctions.UIClick)
             return;
 
-        // Moffstation Start
+        // Moffstation
         HandleActionPressed(args, button);
     }
-// Moffstation End
+
     private void HandleActionPressed(GUIBoundKeyEventArgs args, ActionButton button)
     {
         // Moffstation End

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -660,14 +660,13 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (args.Function != EngineKeyFunctions.UIClick)
             return;
 
-        // Moffstation
+// Moffstation Start
         HandleActionPressed(args, button);
     }
+// Moffstation End
 
     private void HandleActionPressed(GUIBoundKeyEventArgs args, ActionButton button)
     {
-        // Moffstation End
-
         args.Handle();
         if (button.ActionId != null)
         {
@@ -683,7 +682,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     private void OnActionUnpressed(GUIBoundKeyEventArgs args, ActionButton button)
     {
-        // Moffstation Start
+// Moffstation Start
         if (args.Function != EngineKeyFunctions.UIClick)
             return;
 
@@ -694,8 +693,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
     {
         if (_actionsSystem == null)
             return;
-
-        // Moffstation End
+// Moffstation End
 
         args.Handle();
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I've never cherrypicked before so I literally just brough over my work from upstream. ~~This poor Verin just wants some feedback. That's all he wants.~~ https://github.com/space-wizards/space-station-14/pull/35642

Made a minor change to ActionUIController.cs to allow for action buttons to be interacted with within the window.

## Why / Balance
Resolves https://github.com/space-wizards/space-station-14/issues/5537

Honestly, it just makes sense. I could've sworn this was already a thing but here you go.

## Technical details
Split the meat and bones of OnActionPressed and OnActionUnpressed into their own methods and incorporated those methods into OnWindowActionPressed and OnWindowActionUnpressed.

## Media

https://github.com/user-attachments/assets/16e09f3c-78dd-49bf-9927-fd710785aae2



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You can now use actions within the action window.
