### PR TITLE
Add central command syndicate contact

### DIFF
--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -17,6 +17,7 @@ using Content.Server.Shuttles.Events;
 using Content.Server.Station.Components;
 using Content.Server.Station.Events;
 using Content.Server.Station.Systems;
+using Content.Shared._Moffstation.Shuttles.Events;
 using Content.Shared.Access.Systems;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
@@ -219,6 +220,10 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
             };
             _deviceNetworkSystem.QueuePacket(uid, null, payload, netComp.TransmitFrequency);
         }
+        // Moffstation - Begin - CC Syndicate Contact
+        var launchEvent = new EmergencyShuttleLaunchEvent();
+        RaiseLocalEvent(ref launchEvent);
+        // Moffstation - End - CC Syndicate Contact
     }
 
     /// <summary>

--- a/Content.Server/_Moffstation/Spawners/Components/SpawnOnEmergencyShuttleLaunchComponent.cs
+++ b/Content.Server/_Moffstation/Spawners/Components/SpawnOnEmergencyShuttleLaunchComponent.cs
@@ -1,0 +1,17 @@
+﻿using Content.Server._Moffstation.Spawners.EntitySystems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Moffstation.Spawners.Components;
+
+/// <summary>
+/// Spawns a prototype entity when an emergency shuttle is launched.
+/// </summary>
+[RegisterComponent, Access(typeof(SpawnOnEmergencyShuttleLaunchSystem))]
+public sealed partial class SpawnOnEmergencyShuttleLaunchComponent : Component
+{
+    /// <summary>
+    /// Entity prototype to spawn.
+    /// </summary>
+    [DataField(required: true)]
+    public EntProtoId Prototype = string.Empty;
+}

--- a/Content.Server/_Moffstation/Spawners/EntitySystems/SpawnOnEmergencyShuttleLaunchSystem.cs
+++ b/Content.Server/_Moffstation/Spawners/EntitySystems/SpawnOnEmergencyShuttleLaunchSystem.cs
@@ -1,0 +1,35 @@
+﻿using Content.Server._Moffstation.Spawners.Components;
+using Content.Server.Spawners.EntitySystems;
+using Content.Shared._Moffstation.Shuttles.Events;
+
+namespace Content.Server._Moffstation.Spawners.EntitySystems;
+
+/// <summary>
+/// Handles the spawning of specific entities when an emergency shuttle launches.
+/// </summary>
+/// <inheritdoc/>
+public sealed class SpawnOnEmergencyShuttleLaunchSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EmergencyShuttleLaunchEvent>(OnEmergencyShuttleLaunch);
+    }
+
+    /// <summary>
+    /// Spawns the specified prototype when the emergency shuttle is launched.
+    /// </summary>
+    /// <param name="args"></param>
+    /// <remarks>Shitcoded implementation, direct copy paste from <see cref="SpawnOnDespawnSystem"/>
+    /// I'm not waiting a zillion years to make an upstream PR to deduplicate code.</remarks>
+    private void OnEmergencyShuttleLaunch(ref EmergencyShuttleLaunchEvent args)
+    {
+        var query = EntityQueryEnumerator<SpawnOnEmergencyShuttleLaunchComponent, TransformComponent>();
+
+        while (query.MoveNext(out _, out var comp, out var comp2))
+        {
+            Spawn(comp.Prototype, comp2.Coordinates);
+        }
+    }
+}

--- a/Content.Shared/_Moffstation/Shuttles/Events/EmergencyShuttleLaunchEvent.cs
+++ b/Content.Shared/_Moffstation/Shuttles/Events/EmergencyShuttleLaunchEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace Content.Shared._Moffstation.Shuttles.Events;
+
+/// <summary>
+/// Message sent when the emergency shuttle is launched.
+/// </summary>
+[ByRefEvent]
+public readonly record struct EmergencyShuttleLaunchEvent;

--- a/Resources/Locale/en-US/_Moffstation/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Moffstation/ghost/roles/ghost-role-component.ftl
@@ -1,0 +1,7 @@
+﻿ghost-role-information-Syndicate-Contact-name = Syndicate Contact
+ghost-role-information-Syndicate-Contact-description = Make contact with the Syndicate's agents and perform a debrief.
+
+ghost-role-information-Syndicate-Contact-rules = You are a Team Antagonist with Syndicate Agents. Your intention is to lay low and inconspicuously contact the Syndicate's agents that have made it to Central Command.
+    You are not allowed to recall any information you learned as a ghost, except for vague details about who is a Syndicate Agent and their objectives.
+    You don't remember any of your previous life.
+    You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.

--- a/Resources/Locale/en-US/_Moffstation/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Moffstation/ghost/roles/ghost-role-component.ftl
@@ -3,5 +3,4 @@ ghost-role-information-Syndicate-Contact-description = Make contact with the Syn
 
 ghost-role-information-Syndicate-Contact-rules = You are a Team Antagonist with Syndicate Agents. Your intention is to lay low and inconspicuously contact the Syndicate's agents that have made it to Central Command.
     You are not allowed to recall any information you learned as a ghost, except for vague details about who is a Syndicate Agent and their objectives.
-    You don't remember any of your previous life.
-    You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
+    You don't remember any of your previous life. You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.

--- a/Resources/Maps/_Harmony/centcomm.yml
+++ b/Resources/Maps/_Harmony/centcomm.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 255.1.0
   forkId: ""
   forkVersion: ""
-  time: 05/13/2025 02:23:31
-  entityCount: 8700
+  time: 05/25/2025 12:19:58
+  entityCount: 8701
 maps: []
 grids:
 - 1
@@ -46,7 +46,6 @@ entities:
     - type: MetaData
       name: Central Command
     - type: Transform
-      pos: 0.0,0.0
       parent: invalid
     - type: MapGrid
       chunks:
@@ -27421,7 +27420,7 @@ entities:
       pos: 50.5,57.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -38417.34
+      secondsUntilStateChange: -38451.17
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -43178,6 +43177,13 @@ entities:
     components:
     - type: Transform
       pos: 67.5,46.5
+      parent: 1
+- proto: RandomHumanoidSpawnerSyndicateContactMapping
+  entities:
+  - uid: 8701
+    components:
+    - type: Transform
+      pos: 49.5,20.5
       parent: 1
 - proto: RandomPosterLegit
   entities:

--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/Player/human.yml
@@ -1,0 +1,22 @@
+﻿- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: MobHuman
+  id: MobHumanSyndicateContact
+  name: Syndicate Contact
+  components:
+  - type: RandomHumanoidAppearance
+    randomizeName: true
+  - type: Loadout
+    prototypes: [ SyndicateContactGear ]
+    roleLoadout: [ RoleSurvivalSyndicate ]
+  - type: NpcFactionMember
+    factions:
+    - Syndicate
+  - type: GhostRole
+    name: ghost-role-information-Syndicate-Contact-name
+    description: ghost-role-information-Syndicate-Contact-description
+    rules: ghost-role-information-Syndicate-Contact-rules
+    raffle:
+      settings: short
+    mindRoles:
+    - MindRoleGhostRoleTeamAntagonist

--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/Player/humanoid.yml
@@ -1,0 +1,14 @@
+﻿
+# Need to double up on spawners for mapping to work correctly
+- type: entity
+  parent: MarkerBase
+  id: RandomHumanoidSpawnerSyndicateContactMapping
+  name: Syndicate Contact Spawner
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi
+      state: icon
+  - type: SpawnOnEmergencyShuttleLaunch
+    prototype: MobHumanSyndicateContact # I'm so sorry.

--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Devices/pda.yml
@@ -17,3 +17,16 @@
     borderColor: "#FF9751"
   - type: Icon
     state: "pda-prisoner"
+
+- type: entity
+  parent: ChameleonPDA
+  id: SyndicateContactPDA
+  components:
+  - type: Pda
+    id: AgentIDCard
+    penSlot:
+      startingItem: CyberPen
+      priority: -1
+      whitelist:
+        tags:
+        - Write

--- a/Resources/Prototypes/_Moffstation/Roles/Antags/syndie.yml
+++ b/Resources/Prototypes/_Moffstation/Roles/Antags/syndie.yml
@@ -1,0 +1,23 @@
+﻿# CC Contact
+- type: startingGear
+  id: SyndicateContactGear
+  equipment:
+    head: ClothingHeadHatOutlawHat
+    jumpsuit: ClothingUniformJumpsuitChameleon
+    back: ClothingBackpackDuffel
+    eyes: ClothingEyesGlassesSunglasses
+    ears: ClothingHeadsetChameleon
+    gloves: ClothingHandsChameleon
+    outerClothing: ClothingOuterCoatJensen
+    shoes: ClothingShoesChameleon
+    id: SyndiPDA
+  storage:
+    back:
+    - SpaceCash10000
+    - SpaceCash10000
+    - SpaceCash10000
+    - DeathAcidifierImplanter
+    - AllTraitorCodesPaper
+    - Flash
+  inhand:
+  - BriefcaseSyndie


### PR DESCRIPTION
## About the PR
Adds the Syndicate Contact, a ghost role that automatically spawns when the emergency shuttle is launched to CC.

This ghost role is geared towards making contact with syndicate agents and hosting a """debrief""".

## Why / Balance
Further ties into our belief that syndicate agents shouldn't be causing chaos, rather they should be laying low and awaiting their contact at CC.

## Technical details
Adds a new component that spawns a prototype at a spawner when the emergency shuttle leaves.
Adds a new event that fires when an emergency shuttle leaves.

This was coded at 6AM, I worked on this all night for some fucking stupid reason and I'm watching the sun rise as I type this. God.

## Media
![Content Client_cQWMNfr6Jf](https://github.com/user-attachments/assets/912a51da-b84e-47d9-a1de-4021762ac5f3)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
CL broken so no fun
