### PR TITLE
Jetpack Rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -47,6 +47,7 @@
       quickEquip: false
       slots:
         - Back
+        - SuitStorage # Moffstation - Jetpack rebalance
     - type: GasTank
       outputPressure: 21.3
       air:
@@ -57,6 +58,12 @@
     - type: Appearance
     - type: StaticPrice
       price: 100
+    # Moffstation - Start -Jetpack rebalance
+    - type: ClothingSpeedModifier
+      walkModifier: 0.95
+      sprintModifier: 0.8
+    - type: HeldSpeedModifier
+    # Moffstation - End
 
 - type: entity
   id: ActionToggleJetpack
@@ -86,6 +93,7 @@
     sprite: Objects/Tanks/Jetpacks/blue.rsi
     slots:
       - Back
+      - SuitStorage # Moffstation - Jetpack rebalance
 
 # Filled blue
 - type: entity
@@ -119,6 +127,7 @@
     sprite: Objects/Tanks/Jetpacks/black.rsi
     slots:
       - Back
+      - SuitStorage # Moffstation - Jetpack rebalance
 
 # Filled black
 - type: entity
@@ -159,6 +168,11 @@
     - HighRiskItem
   - type: StealTarget
     stealGroup: JetpackCaptainFilled
+  # Moffstation - Start -Jetpack rebalance
+  - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
+  # Moffstation - End
 
 # Filled captain
 - type: entity
@@ -199,6 +213,11 @@
       outputPressure: 42.6
       air:
         volume: 1.5
+  # Moffstation - Start -Jetpack rebalance
+    - type: ClothingSpeedModifier
+      walkModifier: 1.0
+      sprintModifier: 1.0
+  # Moffstation - End
 
 # Filled mini
 - type: entity
@@ -232,6 +251,7 @@
     sprite: Objects/Tanks/Jetpacks/security.rsi
     slots:
       - Back
+      - SuitStorage # Moffstation - Jetpack rebalance
 
 #Filled security
 - type: entity
@@ -267,6 +287,11 @@
       - Back
       - suitStorage
       - Belt
+    # Moffstation - Start -Jetpack rebalance
+  - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
+    # Moffstation - End
 
 # Filled void
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -37,7 +37,7 @@
       state: icon
     - type: Item
       sprite: Objects/Tanks/Jetpacks/blue.rsi
-      size: Huge
+      size: Ginormous # Moffstation - Jetpack rebalance
     - type: UserInterface
       interfaces:
         enum.SharedGasTankUiKey.Key:
@@ -201,6 +201,7 @@
   components:
     - type: Item
       sprite: Objects/Tanks/Jetpacks/mini.rsi
+      size: Huge  # Moffstation - Jetpack rebalance
     - type: Sprite
       sprite: Objects/Tanks/Jetpacks/mini.rsi
     - type: Clothing
@@ -279,6 +280,7 @@
   components:
   - type: Item
     sprite: Objects/Tanks/Jetpacks/void.rsi
+    size: Huge  # Moffstation - Jetpack rebalance
   - type: Sprite
     sprite: Objects/Tanks/Jetpacks/void.rsi
   - type: Clothing


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Jetpacks now have a 20% slowdown modifier, but can now be worn on your suit slot. Void, Mini, and Captain's jetpack are not effected
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Jetpacks are already very robust, but I think many people find having to hold them in your handslot or backpack slot annoying. This is meant to be a compromise, It makes jetpacks more viable while in space, but inhibits your speed if you choose to walk around with one on a station. This is meant to discourage people just walking around with a jetpack casually, having the user choose between gearing up for space or for staying on the station.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Jetpacks can now be worn on your back, but slow you down.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
