### PR TITLE
Resilient Grenades

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -72,7 +72,8 @@
 #Moffstation - End
 
 - type: entity
-  name: explosive grenade
+  #name: explosive grenade (Moffstation - Resilient Grenades - Replaced)
+  name: high explosive grenade
   description: Grenade that creates a small but devastating explosion.
   parent: [GrenadeBase, BaseSyndicateContraband]
   id: ExGrenade

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -20,13 +20,27 @@
     damageContainer: Inorganic
   - type: Destructible
     thresholds:
+    # Moffstation - Begin (Resilient Grenades)
+    #- trigger:
+        #!type:DamageTrigger
+        #damage: 10
+      #behaviors:
+      #- !type:TriggerBehavior
+      #- !type:DoActsBehavior
+        #acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
         damage: 10
       behaviors:
+      - !type:TimerStartBehavior
+    - trigger:
+        !type:DamageTrigger
+        damage: 45
+      behaviors:
       - !type:TriggerBehavior
       - !type:DoActsBehavior
-        acts: ["Destruction"]
+        acts: [ "Destruction" ]
+      # Moffstation - End
   - type: Appearance
   - type: AnimationPlayer
   - type: GenericVisualizer
@@ -35,6 +49,27 @@
         enum.ConstructionVisuals.Layer:
           Primed: { state: primed }
           Unprimed: { state: icon }
+
+# Moffstation - Begin (Resilient Grenades)
+- type: entity
+  parent: GrenadeBase
+  id: GrenadeBaseFragile
+  abstract: true
+  components:
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 10
+      behaviors:
+      - !type:TimerStartBehavior
+    - trigger:
+        !type:DamageTrigger
+        damage: 30
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+#Moffstation - End
 
 - type: entity
   name: explosive grenade
@@ -60,7 +95,10 @@
 - type: entity
   name: flashbang
   description: Eeeeeeeeeeeeeeeeeeeeee.
-  parent: [ GrenadeBase, BaseSecurityContraband ]
+  # Moffstation - Begin (Resilient Grenades)
+  #parent: [ GrenadeBase, BaseSecurityContraband ]
+  parent: [ GrenadeBaseFragile, BaseSecurityContraband ]
+  # Moffstation - End
   id: GrenadeFlashBang
   components:
   - type: Sprite
@@ -111,20 +149,22 @@
     sprite: Objects/Weapons/Grenades/syndgrenade.rsi
   - type: ExplosionResistance
     damageCoefficient: 0.1
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 10
-      behaviors:
-      - !type:TimerStartBehavior
-    - trigger:
-        !type:DamageTrigger
-        damage: 45
-      behaviors:
-      - !type:TriggerBehavior
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
+  # Moffstation - Begin (Resilient Grenades)
+  #- type: Destructible
+    #thresholds:
+    #- trigger:
+        #!type:DamageTrigger
+        #damage: 10
+      #behaviors:
+      #- !type:TimerStartBehavior
+    #- trigger:
+        #!type:DamageTrigger
+        #damage: 45
+      #behaviors:
+      #- !type:TriggerBehavior
+      #- !type:DoActsBehavior
+        #acts: ["Destruction"]
+  # Moffstation - End
   - type: OnUseTimerTrigger
     delay: 5
   - type: ExplodeOnTrigger
@@ -165,7 +205,10 @@
 
 
 - type: entity
-  parent: [ GrenadeBase, BaseSyndicateContraband ]
+  # Moffstation - Begin (Resilient Grenades)
+  #parent: [ GrenadeBase, BaseSyndicateContraband ]
+  parent: [ GrenadeBaseFragile, BaseSyndicateContraband ]
+  # Moffstation - End
   id: SingularityGrenade
   name: singularity grenade
   description: Grenade that simulates the power of a singularity, pulling things in a heap.
@@ -320,6 +363,13 @@
     damageContainer: Inorganic
   - type: Destructible
     thresholds:
+    # Moffstation - Begin (Resilient Grenades)
+    - trigger:
+        !type:DamageTrigger
+        damage: 10
+      behaviors:
+      - !type:TimerStartBehavior
+    # Moffstation - End
     - trigger:
         !type:DamageTrigger
         damage: 50
@@ -347,7 +397,10 @@
 - type: entity
   name: EMP grenade
   description: A grenade designed to wreak havoc on electronic systems.
-  parent: [GrenadeBase, BaseSyndicateContraband]
+  # Moffstation - Begin (Resilient Grenades)
+  #parent: [GrenadeBase, BaseSyndicateContraband]
+  parent: [GrenadeBaseFragile, BaseSyndicateContraband]
+  # Moffstation - End
   id: EmpGrenade
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -9,11 +9,24 @@
   - type: DeleteOnTrigger
   - type: Destructible
     thresholds:
+    # Moffstation - Begin (Resilient Grenades)
+    #- trigger:
+        #!type:DamageTrigger
+        #damage: 10
+      #behaviors:
+      #- !type:TriggerBehavior
     - trigger:
         !type:DamageTrigger
         damage: 10
       behaviors:
-      - !type:TriggerBehavior
+      - !type:TimerStartBehavior
+    - trigger:
+        !type:DamageTrigger
+        damage: 45
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      # Moffstation - End
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -70,7 +70,8 @@
   parent: [ProjectileGrenadeBase, BaseSyndicateContraband]
   id: GrenadeIncendiary
   name: incendiary grenade
-  description: Guaranteed to light up the mood.
+  #description: Guaranteed to light up the mood. (Resilient Grenades - Replaced)
+  description: Releases a spray of incendiary shrapnel in all directions. Guaranteed to light up the mood.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Grenades/pyrogrenade.rsi
@@ -95,7 +96,8 @@
 - type: entity
   parent: [ProjectileGrenadeBase, BaseSyndicateContraband]
   id: GrenadeShrapnel
-  name: shrapnel grenade
+  #name: shrapnel grenade (Moffstation - Resilient Grenades - Replaced)
+  name: fragmentation grenade
   description: Releases a deadly spray of shrapnel that causes severe bleeding.
   components:
   - type: Sprite


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Current logic for grenades detonates them instantly when they take 10 damage. I find this infuriating and unfun. However, the Minibomb actually has separate arm and instantly detonate thresholds that can be added to all grenades!

New logic for grenades:
- All grenades will arm (start their fuse) at 10 damage. Better get it out quick!
Grenades have different behavior for if they take more than 10 damage before their fuse runs out:
- *Fragile* grenades (EMP, Supermatter, Whitehole, Flashbang) will be destroyed without detonating if they take 30 damage.
- *Projectile* grenades (Shrapnel, Stinger, incendiary) will be destroyed without detonating if they take 45 damage.
- *Canister* & *Explosive* grenades (Tear gas, Smoke, Cleanade, Metal foam, Explosive, Minibomb) will detonate instantly if they take 45 damage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Grenades are now a bit safer to carry while still being dangerous

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
**Changelog**
:cl: Nox38
- tweak: All grenades will start their fuse after taking 10 damage, instead of the previous instant detonation.
- tweak: Most grenades will detonate instantly on taking 45 damage.
- tweak: EMP, Supermatter, Whitehole, and Flashbang grenades will be instantly destroyed without detonating on taking 30 damage.
- tweak: Stinger, Incendiary, and Shrapnel grenades will be instantly destroyed without detonating on taking 45 damage.