### PR TITLE
Makes dwarves stout again

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -50,7 +50,10 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
         var speciesPrototype = _prototypeManager.Index(component.Species);
         var height = Math.Clamp(MathF.Round(component.Height, 2), speciesPrototype.MinHeight, speciesPrototype.MaxHeight); // should NOT be locked, at all
 
-        sprite.Scale = new Vector2(speciesPrototype.ScaleHeight ? height : 1f, height);
+        sprite.Scale = new Vector2(
+            (speciesPrototype.ScaleHeight ? height : 1f) * speciesPrototype.ImplicitSpriteScale.X,
+            height * speciesPrototype.ImplicitSpriteScale.Y
+        );
         // Moffstation End
 
         sprite[sprite.LayerMapReserveBlank(HumanoidVisualLayers.Eyes)].Color = component.EyeColor;

--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared.Dataset;
 using Content.Shared.Humanoid.Markings;
 using Robust.Shared.Prototypes;
@@ -159,6 +160,13 @@ public sealed partial class SpeciesPrototype : IPrototype
     /// </summary>
     [DataField("scaleHeight")]
     public bool ScaleHeight = true;
+
+    /// <summary>
+    /// How much to implicitly scale sprites of characters of this species. For example, dwarves are inherently squashed
+    /// along the Y direction. Note that this is applied after customizeable height scaling.
+    /// </summary>
+    [DataField]
+    public Vector2 ImplicitSpriteScale = Vector2.One;
     // Moffstation End
 }
 

--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+using System.Numerics; // Moffstation
 using Content.Shared.Dataset;
 using Content.Shared.Humanoid.Markings;
 using Robust.Shared.Prototypes;

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -7,3 +7,4 @@
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobDwarfDummy
   skinColoration: HumanToned
+  implicitSpriteScale: 1, 0.8

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -7,4 +7,4 @@
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobDwarfDummy
   skinColoration: HumanToned
-  implicitSpriteScale: 1, 0.8
+  implicitSpriteScale: 1, 0.8 # Moffstation


### PR DESCRIPTION
In what's both utterly cursed and I think a very clean way to do it. (Though somebody should probably track down where the innate scaling was before :thonk: )

Media:
![image](https://github.com/user-attachments/assets/d0671d9a-1556-45d5-917c-581299f80e18)
Dwarves on the left, humans on the right; tallest (height sliders) on the top, shortest on the bottom.

:cl:
- fix: Dwarves are stout again.
