### PR TITLE
Minor nukie buffs/changes

### DIFF
--- a/Resources/Locale/en-US/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/prototypes/roles/antags.ftl
@@ -26,10 +26,10 @@ roles-antag-suspicion-suspect-objective = Kill the innocents.
 
 roles-antag-nuclear-operative-commander-name = Nuclear operative commander
 roles-antag-nuclear-operative-commander-objective = Lead your team to the destruction of the station.
-
-roles-antag-nuclear-operative-agent-name = Nuclear operative agent
-roles-antag-nuclear-operative-agent-objective = Like default operative, the team's treatment will have priority.
-
+# Moffstation - Begin (Nuclear Operative Balancing)
+roles-antag-nuclear-operative-agent-name = Nuclear operative corpsman
+roles-antag-nuclear-operative-agent-objective = Keep your team alive so they can complete their mission.
+# Moffstation - End
 roles-antag-nuclear-operative-name = Nuclear operative
 roles-antag-nuclear-operative-objective = Find the nuke disk and blow up the station.
 

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -86,7 +86,7 @@ uplink-pistol-magazine-name = Pistol Magazine (.35 auto)
 uplink-pistol-magazine-desc = Pistol magazine with 10 catridges. Compatible with the Viper.
 
 uplink-pistol-magazine-c20r-name = SMG magazine (.35 auto)
-uplink-pistol-magazine-c20r-desc = Rifle magazine with 30 catridges. Compatible with C-20r.
+uplink-pistol-magazine-c20r-desc = Sub Machine Gun magazine with 30 cartridges. Compatible with C-20r. # Moffstation - Nuclear Operative Balancing
 
 uplink-pistol-magazine-caseless-name = Pistol Magazine (.25 caseless)
 uplink-pistol-magazine-caseless-desc = Pistol magazine with 10 catridges. Compatible with the Cobra.

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -157,6 +157,19 @@
         amount: 2
       - id: EmpGrenade
         amount: 2
+# Moffstation - Begin (Nuclear Operative Balancing)
+- type: entity
+  id: ClothingBeltMilitaryWebbingNukeOpsFilled
+  parent: ClothingBeltMilitaryWebbing
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: MagazinePistol
+      amount: 2
+    - id: CombatKnife
+    - id: DeathRattleImplanter
+# Moffstation - End
 
 - type: entity
   id: ClothingBeltMilitaryWebbingMedFilled
@@ -165,6 +178,12 @@
   components:
   - type: StorageFill
     contents:
+      # Moffstation - Begin (Nuclear Operative Balancing)
+      - id: MagazinePistol
+        amount: 2
+      - id: CombatKnife
+      - id: DeathRattleImplanter
+      # Moffstation - End
       - id: ChemistryBottleEpinephrine
         amount: 2
       - id: ChemistryBottleEphedrine

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1637,7 +1637,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Armor/syndie-raid.rsi, state: icon }
   productEntity: ClothingBackpackSyndicateRaidBundle
   cost:
-    Telecrystal: 8
+    Telecrystal: 4 # Moffstation - Nuclear Operative Balancing
   categories:
   - UplinkWearables
   conditions:

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -91,7 +91,7 @@
   parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband]
   id: ClothingShoesBootsMagSyndie
   name: blood-red magboots
-  description: Reverse-engineered magnetic boots that have a heavy magnetic pull and integrated thrusters. It can hold 0.75 L of gas.
+  description: Upgraded magnetic boots with integrated thrusters. It can hold 0.75 L of gas, enough for about 2 minutes of flight. # Moffstation - Nuclear Operative Balancing
   components:
   - type: Sprite
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi
@@ -99,8 +99,10 @@
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.95
-    sprintModifier: 0.9
+    # Moffstation - Begin (Nuclear Operative Balancing)
+    walkModifier: 0.85
+    sprintModifier: 0.8
+    # Moffstation - End
   - type: GasTank
     outputPressure: 42.6
     air:

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -639,15 +639,20 @@
 - type: entity
   parent: [ IDCardStandard, BaseSyndicateContraband ]
   id: SyndicateIDCard
-  name: syndicate ID card
+  # Moffstation - Begin (Nuclear Operative Balancing)
+  name: syndicate operative ID card
+  description: A modified ID capable of copying the access of another ID by simply touching them together. Used primarily by Gorlex assault teams.
+  # Moffstation - End
   components:
   - type: Sprite
     layers:
     - state: syndie
+  - type: AgentIDCard # Moffstation - Nuclear Operative Balancing
   - type: Access
     tags:
     - NuclearOperative
     - SyndicateAgent
+    - Maintenance # Moffstation - Nuclear Operative Balancing
 
 - type: entity
   parent: [ IDCardStandard, BaseMajorContraband ]

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -50,10 +50,10 @@
     ears: ClothingHeadsetAltSyndicate
 #    gloves: ClothingHandsGlovesCombat # Moffstation - Removing items duplicated by the loadout
     outerClothing: ClothingOuterHardsuitSyndie
-    shoes: ClothingShoesBootsCombatFilled
+    shoes: ClothingShoesBootsMagSyndie # Moffstation - Nuclear Operative Balancing
     id: SyndiPDA
     pocket2: PlushieCarp
-    belt: ClothingBeltMilitaryWebbing
+    belt: ClothingBeltMilitaryWebbingNukeOpsFilled # Moffstation - Nuclear Operative Balancing
   storage:
     back:
     - WeaponPistolViper
@@ -97,7 +97,7 @@
   equipment:
     eyes: ClothingEyesHudSyndicateAgent
     outerClothing: ClothingOuterHardsuitSyndieMedic
-    shoes: ClothingShoesBootsMagSyndie
+    #shoes: ClothingShoesBootsMagSyndie # Moffstation - Nuclear Operative Balancing
     id: SyndiAgentPDA
     belt: ClothingBeltMilitaryWebbingMedFilled
   storage:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
- Raid suits now cost 4 TC instead of 8 TC, because of how much less useful thick space makes them.
- Syndicate magboots no longer have a general 10% slowdown, but will apply the standard magboot slowdown when activated.
- Standard nukie IDs can copy access like an agent ID.
- All operatives start with a syndicate deathrattle implant and two pistol magazines in their chest rig, and a free pair of syndicate magboots.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Nukies have a particularly low winrate on moff, and I feel these QOL changes are the first step towards fixing this.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Nox38
- tweak: Changed nukie equipment slightly: Basic nukie IDs can copy access, syndie magboots come free but have the same slowdown as normal magboots, and nukies start with spare pistol magazines and a deathrattle implant.
