### PR TITLE
Caustic damage can now acidify

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -75,13 +75,13 @@
             min: 1
             max: 1
       - !type:GibBehavior { }
+    # Moffstation - End
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
         damage: 400
       behaviors:
       - !type:GibBehavior { }
-    # Moffstation - End
     - trigger:
         !type:DamageTypeTrigger
         damageType: Heat

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -62,12 +62,26 @@
     damageContainer: Biological
   - type: Destructible
     thresholds:
+    # Moffstation - Start - Caustic Damage Acidifies Corpses
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Caustic
+        damage: 400
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawnInContainer: false
+        spawn:
+          Acidifier:
+            min: 1
+            max: 1
+      - !type:GibBehavior { }
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
         damage: 400
       behaviors:
       - !type:GibBehavior { }
+    # Moffstation - End
     - trigger:
         !type:DamageTypeTrigger
         damageType: Heat

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -125,6 +125,7 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: acid
   color: "#a1000b"
+  worksOnTheDead: true # Moffstation - Acids burn
   boilingPoint: 78.2 # This isn't a real chemical...
   meltingPoint: -19.4
   plantMetabolism:
@@ -171,6 +172,7 @@
   desc: reagent-desc-ferrochromic-acid
   flavor: sour
   color: "#48b3b8"
+  worksOnTheDead: true # Moffstation - Acids burn
   physicalDesc: reagent-physical-desc-ferrous
   metabolisms:
     Drink:
@@ -193,6 +195,7 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: acid
   color: "#5050ff"
+  worksOnTheDead: true # Moffstation - Acids burn
   boilingPoint: 165
   meltingPoint: -87
   reactiveEffects:
@@ -233,6 +236,7 @@
   physicalDesc: reagent-physical-desc-oily
   flavor: acid
   color: "#BF8C00"
+  worksOnTheDead: true # Moffstation - Acids burn
   recognizable: true
   boilingPoint: 337.0
   meltingPoint: 10.31


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Inspired by PR#34617 from Wizden, caustic damage will now acidify targets.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A new, brutal, but niche option for round removal - this change hopes to make acids more lethal and noteworthy.

## Technical details
<!-- Summary of code changes for easier review. -->
Added acidify condition to mobs at 400 caustic damage. 
Made the following chemicals usable on dead mobs:
 - Polytrinic Acid
 - Ferrochromic Acid
 - Fluorosulfuric Acid
 - Sulfuric Acid

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/049710b4-6b7d-4063-9d3b-a9cf47e67eb5

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
 - Add: Caustic damage can now Acidify Mobs!