### PR TITLE
Lobby pausing

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -128,6 +128,11 @@ namespace Content.Server.GameTicking
                         _pvsOverride.RemoveSessionOverride(mindId.Value, session);
                     }
 
+                    // Moffstation - Start - Auto-pause if there's nobody left to play
+                    if (_cfg.GetCVar(CCVars.EmptyAutoPause) && _playerManager.PlayerCount <= 1)
+                        PauseStart();
+                    // Moffstation - End
+
                     _userDb.ClientDisconnected(session);
                     break;
                 }

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -671,13 +671,7 @@ namespace Content.Server.GameTicking
             else
             {
                 if (_playerManager.PlayerCount == 0)
-                {
                     _roundStartCountdownHasNotStartedYetDueToNoPlayers = true;
-                    // Moffstation - Start - Auto-pause if we hit 0 players
-                    if (_cfg.GetCVar(CCVars.EmptyAutoPause))
-                        PauseStart();
-                    // Moffstation - End
-                }
                 else
                     _roundStartTime = _gameTiming.CurTime + LobbyDuration;
 

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -671,7 +671,13 @@ namespace Content.Server.GameTicking
             else
             {
                 if (_playerManager.PlayerCount == 0)
+                {
                     _roundStartCountdownHasNotStartedYetDueToNoPlayers = true;
+                    // Moffstation - Start - Auto-pause if we hit 0 players
+                    if (_cfg.GetCVar(CCVars.EmptyAutoPause))
+                        PauseStart();
+                    // Moffstation - End
+                }
                 else
                     _roundStartTime = _gameTiming.CurTime + LobbyDuration;
 

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -109,6 +109,8 @@ namespace Content.Server.GameTicking
             if (!DummyTicker)
                 RestartRound();
 
+            PauseStart(_cfg.GetCVar(CCVars.StartServerPaused)); // Moffstation - Pause the round on startup if the Cvar is enabled
+
             _postInitialized = true;
         }
 

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -138,6 +138,16 @@ namespace Content.Server.Voting.Managers
 
         private void StartVote(ICommonSession? initiator)
         {
+            // Moffstation - Start - block restart votes while the lobby is paused
+            _gameTicker = _entityManager.EntitySysManager.GetEntitySystem<GameTicker>();
+            if (_gameTicker.Paused && _cfg.GetCVar(CCVars.BlockRestartWhenPaused))
+            {
+                if (initiator != null)
+                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"{initiator.UserId} attempted to restart the round while the lobby was paused");
+                _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-restart-blocked-paused"));
+                return;
+            }
+            // Moffstation - End
             var alone = _playerManager.PlayerCount == 1 && initiator != null;
             var options = new VoteOptions
             {

--- a/Content.Shared/CCVar/CCVars.Server.cs
+++ b/Content.Shared/CCVar/CCVars.Server.cs
@@ -59,4 +59,10 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> ForceClientHudVersionWatermark =
         CVarDef.Create("server.force_client_hud_version_watermark", false, CVar.REPLICATED | CVar.SERVER);
+
+    /// <summary>
+    /// Moffstation - Pauses the lobby on server startup. Requires an admin to unpause before rounds begin
+    /// </summary>
+    public static readonly CVarDef<bool> StartServerPaused =
+        CVarDef.Create("server.start_server_paused", true, CVar.SERVERONLY);
 }

--- a/Content.Shared/CCVar/CCVars.Server.cs
+++ b/Content.Shared/CCVar/CCVars.Server.cs
@@ -65,4 +65,10 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> StartServerPaused =
         CVarDef.Create("server.start_server_paused", true, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Moffstation - Automatically pauses the lobby (until an admin unpauses) when the server reaches 0 players
+    /// </summary>
+    public static readonly CVarDef<bool> EmptyAutoPause =
+        CVarDef.Create("server.empty_auto_pause", true, CVar.SERVERONLY);
 }

--- a/Content.Shared/CCVar/CCVars.Vote.cs
+++ b/Content.Shared/CCVar/CCVars.Vote.cs
@@ -177,4 +177,10 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> VotekickIgnoreGhostReqInLobby =
         CVarDef.Create("votekick.ignore_ghost_req_in_lobby", true, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Moffstation - blocks restart votes when the lobby is paused
+    /// </summary>
+    public static readonly CVarDef<bool> BlockRestartWhenPaused =
+        CVarDef.Create("vote.block_restart_when_paused", true, CVar.SERVERONLY);
 }

--- a/Resources/Locale/en-US/_Moffstation/voting/voting.ftl
+++ b/Resources/Locale/en-US/_Moffstation/voting/voting.ftl
@@ -1,0 +1,1 @@
+ui-vote-restart-blocked-paused = Restart votes are unavailable while the lobby is paused


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
We've had a few issues with the round being unpaused when we don't want it to be in the past. This PR does 3 things (all are configurable with cvars):
- When the server starts up, it begins paused until an admin unpauses
- When the server hits 1 player, the lobby will automatically pause until an admin unpauses
- When the lobby is paused, round restart votes cannot be initiated (previously this could be used to bypass a lobby pause)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes some issues we've had, and puts in some fallbacks in case we make mistakes. 
## Technical details
<!-- Summary of code changes for easier review. -->
some basic C#
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
