### PR TITLE
Remove wizard from natural spawn, make it admeme only

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -153,7 +153,7 @@
   rules:
   - DummyNonAntagChance
   - Traitor
-  - SubGamemodesRule
+  - SubGamemodesRuleNoWizard # Moffstation - Remove wizard from natural spawn
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -182,7 +182,7 @@
   rules:
   - Nukeops
   - DummyNonAntagChance
-  - SubGamemodesRule
+  - SubGamemodesRuleNoWizard # Moffstation - Remove wizard from natural spawn
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -200,7 +200,7 @@
   rules:
   - DummyNonAntagChance
   - Revolutionary
-  - SubGamemodesRule
+  - SubGamemodesRuleNoWizard # Moffstation - Remove wizard from natural spawn
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,8 +2,8 @@
   id: Secret
   weights:
     Nukeops: 0.20
-    Traitor: 0.55
+    Traitor: 0.60 # Moffstation - remove wizard from natural spawn
     Zombie: 0.05
     Survival: 0.10
     Revolutionary: 0.05
-    Wizard: 0.05 # Why not, should probably be lower
+#    Wizard: 0.05 # Why not, should probably be lower # Moffstation - remove wizard from natural spawn


### PR DESCRIPTION
## About the PR
Makes the Wizard antag admeme only.

## Why / Balance
From my (very short I admit) time adminning on Moffstation, and from general player feedback, I have seen wizards constantly in a weird place from a roleplay and rules standpoint.

Moffstation's ruleset requires antagonists to seek permission from admins before attempting to friendly antag. Generally you're not supposed to do it all. Crew is also expected to treat the wizard like an actual threat (perm. escalation to lethals) as well. I have observed:
- Wizards being too nice to the crew or security and generally causing a round with nothing interesting going on.
- Crew or security being too nice to the Wizard and generally causing a round with nothing interesting going on.
- Wizards who absolutely obliterate the station in a hydrogen bomb vs. coughing baby moment where everyone dies and nobody really has fun.

Generally it creates a lot of inconsistencies for both parties and it ends up in a "who shoots first" moment and whoever's at the end of the stick will always be mad at the end of the day. Generally, people who are on Moffstation are looking to roleplay, and the wizard doesn't offer much of anything interesting in terms of natural roleplay (especially when these wizard friendly moments or gimmicks happen very often). It just doesn't make for an interesting round.

Making wizard admeme only is better as we don't have to deal with rule breakage bait or inconsistencies in ruling how things should play out. If we want to run wizard, we run it and tell them what to do or generally how it should go.

I'm also not interested in making Wizard a free agent as it creates yet another grey area and leads to player frustration. It will also instantly sideswipe any other major antag that it happens to be in.

## Technical details
Edits weights.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
CL broken
