### PR TITLE
Solar Panel Variation Pass Fix

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -456,3 +456,4 @@
     - id: SmugglerStashVariationPass
       prob: 0.90
     - id: SolarPanelDamageVariationPass # Moffstation - Roundstart Solar Panel variation
+    - id: SolarPanelEmptyVariationPass # Moffstation - Roundstart Solar Panel variation

--- a/Resources/Prototypes/_Moffstation/GameRules/variation.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/variation.yml
@@ -8,4 +8,14 @@
     entitiesPerReplacementStdDev: 5
     replacements:
     - id: SolarPanelBroken
+
+- type: entity
+  id: SolarPanelEmptyVariationPass
+  parent: BaseVariationPass
+  components:
+  - type: SolarPanelReplaceVariationPass
+  - type: EntityReplaceVariationPass
+    entitiesPerReplacementAverage: 20
+    entitiesPerReplacementStdDev: 5
+    replacements:
     - id: SolarAssembly


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR

Fixed an issue where solar panels would be replaced with both the unfinished one and the broken one. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details

Created a second variation pass that replaces solar panels with the unfinished variety, while preserving one that replaces them with the damaged ones. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/f769e0db-b400-4226-aa44-114ebc09723c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Southbridge
- fix: Solar Panel Round Start variation now won't spawn both a broken and an unfinished panel.

