### PR TITLE
Survival Boxes but Cool

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -210,7 +210,7 @@
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodBreadBaguette
+    - id: FoodSnackNutribrick # Moffstation - (Survival Box Improvements)
     - id: DrinkWaterBottleFull
 
 - type: entity
@@ -224,7 +224,7 @@
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodBreadBaguette
+    - id: FoodSnackNutribrick # Moffstation - (Survival Box Improvements)
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -210,7 +210,6 @@
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodBreadBaguette
     - id: DrinkWaterBottleFull
 
 - type: entity
@@ -224,7 +223,6 @@
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodBreadBaguette
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -210,7 +210,7 @@
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick # Moffstation - (Survival Box Improvements)
+    - id: FoodBreadBaguette
     - id: DrinkWaterBottleFull
 
 - type: entity
@@ -224,7 +224,7 @@
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick # Moffstation - (Survival Box Improvements)
+    - id: FoodBreadBaguette
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -210,6 +210,7 @@
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
+    - id: FoodSnackNutribrick # Moffstation - (Survival Box Improvements)
     - id: DrinkWaterBottleFull
 
 - type: entity
@@ -223,6 +224,7 @@
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
+    - id: FoodSnackNutribrick # Moffstation - (Survival Box Improvements)
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -245,6 +247,7 @@
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodSnackNutribrick
+    - id: DrinkWaterBottleFull # Moffstation - (Survival Box Improvements)
   - type: Sprite
     layers:
     - state: internals
@@ -262,6 +265,7 @@
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodSnackNutribrick
+    - id: DrinkWaterBottleFull # Moffstation - (Survival Box Improvements)
   - type: Sprite
     layers:
     - state: internals

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BoxCardboard
+  parent: BoxSurvivalEmpty # Moffstation - (Survival Box Improvements)
   id: BoxSurvival
   name: survival box
   description: It's a box with basic internals inside.
@@ -19,7 +19,7 @@
     - state: emergencytank
 
 - type: entity
-  parent: BoxSurvival
+  parent: BoxSurvivalEmpty # Moffstation - (Survival Box Improvements)
   id: BoxSurvivalNitrogen
   suffix: Standard N2
   components:
@@ -39,7 +39,7 @@
     currentLabel: reagent-name-nitrogen
 
 - type: entity
-  parent: BoxCardboard
+  parent: BoxSurvivalEmpty # Moffstation - (Survival Box Improvements)
   id: BoxSurvivalEngineering
   name: extended-capacity survival box
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
@@ -47,7 +47,7 @@
   components:
   - type: StorageFill
     contents:
-    - id: ClothingMaskBreath
+    - id: ClothingMaskGas # Moffstation - (Survival Box Improvements)
     - id: ExtendedEmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
@@ -65,7 +65,7 @@
   components:
   - type: StorageFill
     contents:
-    - id: ClothingMaskBreath
+    - id: ClothingMaskGas # Moffstation - (Survival Box Improvements)
     - id: ExtendedEmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
@@ -79,8 +79,7 @@
     currentLabel: reagent-name-nitrogen
 
 - type: entity
-
-  parent: BoxCardboard
+  parent: BoxSurvivalEmpty # Moffstation - (Survival Box Improvements)
   id: BoxSurvivalSecurity
   name: survival box
   description: It's a box with basic internals inside.
@@ -120,8 +119,7 @@
     currentLabel: reagent-name-nitrogen
 
 - type: entity
-
-  parent: BoxCardboard
+  parent: BoxSurvivalEmpty # Moffstation - (Survival Box Improvements)
   id: BoxSurvivalMedical
   name: survival box
   description: It's a box with basic internals inside.
@@ -161,7 +159,7 @@
     currentLabel: reagent-name-nitrogen
 
 - type: entity
-  parent: BoxCardboard
+  parent: BoxSurvivalEmpty # Moffstation - (Survival Box Improvements)
   id: BoxHug
   name: box of hugs
   description: A special box for sensitive people.
@@ -175,7 +173,7 @@
     heldPrefix: hug
   - type: StorageFill
     contents:
-    - id: ClothingMaskBreath
+    - id: ClothingMaskClown # Moffstation - (Survival Box Improvements)
     - id: EmergencyFunnyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
@@ -192,7 +190,7 @@
   components:
   - type: StorageFill
     contents:
-    - id: ClothingMaskBreath
+    - id: ClothingMaskClown # Moffstation - (Survival Box Improvements)
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
@@ -202,13 +200,13 @@
     currentLabel: reagent-name-nitrogen
 
 - type: entity
-  parent: BoxSurvival
+  parent: BoxSurvivalEmpty # Moffstation - (Survival Box Improvements)
   id: BoxMime
   suffix: Mime, Emergency
   components:
   - type: StorageFill
     contents:
-    - id: ClothingMaskBreath
+    - id: ClothingMaskMime # Moffstation - (Survival Box Improvements)
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
@@ -222,7 +220,7 @@
   components:
   - type: StorageFill
     contents:
-    - id: ClothingMaskBreath
+    - id: ClothingMaskMime # Moffstation - (Survival Box Improvements)
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
@@ -236,7 +234,7 @@
     currentLabel: reagent-name-nitrogen
 
 - type: entity
-  parent: BoxCardboard
+  parent: BoxSurvivalEmpty # Moffstation - (Survival Box Improvements)
   id: BoxSurvivalSyndicate
   name: extended-capacity survival box
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -42,7 +42,6 @@
       - ExpendableLight
       tags:
       - FoodSnack
-      - Bread
 # Moffstation - End
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -212,14 +212,25 @@
       - state: writing
 
 - type: entity
-  parent: BoxHug
+  parent: BoxCardboard
   id: BoxHugHealing
   suffix: Medical
   components:
+  # Moffstation - Begin (Survival Box Improvements)
+  - type: Sprite
+    layers:
+    - state: box_hug
+    - state: heart
+  - type: Item
+    heldPrefix: hug
   - type: StorageFill
     contents:
       - id: Brutepack
         amount: 3
+  - type: Tag
+    tags:
+    - BoxHug
+  # Moffstation - End
 
 - type: entity
   name: inflatable wall box

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -42,6 +42,7 @@
       - ExpendableLight
       tags:
       - FoodSnack
+      - Bread
 # Moffstation - End
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -18,6 +18,32 @@
     tags:
     - BoxCardboard
 
+# Moffstation - Begin
+- type: entity
+  parent: BoxCardboard
+  id: BoxSurvivalEmpty
+  name: survival box
+  description: A cardboard box for storing emergency supplies.
+  components:
+  - type: Item
+    size: Normal
+    shape:
+    - 0,0,1,1
+  - type: Storage
+    maxItemSize: Small
+    grid:
+    - 0,0,2,2
+    whitelist:
+      components:
+      - BreathMask
+      - GasTank
+      - Hypospray
+      - Sealable
+      - ExpendableLight
+      tags:
+      - FoodSnack
+# Moffstation - End
+
 - type: entity
   name: mousetrap box
   parent: BoxCardboard

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -34,15 +34,8 @@
     grid:
     - 0,0,2,2
     whitelist:
-      components:
-      - BreathMask
-      - GasTank
-      - Hypospray
-      - Sealable
-      - ExpendableLight
       tags:
-      - FoodSnack
-      - Bread
+      - SurvivalBoxInsertable
 # Moffstation - End
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Masks/base_clothingmask.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/base_clothingmask.yml
@@ -6,7 +6,7 @@
   - type: Sprite
     state: icon
   - type: Item
-    size: Small
+    size: Tiny # Moffstation - (Survival Box Improvements)
   - type: Clothing
     slots: [mask]
   - type: StaticPrice

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -30,8 +30,9 @@
   components:
   # Moffstation - Begin (Survival Box Improvements)
 #  - type: Item
-#  - type: Sprite
+#      size: Tiny
   # Moffstation - End
+  - type: Sprite
     sprite: Clothing/Mask/gassecurity.rsi
   - type: Clothing
     sprite: Clothing/Mask/gassecurity.rsi

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -15,6 +15,7 @@
   - type: IdentityBlocker
   - type: Tag
     tags:
+    - SurvivalBoxInsertable # Moffstation - (Survival Box Improvements)
     - HamsterWearable
     - WhitelistChameleon
   - type: HideLayerClothing
@@ -26,7 +27,7 @@
   parent: [ClothingMaskGas, BaseSecurityContraband]
   id: ClothingMaskGasSecurity
   name: security gas mask
-  description: A standard issue Security gas mask. Provides some additional protection. # Moffstation - (Survival Box Improvements)
+  description: A standard issue Security gas mask.
   components:
   # Moffstation - Begin (Survival Box Improvements)
 #  - type: Item
@@ -48,7 +49,7 @@
   parent: [ClothingMaskGas, BaseSyndicateContraband]
   id: ClothingMaskGasSyndicate
   name: syndicate gas mask
-  description: A close-fitting tactical mask that can be connected to an air supply. Protects from bright lights and welding flares, as well as physical damage. # Moffstation - (Survival Box Improvements)
+  description: A close-fitting tactical mask that can be connected to an air supply.
   components:
   - type: Sprite
     sprite: Clothing/Mask/gassyndicate.rsi
@@ -80,10 +81,10 @@
         Heat: 0.80
 
 - type: entity
-  parent: [ClothingMaskGas, BaseCommandContraband] # Moffstation - (Survival Box Improvements)
+  parent: [ClothingMaskGasAtmos, BaseCommandContraband]
   id: ClothingMaskGasCaptain
   name: captain's gas mask
-  description: Nanotrasen cut corners and repainted a spare gas mask, but don't tell anyone. # Moffstation - (Survival Box Improvements)
+  description: Nanotrasen cut corners and repainted a spare atmospheric gas mask, but don't tell anyone.
   components:
   - type: Sprite
     sprite: Clothing/Mask/gascaptain.rsi
@@ -93,7 +94,7 @@
   - type: IngestionBlocker
 
 - type: entity
-  parent: [ ClothingMaskGas, BaseCentcommContraband ] # Moffstation - (Survival Box Improvements)
+  parent: [ClothingMaskGasAtmos, BaseCommandContraband]
   id: ClothingMaskGasCentcom
   name: CentComm gas mask
   description: Oooh, gold and green. Fancy! This should help as you sit in your office.
@@ -141,6 +142,7 @@
     tags:
     - PetWearable
     - WhitelistChameleon
+    - SurvivalBoxInsertable # Moffstation - (Survival Box Improvements)
   - type: PhysicalComposition
     materialComposition:
       Steel: 50
@@ -184,6 +186,7 @@
     tags:
     - PetWearable
     - WhitelistChameleon
+    - SurvivalBoxInsertable # Moffstation - (Survival Box Improvements)
   - type: PhysicalComposition
     materialComposition:
       Steel: 50
@@ -198,10 +201,6 @@
   name: clown wig and mask
   description: A true prankster's facial attire. A clown is incomplete without his wig and mask.
   components:
-  # Moffstation - Begin (Survival Box Improvements)
-  - type: Item
-    size: Tiny
-  # Moffstation - End
   - type: Sprite
     sprite: Clothing/Mask/clown.rsi
   - type: Clothing
@@ -225,6 +224,7 @@
     - ClownMask
     - HamsterWearable
     - WhitelistChameleon
+    - SurvivalBoxInsertable # Moffstation - (Survival Box Improvements)
   - type: HideLayerClothing
     slots:
     - Snout
@@ -292,6 +292,7 @@
     tags:
     - HamsterWearable
     - WhitelistChameleon
+    - SurvivalBoxInsertable # Moffstation - (Survival Box Improvements)
   - type: HideLayerClothing
     slots:
     - Snout
@@ -382,6 +383,7 @@
   - type: Tag
     tags:
     - WhitelistChameleon
+    - SurvivalBoxInsertable # Moffstation - (Survival Box Improvements)
   - type: HideLayerClothing
     slots:
     - Hair
@@ -426,6 +428,7 @@
   - type: Tag
     tags:
     - WhitelistChameleon
+    - SurvivalBoxInsertable # Moffstation - (Survival Box Improvements)
   - type: HideLayerClothing
     slots:
     - Hair
@@ -699,6 +702,7 @@
   - type: Tag
     tags:
     - WhitelistChameleon
+    - SurvivalBoxInsertable
 
 # Entity tables
 - type: entityTable

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -26,11 +26,12 @@
   parent: [ClothingMaskGas, BaseSecurityContraband]
   id: ClothingMaskGasSecurity
   name: security gas mask
-  description: A standard issue Security gas mask.
+  description: A standard issue Security gas mask. Provides some additional protection. # Moffstation - (Survival Box Improvements)
   components:
-  - type: Item
-    size: Tiny
-  - type: Sprite
+  # Moffstation - Begin (Survival Box Improvements)
+#  - type: Item
+#  - type: Sprite
+  # Moffstation - End
     sprite: Clothing/Mask/gassecurity.rsi
   - type: Clothing
     sprite: Clothing/Mask/gassecurity.rsi
@@ -46,7 +47,7 @@
   parent: [ClothingMaskGas, BaseSyndicateContraband]
   id: ClothingMaskGasSyndicate
   name: syndicate gas mask
-  description: A close-fitting tactical mask that can be connected to an air supply.
+  description: A close-fitting tactical mask that can be connected to an air supply. Protects from bright lights and welding flares, as well as physical damage. # Moffstation - (Survival Box Improvements)
   components:
   - type: Sprite
     sprite: Clothing/Mask/gassyndicate.rsi
@@ -78,10 +79,10 @@
         Heat: 0.80
 
 - type: entity
-  parent: [ClothingMaskGasAtmos, BaseCommandContraband]
+  parent: [ClothingMaskGas, BaseCommandContraband] # Moffstation - (Survival Box Improvements)
   id: ClothingMaskGasCaptain
   name: captain's gas mask
-  description: Nanotrasen cut corners and repainted a spare atmospheric gas mask, but don't tell anyone.
+  description: Nanotrasen cut corners and repainted a spare gas mask, but don't tell anyone. # Moffstation - (Survival Box Improvements)
   components:
   - type: Sprite
     sprite: Clothing/Mask/gascaptain.rsi
@@ -91,7 +92,7 @@
   - type: IngestionBlocker
 
 - type: entity
-  parent: [ ClothingMaskGasAtmos, BaseCentcommContraband ]
+  parent: [ ClothingMaskGas, BaseCentcommContraband ] # Moffstation - (Survival Box Improvements)
   id: ClothingMaskGasCentcom
   name: CentComm gas mask
   description: Oooh, gold and green. Fancy! This should help as you sit in your office.
@@ -107,7 +108,7 @@
   parent: [ClothingMaskGas, BaseCargoContraband]
   id: ClothingMaskGasExplorer
   name: explorer gas mask
-  description: A military-grade gas mask that can be connected to an air supply.
+  description: A military-grade gas mask that can be connected to an air supply. Protects the face from work-related damages.
   components:
   - type: Sprite
     sprite: Clothing/Mask/gasexplorer.rsi

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -196,6 +196,10 @@
   name: clown wig and mask
   description: A true prankster's facial attire. A clown is incomplete without his wig and mask.
   components:
+  # Moffstation - Begin (Survival Box Improvements)
+  - type: Item
+    size: Tiny
+  # Moffstation - End
   - type: Sprite
     sprite: Clothing/Mask/clown.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -4,6 +4,8 @@
   name: gas mask
   description: A face-covering mask that can be connected to an air supply.
   components:
+  - type: Item
+    size: Tiny
   - type: Sprite
     sprite: Clothing/Mask/gas.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -4,8 +4,10 @@
   name: gas mask
   description: A face-covering mask that can be connected to an air supply.
   components:
+  # Moffstation - Begin (Survival Box Improvements)
   - type: Item
     size: Tiny
+  # Moffstation - End
   - type: Sprite
     sprite: Clothing/Mask/gas.rsi
   - type: Clothing
@@ -94,7 +96,7 @@
   - type: IngestionBlocker
 
 - type: entity
-  parent: [ClothingMaskGasAtmos, BaseCommandContraband]
+  parent: [ ClothingMaskGasAtmos, BaseCentcommContraband ]
   id: ClothingMaskGasCentcom
   name: CentComm gas mask
   description: Oooh, gold and green. Fancy! This should help as you sit in your office.
@@ -110,7 +112,7 @@
   parent: [ClothingMaskGas, BaseCargoContraband]
   id: ClothingMaskGasExplorer
   name: explorer gas mask
-  description: A military-grade gas mask that can be connected to an air supply. Protects the face from work-related damages.
+  description: A military-grade gas mask that can be connected to an air supply.
   components:
   - type: Sprite
     sprite: Clothing/Mask/gasexplorer.rsi
@@ -702,7 +704,7 @@
   - type: Tag
     tags:
     - WhitelistChameleon
-    - SurvivalBoxInsertable
+    - SurvivalBoxInsertable # Moffstation - (Survival Box Improvements)
 
 # Entity tables
 - type: entityTable

--- a/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
@@ -6,7 +6,10 @@
   suffix: Chameleon
   components:
     - type: Tag
-      tags: [] # ignore "WhitelistChameleon" tag
+      # Moffstation - Begin (Survival Box Improvements)
+      tags:
+      - SurvivalBoxInsertable
+      # Moffstation - End
     - type: Sprite
       sprite: Clothing/Mask/gas.rsi
     - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -658,6 +658,11 @@
     inHandsMaxFillLevels: 2
     inHandsFillBaseName: -fill-
   - type: Sealable
+  # Moffstation - Begin (Survival Box Improvements)
+  - type: Tag
+    tags:
+    - SurvivalBoxInsertable
+  # Moffstation - End
 
 - type: entity
   parent: DrinkWaterBottleFull

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -421,6 +421,7 @@
   - type: Tag
     tags:
       - FoodSnack
+      - SurvivalBoxInsertable # Moffstation - (Survival Box Improvements)
   - type: Sprite
     sprite: Objects/Consumable/Food/snacks.rsi
     state: nutribrick

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -189,7 +189,10 @@
         - ReagentId: TranexamicAcid
           Quantity: 3
   - type: Tag
-    tags: []
+    # Moffstation - Begin(Survival Box Improvements)
+    tags:
+    - SurvivalBoxInsertable
+    # Moffstation - End
 
 - type: entity
   name: poison auto-injector

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -8,6 +8,7 @@
     tags:
     - Flare
     - Trash
+    - SurvivalBoxInsertable # Moffstation - (Survival Box Improvements)
   - type: SpaceGarbage
   - type: ExpendableLight
     glowDuration: 225

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -110,6 +110,11 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 100
+  # Moffstation - Begin (Survival Box Improvements)
+  - type: Tag
+    tags:
+    - SurvivalBoxInsertable
+  # Moffstation - End
 
 - type: entity
   parent: EmergencyOxygenTank

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -30,6 +30,7 @@
   storage:
     back:
     - RubberStampMime
+    - FoodBreadBaguette # Moffstation - (Survival Box Improvements)
 
 - type: entity
   id: ActionMimeInvisibleWall

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1265,6 +1265,11 @@
 - type: Tag
   id: SurveillanceCameraMonitorCircuitboard
 
+# Moffstation - Begin (Survival Box Improvements)
+- type: Tag
+  id: SurvivalBoxInsertable
+# Moffstation - End
+
 - type: Tag
   id: Syndicate
 


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Survival boxes are now 2x2, BUT they can only fit the types of items that spawn in them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Now you have a reason to keep around your survival box!

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/1303184d-27b7-4a35-86f0-8410ca283983)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Nox38
- tweak: Survival boxes now have a whitelist, but are 2x2 in the inventory.
