### PR TITLE
Contribution guideline changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,14 @@ We don't have any specific guidelines for new art and sprites other than:
 
 Art is voted on by the community of Moffstation, and if it is accepted, it will be added to the game.
 
+## Balance Changes
+Changes centered around balance are brought under higher scrutiny than normal changes.
+
+If you wish to make a change that is purely balance centric, we encourage you to submit it to upstream instead.
+
+## Rules Changes
+We do not accept or consider rules changes submitted over github by non-staff. Please use the appropriate channel within the discord to suggest changes to the rules.
+
 ## Before submitting a pull request
 Before submitting a pull request, make sure to:
 - Test your changes in a development environment running Moffstation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ Changes centered around balance are brought under higher scrutiny than normal ch
 If you wish to make a change that is purely balance centric, we encourage you to submit it to upstream instead.
 
 ## Rules Changes
-We do not accept or consider rules changes submitted over github by non-staff. Please use the appropriate channel within the discord to suggest changes to the rules.
+We do not accept or consider rules changes submitted over GitHub by non-staff. Please use the appropriate channel within the discord to suggest changes to the rules.
 
 ## Before submitting a pull request
 Before submitting a pull request, make sure to:


### PR DESCRIPTION
As we have been getting alot more balance suggestions/PRs recently, we needed somewhat of an official stance on how to handle changes revolving around balance. (It may be vague, but it does warn people that what they're trying to change will come under more scrutiny)
There is quite a few reasons that I want to limit balance PRs, but put simply upstream has a greater ability to gauge and change balance, since they're much larger, have more rounds, have more discussion, and have more maintainers. Additionally, diverging from them on balance in many places will make things much harder to maintain over time.

This doesn't mean 0 balance PRs but they definitely need to treated with more scrutiny, and many of them should be directed at upstream rather than us.

Additionally, I put a policy down for rules PRs. I think most people would use the discord anyway, but this just makes it official.