### PR TITLE
Evac pods shower thoughts

### DIFF
--- a/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
@@ -317,26 +317,24 @@ public sealed partial class DockingSystem
             var configIsPriority = IsConfigPriority(config, priorityTag);
             var bestMatchIsPriority = IsConfigPriority(bestMatch, priorityTag);
             //If worse it moves on, if better it sets it, and if it's the same gets skipped
-            if (configIsPriority != bestMatchIsPriority)
+            switch (configIsPriority)
             {
-                switch (configIsPriority)
-                {
-                    case false when bestMatchIsPriority:
-                        continue;
-                    case true when !bestMatchIsPriority:
-                        bestMatch = config;
-                        continue;
-                }
+                case false when bestMatchIsPriority:
+                    continue;
+                case true when !bestMatchIsPriority:
+                    bestMatch = config;
+                    continue;
             }
 
             // Same with this one
-            if (bestMatch.Docks.Count != config.Docks.Count)
+            if (bestMatch.Docks.Count > config.Docks.Count)
+                continue;
+            if (bestMatch.Docks.Count < config.Docks.Count)
             {
-                if (bestMatch.Docks.Count > config.Docks.Count)
-                    continue;
                 bestMatch = config;
                 continue;
             }
+
 
             // These aren't going to be the same so don't bother lol
             if (Math.Abs(Angle.ShortestDistance(bestMatch.Angle.Reduced(), targetGridAngle).Theta) < Math.Abs(Angle.ShortestDistance(config.Angle.Reduced(), targetGridAngle).Theta))

--- a/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
@@ -314,12 +314,31 @@ public sealed partial class DockingSystem
             if (queueBusted)
                 continue;
 
-            if (!IsConfigPriority(config, priorityTag) && IsConfigPriority(bestMatch, priorityTag))
-                continue;
+            var configIsPriority = IsConfigPriority(config, priorityTag);
+            var bestMatchIsPriority = IsConfigPriority(bestMatch, priorityTag);
+            //If worse it moves on, if better it sets it, and if it's the same gets skipped
+            if (configIsPriority != bestMatchIsPriority)
+            {
+                switch (configIsPriority)
+                {
+                    case false when bestMatchIsPriority:
+                        continue;
+                    case true when !bestMatchIsPriority:
+                        bestMatch = config;
+                        continue;
+                }
+            }
 
-            if (bestMatch.Docks.Count > config.Docks.Count)
+            // Same with this one
+            if (bestMatch.Docks.Count != config.Docks.Count)
+            {
+                if (bestMatch.Docks.Count > config.Docks.Count)
+                    continue;
+                bestMatch = config;
                 continue;
+            }
 
+            // These aren't going to be the same so don't bother lol
             if (Math.Abs(Angle.ShortestDistance(bestMatch.Angle.Reduced(), targetGridAngle).Theta) < Math.Abs(Angle.ShortestDistance(config.Angle.Reduced(), targetGridAngle).Theta))
                 continue;
             bestMatch = config;


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
I was in the shower thinking over my logic and why they arrivals shuttle wasn't docking at the correct spot on amber, as well as why the pods wouldn't always be at the right spot at centcomm. And then it hit me: in my previous code all 3 comparisons had to be beaten in order to become the new best config. This is not what we want, as a dock with priority should always beat one without priority, and an option with more docks should take priority over what angle the shuttle has to change in order to dock.

I've changed the logic to meet, beat, and lose
if it meets the current config, it proceeds to the other comparisons.
if it beats the current config at any point, it takes it and compares it to the remaining ones.
if it loses at any point, it will instantly toss it and begin compares it to the next config.

Someone should double check my logic, and let me know if there's a more efficient way of doing this,
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed arrivals and evac pods, they should ALWAYS dock in the correct places now
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
