### PR TITLE
Revert "lower playercount requirements for nukies and zombies"

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -114,7 +114,7 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 15 # Moffstation - Altering required playercount for certain antags, due to tendency not to meet the required readycount
+    minPlayers: 20
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml
   - type: AntagSelection
@@ -321,7 +321,7 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 15 # Moffstation - Altering required playercount for certain antags, due to tendency not to meet the required readycount
+    minPlayers: 20
     delay:
       min: 600
       max: 900


### PR DESCRIPTION
Reverts moff-station/moff-station-14#25

This PR was merged because when we first started the server we didn't have enough players to trigger gamemodes other than traitors, we no longer have that issue so I think we're good to raise it again.