### PR TITLE
Persona Saber Fixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -79,7 +79,7 @@
   name: captain's persona sabre
   parent: [ BaseSword, BaseCommandContraband ]
   id: CaptainSabre
-  description: A ceremonial weapon belonging to the captain of the station. Has a built-in PAI for advising the captain on various official matters.
+  description: A ceremonial weapon belonging to the captain of the station. A PAI is built into the grip, for advising the captain on various official matters.
   components:
   - type: Instrument
     allowPercussion: false
@@ -103,18 +103,22 @@
         requireInputValidation: false
   - type: Input
     context: "human"
-  - type: BlockMovement
   - type: PAI
-  - type: GhostRole
-    makeSentient: true
-    name: Captain's Persona Saber
-    description: Advise the captain on official matters, and thirst for blood.
-    rules: ghost-role-information-familiar-rules
+  - type: BlockMovement
+  - type: ToggleableGhostRole
+    examineTextMindPresent: pai-system-pai-installed
+    examineTextMindSearching: pai-system-still-searching
+    examineTextNoMind: pai-system-off
+    beginSearchingText: pai-system-searching
+    roleName: Captain's Persona Sabre
+    roleDescription: pai-system-role-description
+    roleRules: ghost-role-information-familiar-rules
     mindRoles:
     - MindRoleGhostRoleFamiliar
-    raffle:
-      settings: default
-  - type: GhostTakeoverAvailable
+    wipeVerbText: pai-system-wipe-device-verb-text
+    wipeVerbPopup: pai-system-wiped-device
+    stopSearchVerbText: pai-system-stop-searching-verb-text
+    stopSearchVerbPopup: pai-system-stopped-searching
   - type: Examiner
   - type: IntrinsicRadioReceiver
   - type: ActiveRadio


### PR DESCRIPTION
## About the PR
Captain's saber can now be wiped and start/stop searching at will like a normal PAI. It also no longer has a description encouraging them to be bloodthirsty.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Nox38
- fix: Captain's Saber's PAI can now be turned off or on.