### PR TITLE
Vent Critter Hordes

### DIFF
--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -4,8 +4,8 @@ using Content.Shared.Storage;
 namespace Content.Server.StationEvents.Components;
 
 // Moffstation - Start - Rename to use upstream functionality
-[RegisterComponent, Access(typeof(VentCrittersRuleUpstream))]
-public sealed partial class VentCrittersRuleComponentUpstream : Component
+[RegisterComponent, Access(typeof(UpstreamVentCrittersRule))]
+public sealed partial class UpstreamVentCrittersRuleComponent : Component
 // Moffstation - End
 {
     [DataField("entries")]

--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -16,6 +16,8 @@ public sealed partial class VentCrittersRuleComponent : Component
     [DataField("specialEntries")]
     public List<EntitySpawnEntry> SpecialEntries = new();
 
+
+    // Moffstation - Start - New variables for single vent spawn
     public EntityCoordinates? Location;
 
     /// <summary>
@@ -23,4 +25,5 @@ public sealed partial class VentCrittersRuleComponent : Component
     /// </summary>
     [DataField]
     public int SpawnChances = 100;
+    // Moffstation - End
 }

--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.StationEvents.Events;
 using Content.Shared.Storage;
+using Robust.Shared.Map;
 
 namespace Content.Server.StationEvents.Components;
 
@@ -15,15 +16,11 @@ public sealed partial class VentCrittersRuleComponent : Component
     [DataField("specialEntries")]
     public List<EntitySpawnEntry> SpecialEntries = new();
 
-    /// <summary>
-    /// The number of players per spawn that occurs.
-    /// </summary>
-    [DataField]
-    public int PlayerRatio = 10;
+    public EntityCoordinates? Location;
 
     /// <summary>
-    /// The chance per spawn that an additional critter will be spawned (spawns can stack)
+    /// The amount of chances something gets to spawn. estimated number of spawns can be calculated with (SpawnChances * entryProb)
     /// </summary>
     [DataField]
-    public float ExtraSpawnChance = 0.5f;
+    public int SpawnChances = 100;
 }

--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -1,12 +1,12 @@
-﻿using Content.Server._Moffstation.StationEvents.Events;
-using Content.Server.StationEvents.Events;
+﻿using Content.Server.StationEvents.Events;
 using Content.Shared.Storage;
-using Robust.Shared.Map;
 
 namespace Content.Server.StationEvents.Components;
 
-[RegisterComponent, Access(typeof(VentCrittersRule))]
-public sealed partial class VentCrittersRuleComponent : Component
+// Moffstation - Start - Rename to use upstream functionality
+[RegisterComponent, Access(typeof(VentCrittersRuleUpstream))]
+public sealed partial class VentCrittersRuleComponentUpstream : Component
+// Moffstation - End
 {
     [DataField("entries")]
     public List<EntitySpawnEntry> Entries = new();
@@ -16,14 +16,4 @@ public sealed partial class VentCrittersRuleComponent : Component
     /// </summary>
     [DataField("specialEntries")]
     public List<EntitySpawnEntry> SpecialEntries = new();
-
-    // Moffstation - Start - New variables for single vent spawn
-    /// <summary>
-    /// The amount of chances something gets to spawn. estimated number of spawns can be calculated with (SpawnChances * entryProb)
-    /// </summary>
-    [DataField]
-    public int SpawnAttempts = 100;
-
-    public EntityCoordinates? Location;
-    // Moffstation - End
 }

--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -14,4 +14,16 @@ public sealed partial class VentCrittersRuleComponent : Component
     /// </summary>
     [DataField("specialEntries")]
     public List<EntitySpawnEntry> SpecialEntries = new();
+
+    /// <summary>
+    /// The number of players per spawn that occurs.
+    /// </summary>
+    [DataField]
+    public int PlayerRatio = 10;
+
+    /// <summary>
+    /// The chance per spawn that an additional critter will be spawned (spawns can stack)
+    /// </summary>
+    [DataField]
+    public float ExtraSpawnChance = 0.5f;
 }

--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server.StationEvents.Events;
+﻿using Content.Server._Moffstation.StationEvents.Events;
+using Content.Server.StationEvents.Events;
 using Content.Shared.Storage;
 using Robust.Shared.Map;
 
@@ -16,14 +17,13 @@ public sealed partial class VentCrittersRuleComponent : Component
     [DataField("specialEntries")]
     public List<EntitySpawnEntry> SpecialEntries = new();
 
-
     // Moffstation - Start - New variables for single vent spawn
-    public EntityCoordinates? Location;
-
     /// <summary>
     /// The amount of chances something gets to spawn. estimated number of spawns can be calculated with (SpawnChances * entryProb)
     /// </summary>
     [DataField]
-    public int SpawnChances = 100;
+    public int SpawnAttempts = 100;
+
+    public EntityCoordinates? Location;
     // Moffstation - End
 }

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -7,14 +7,14 @@ using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
 
-public sealed class VentCrittersRuleUpstream : StationEventSystem<VentCrittersRuleComponent>    // Moffstation, renamed so our rule is used instead. See used version in Moffstation namespace
+public sealed class VentCrittersRuleUpstream : StationEventSystem<VentCrittersRuleComponentUpstream>    // Moffstation, renamed so our rule is used instead. See used version in Moffstation namespace
 {
     /*
      * DO NOT COPY PASTE THIS TO MAKE YOUR MOB EVENT.
      * USE THE PROTOTYPE.
      */
 
-    protected override void Started(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    protected override void Started(EntityUid uid, VentCrittersRuleComponentUpstream component, GameRuleComponent gameRule, GameRuleStartedEvent args)  // Moffstation - Changed to use the upstream component
     {
         base.Started(uid, component, gameRule, args);
 

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -7,14 +7,14 @@ using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
 
-public sealed class VentCrittersRuleUpstream : StationEventSystem<VentCrittersRuleComponentUpstream>    // Moffstation, renamed so our rule is used instead. See used version in Moffstation namespace
+public sealed class UpstreamVentCrittersRule : StationEventSystem<UpstreamVentCrittersRuleComponent>    // Moffstation, renamed so our rule is used instead. See used version in Moffstation namespace
 {
     /*
      * DO NOT COPY PASTE THIS TO MAKE YOUR MOB EVENT.
      * USE THE PROTOTYPE.
      */
 
-    protected override void Started(EntityUid uid, VentCrittersRuleComponentUpstream component, GameRuleComponent gameRule, GameRuleStartedEvent args)  // Moffstation - Changed to use the upstream component
+    protected override void Started(EntityUid uid, UpstreamVentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)  // Moffstation - Changed to use the upstream component
     {
         base.Started(uid, component, gameRule, args);
 

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -105,6 +105,8 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
         }
 
         // Pick one at random
-        component.Location = _random.Pick(validLocations);
+        if (validLocations.Count != 0)
+            component.Location = _random.Pick(validLocations);
+
     }
 }

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -1,4 +1,3 @@
-using Content.Server.Pinpointer;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Station.Components;
@@ -8,109 +7,52 @@ using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
 
-/// <remarks>
-/// Moffstation - File has been completely rewritten, do not accept upstream changes
-/// </remarks>
-public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleComponent>
+public sealed class VentCrittersRuleUpstream : StationEventSystem<VentCrittersRuleComponent>    // Moffstation, renamed so our rule is used instead. See used version in Moffstation namespace
 {
     /*
      * DO NOT COPY PASTE THIS TO MAKE YOUR MOB EVENT.
      * USE THE PROTOTYPE.
      */
 
-    [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly NavMapSystem _navMap = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
-
-    protected override void Added(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
+    protected override void Started(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
-        base.Added(uid, component, gameRule, args);
+        base.Started(uid, component, gameRule, args);
 
-        // Choose location and make sure it's not null
-        ChooseLocation(component);
-        if (component.Location is not { } location)
-        {
-            Log.Warning($"Unable to find a valid location for {args.RuleId}!");
-            ForceEndSelf(uid, gameRule);
-            return;
-        }
-
-        // Get the event component so we can format the announcement
-        if (TryComp<StationEventComponent>(uid, out var stationEventComp) && stationEventComp.StartAnnouncement != null)
-        {
-            // Get the nearest beacon
-            var mapLocation = _transform.ToMapCoordinates(location);
-            var nearestBeacon = _navMap.GetNearestBeaconString(mapLocation, onlyName: true);
-
-            // Get the duration, if its null we'll just use 0
-            var duration = stationEventComp.Duration?.Seconds ?? 0;
-
-            // Format the announcement with the time and location, if the string doesn't have them it'll still work fine
-            stationEventComp.StartAnnouncement =
-                Loc.GetString(stationEventComp.StartAnnouncement,
-                    ("location", nearestBeacon),
-                    ("time", duration));
-        }
-    }
-
-    protected override void Ended(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
-    {
-        base.Ended(uid, component, gameRule, args);
-
-        // Make sure the location is not null
-        if (component.Location is not { } location)
-        {
-            Log.Warning($"Location for gamerule {args.RuleId} was null!");
-            return;
-        }
-
-        //Spawn in the stuff
-        for (var i = 0; i < component.SpawnChances; i++)
-        {
-            foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
-            {
-                Spawn(spawn, location);
-            }
-        }
-
-        // Spawn a special spawn (guaranteed spawn)
-        var specialEntry = RobustRandom.Pick(component.SpecialEntries);
-        Spawn(specialEntry.PrototypeId, location);
-
-        // Extra chance to spawn additional entities
-        if (component.SpecialEntries.Count != 0)
-        {
-            foreach (var specialSpawn in EntitySpawnCollection.GetSpawns(component.SpecialEntries, RobustRandom))
-            {
-                Spawn(specialSpawn, location);
-            }
-        }
-    }
-
-    private void ChooseLocation(VentCrittersRuleComponent component)
-    {
-        // Get a station
         if (!TryGetRandomStation(out var station))
         {
             return;
         }
 
-        //Query the possible locations
         var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
         var validLocations = new List<EntityCoordinates>();
-
-        // Filter to things on the same station
         while (locations.MoveNext(out _, out _, out var transform))
         {
             if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station)
             {
                 validLocations.Add(transform.Coordinates);
+                foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
+                {
+                    Spawn(spawn, transform.Coordinates);
+                }
             }
         }
 
-        // Pick one at random
-        if (validLocations.Count != 0)
-            component.Location = _random.Pick(validLocations);
+        if (component.SpecialEntries.Count == 0 || validLocations.Count == 0)
+        {
+            return;
+        }
 
+        // guaranteed spawn
+        var specialEntry = RobustRandom.Pick(component.SpecialEntries);
+        var specialSpawn = RobustRandom.Pick(validLocations);
+        Spawn(specialEntry.PrototypeId, specialSpawn);
+
+        foreach (var location in validLocations)
+        {
+            foreach (var spawn in EntitySpawnCollection.GetSpawns(component.SpecialEntries, RobustRandom))
+            {
+                Spawn(spawn, location);
+            }
+        }
     }
 }

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -1,17 +1,16 @@
-using Content.Server.Antag;
-using Content.Server.Chat.Systems;
 using Content.Server.Pinpointer;
-using Content.Server.Station.Systems;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Station.Components;
 using Content.Shared.Storage;
 using Robust.Shared.Map;
-using Robust.Shared.Player;
 using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
 
+/// <remarks>
+/// Moffstation - File has been completely rewritten, do not accept upstream changes
+/// </remarks>
 public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleComponent>
 {
     /*
@@ -20,13 +19,8 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
      */
 
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly AntagSelectionSystem _antag = default!;
-    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
     [Dependency] private readonly NavMapSystem _navMap = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
-    [Dependency] private readonly ChatSystem _chatSystem = default!;
-    [Dependency] private readonly StationSystem _station = default!;
-
     protected override void Added(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
     {
         // Choose location and make sure it's not null

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -1,3 +1,4 @@
+using Content.Server.Antag;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Station.Components;
@@ -13,6 +14,9 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
      * DO NOT COPY PASTE THIS TO MAKE YOUR MOB EVENT.
      * USE THE PROTOTYPE.
      */
+
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly AntagSelectionSystem _antag = default!;
 
     protected override void Started(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
@@ -30,11 +34,16 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
             if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station)
             {
                 validLocations.Add(transform.Coordinates);
-                foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
-                {
-                    Spawn(spawn, transform.Coordinates);
-                }
             }
+        }
+
+        var pickedLocation = _random.Pick(validLocations);
+
+        component.
+
+        foreach (var spawn in EntitySpawnCollection.GetSpawns(component.SpecialEntries, RobustRandom))
+        {
+
         }
 
         if (component.SpecialEntries.Count == 0 || validLocations.Count == 0)
@@ -54,5 +63,12 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
                 Spawn(spawn, location);
             }
         }
+    }
+
+    private void SpawnCritter(string prototypeId, EntityCoordinates spawn, float recursionChance)
+    {
+        Spawn(prototypeId, spawn);
+        if (_random.NextFloat() < recursionChance)
+            SpawnCritter(prototypeId, spawn, recursionChance);
     }
 }

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -21,8 +21,11 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly NavMapSystem _navMap = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+
     protected override void Added(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
     {
+        base.Added(uid, component, gameRule, args);
+
         // Choose location and make sure it's not null
         ChooseLocation(component);
         if (component.Location is not { } location)
@@ -48,8 +51,6 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
                     ("location", nearestBeacon),
                     ("time", duration));
         }
-
-        base.Added(uid, component, gameRule, args);
     }
 
     protected override void Ended(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
@@ -58,7 +59,10 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
 
         // Make sure the location is not null
         if (component.Location is not { } location)
+        {
+            Log.Warning($"Location for gamerule {args.RuleId} was null!");
             return;
+        }
 
         //Spawn in the stuff
         for (var i = 0; i < component.SpawnChances; i++)

--- a/Content.Server/_Moffstation/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/_Moffstation/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -1,0 +1,29 @@
+﻿using Content.Server._Moffstation.StationEvents.Events;
+using Content.Server.StationEvents.Events;
+using Content.Shared.Storage;
+using Robust.Shared.Map;
+
+namespace Content.Server._Moffstation.StationEvents.Components;
+
+[RegisterComponent, Access(typeof(VentCrittersRule))]
+public sealed partial class VentCrittersRuleComponent : Component
+{
+    [DataField("entries")]
+    public List<EntitySpawnEntry> Entries = new();
+
+    /// <summary>
+    /// At least one special entry is guaranteed to spawn
+    /// </summary>
+    [DataField("specialEntries")]
+    public List<EntitySpawnEntry> SpecialEntries = new();
+
+    // Moffstation - Start - New variables for single vent spawn
+    /// <summary>
+    /// The amount of chances something gets to spawn. estimated number of spawns can be calculated with (SpawnChances * entryProb)
+    /// </summary>
+    [DataField]
+    public int SpawnAttempts = 100;
+
+    public EntityCoordinates? Location;
+    // Moffstation - End
+}

--- a/Content.Server/_Moffstation/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/_Moffstation/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -17,7 +17,6 @@ public sealed partial class VentCrittersRuleComponent : Component
     [DataField("specialEntries")]
     public List<EntitySpawnEntry> SpecialEntries = new();
 
-    // Moffstation - Start - New variables for single vent spawn
     /// <summary>
     /// The amount of chances something gets to spawn. estimated number of spawns can be calculated with (SpawnChances * entryProb)
     /// </summary>
@@ -25,5 +24,4 @@ public sealed partial class VentCrittersRuleComponent : Component
     public int SpawnAttempts = 100;
 
     public EntityCoordinates? Location;
-    // Moffstation - End
 }

--- a/Content.Server/_Moffstation/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/_Moffstation/StationEvents/Events/VentCrittersRule.cs
@@ -1,0 +1,114 @@
+using Content.Server.Pinpointer;
+using Content.Server.StationEvents.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Station.Components;
+using Content.Shared.Storage;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+
+namespace Content.Server._Moffstation.StationEvents.Events;
+
+/// <remarks>
+/// Moffstation - File has been completely rewritten, do not accept upstream changes
+/// </remarks>
+public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleComponent>
+{
+    /*
+     * DO NOT COPY PASTE THIS TO MAKE YOUR MOB EVENT.
+     * USE THE PROTOTYPE.
+     */
+
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly NavMapSystem _navMap = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    protected override void Added(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
+    {
+        base.Added(uid, component, gameRule, args);
+
+        // Choose location and make sure it's not null
+        component.Location = ChooseLocation();
+        if (component.Location is not { } location)
+        {
+            Log.Warning($"Unable to find a valid location for {args.RuleId}!");
+            ForceEndSelf(uid, gameRule);
+            return;
+        }
+
+        // Get the event component so we can format the announcement
+        if (TryComp<StationEventComponent>(uid, out var stationEventComp) && stationEventComp.StartAnnouncement != null)
+        {
+            // Get the nearest beacon
+            var mapLocation = _transform.ToMapCoordinates(location);
+            var nearestBeacon = _navMap.GetNearestBeaconString(mapLocation, onlyName: true);
+
+            // Get the duration, if its null we'll just use 0
+            var duration = stationEventComp.Duration?.Seconds ?? 0;
+
+            // Format the announcement with the time and location, if the string doesn't have them it'll still work fine
+            stationEventComp.StartAnnouncement =
+                Loc.GetString(stationEventComp.StartAnnouncement,
+                    ("location", nearestBeacon),
+                    ("time", duration));
+        }
+    }
+
+    protected override void Ended(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
+    {
+        base.Ended(uid, component, gameRule, args);
+
+        // Make sure the location is not null
+        if (component.Location is not { } location)
+        {
+            Log.Warning($"Location for gamerule {args.RuleId} was null!");
+            return;
+        }
+
+        //Spawn in the stuff
+        for (var i = 0; i < component.SpawnAttempts; i++)
+        {
+            foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
+            {
+                Spawn(spawn, location);
+            }
+        }
+
+        // Spawn a special spawn (guaranteed spawn)
+        var specialEntry = RobustRandom.Pick(component.SpecialEntries);
+        Spawn(specialEntry.PrototypeId, location);
+
+        // Extra chance to spawn additional entities
+        if (component.SpecialEntries.Count != 0)
+        {
+            foreach (var specialSpawn in EntitySpawnCollection.GetSpawns(component.SpecialEntries, RobustRandom))
+            {
+                Spawn(specialSpawn, location);
+            }
+        }
+    }
+
+    private EntityCoordinates? ChooseLocation()
+    {
+        // Get a station
+        if (!TryGetRandomStation(out var station))
+        {
+            return null;
+        }
+        //Query the possible locations
+        var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
+        var validLocations = new List<EntityCoordinates>();
+        // Filter to things on the same station
+        while (locations.MoveNext(out _, out _, out var transform))
+        {
+            if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station)
+            {
+                validLocations.Add(transform.Coordinates);
+            }
+        }
+        // Pick one at random
+        if (validLocations.Count != 0)
+            return _random.Pick(validLocations);
+        return null;
+    }
+}

--- a/Content.Server/_Moffstation/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/_Moffstation/StationEvents/Events/VentCrittersRule.cs
@@ -10,9 +10,6 @@ using Robust.Shared.Random;
 
 namespace Content.Server._Moffstation.StationEvents.Events;
 
-/// <remarks>
-/// Moffstation - File has been completely rewritten, do not accept upstream changes
-/// </remarks>
 public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleComponent>
 {
     /*

--- a/Content.Server/_Moffstation/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/_Moffstation/StationEvents/Events/VentCrittersRule.cs
@@ -1,3 +1,4 @@
+using Content.Server._Moffstation.StationEvents.Components;
 using Content.Server.Pinpointer;
 using Content.Server.StationEvents.Components;
 using Content.Server.StationEvents.Events;

--- a/Content.Server/_Moffstation/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/_Moffstation/StationEvents/Events/VentCrittersRule.cs
@@ -26,7 +26,6 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
 
     protected override void Added(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
     {
-        base.Added(uid, component, gameRule, args);
 
         // Choose location and make sure it's not null
         component.Location = ChooseLocation();
@@ -53,6 +52,8 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
                     ("location", nearestBeacon),
                     ("time", duration));
         }
+
+        base.Added(uid, component, gameRule, args);
     }
 
     protected override void Ended(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)

--- a/Resources/Locale/en-US/_Moffstation/station-events/vent-critters.ftl
+++ b/Resources/Locale/en-US/_Moffstation/station-events/vent-critters.ftl
@@ -1,0 +1,2 @@
+station-event-vent-creatures-start-announcement-no-time-no-location =  Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
+station-event-vent-creatures-start-announcement-no-time = Attention. A large influx of unknown life forms have been detected moving within the station's ventilation systems. They are expected to emerge near {$location}. Please evacuate the area to avoid loss of personnel.

--- a/Resources/Locale/en-US/station-events/events/vent-critters.ftl
+++ b/Resources/Locale/en-US/station-events/events/vent-critters.ftl
@@ -1,1 +1,3 @@
-﻿station-event-vent-creatures-start-announcement = Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
+﻿#Moffstation - changing this to use our version with the time and date instead, other versions can be found in our namespace's file
+#station-event-vent-creatures-start-announcement = Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
+station-event-vent-creatures-start-announcement =  Attention. A large influx of unknown life forms have been detected moving through the station's ventilation systems. They are expected to emerge near {$location} in approximately {$time} seconds. Please evacuate the area to avoid loss of personnel.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -424,7 +424,7 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 15 # Moffstation - used as delay
+    duration: 30 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobAdultSlimesBlueAngry
@@ -445,7 +445,7 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 15 # Moffstation - used as delay
+    duration: 30 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobPurpleSnake
@@ -466,7 +466,7 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 15 # Moffstation - used as delay
+    duration: 30 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobGiantSpiderAngry
@@ -483,7 +483,7 @@
     earliestStart: 20
     minimumPlayers: 20
     weight: 1.5
-    duration: 15 # Moffstation - used as delay
+    duration: 30 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobClownSpider

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -424,7 +424,7 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 60
+    duration: 15 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobAdultSlimesBlueAngry
@@ -445,7 +445,7 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 60
+    duration: 15 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobPurpleSnake
@@ -466,7 +466,7 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 60
+    duration: 15 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobGiantSpiderAngry
@@ -483,7 +483,7 @@
     earliestStart: 20
     minimumPlayers: 20
     weight: 1.5
-    duration: 60
+    duration: 15 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobClownSpider

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -28,7 +28,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 15 # Moffstation - used as delay
+    duration: 30 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobMouse
@@ -51,7 +51,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 15 # Moffstation - used as delay
+    duration: 30 # Moffstation - used as delay
     minimumPlayers: 30 # Hopefully this is enough for the Rat King's potential Army (it was not, raised from 15 -> 30)
   - type: VentCrittersRule
     entries:
@@ -76,7 +76,7 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 6
-    duration: 15 # Moffstation - used as delay
+    duration: 30 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobCockroach
@@ -93,7 +93,7 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 6
-    duration: 15 # Moffstation - used as delay
+    duration: 30 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobSnail
@@ -113,7 +113,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 15 # Moffstation - used as delay
+    duration: 30 # Moffstation - used as delay
     minimumPlayers: 30
   - type: VentCrittersRule
     entries:
@@ -136,7 +136,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 15 # Moffstation - used as delay
+    duration: 30 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobMothroach

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -28,7 +28,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 50
+    duration: 15 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobMouse
@@ -51,7 +51,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 50
+    duration: 15 # Moffstation - used as delay
     minimumPlayers: 30 # Hopefully this is enough for the Rat King's potential Army (it was not, raised from 15 -> 30)
   - type: VentCrittersRule
     entries:
@@ -76,7 +76,7 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 6
-    duration: 50
+    duration: 15 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobCockroach
@@ -93,7 +93,7 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 6
-    duration: 50
+    duration: 15 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobSnail
@@ -113,7 +113,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 50
+    duration: 15 # Moffstation - used as delay
     minimumPlayers: 30
   - type: VentCrittersRule
     entries:
@@ -124,7 +124,7 @@
     - id: MobSnailMoth
       prob: 0.002
     - id: MobSnailInstantDeath
-      prob: 0.00001 #  ~ 1:2000 snails
+      prob: 0.00005 #  ~ 1:2000 snails  # Moffstation - change it to make it actually around 1 in 2000
 
 - type: entity
   id: MothroachMigration
@@ -136,7 +136,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 50
+    duration: 15 # Moffstation - used as delay
   - type: VentCrittersRule
     entries:
     - id: MobMothroach


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Inspired by Delta-V's feature of having all creatures spawn at a single vent, this PR adds our own implementation of it. All vent creatures will now spawn at one vent instead of several spread throughout the station.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This fixes several issues with vent creatures. The station is warned in advance with the time and location, which helps security prepare a proper response and prevents the crew from being killed without warning.
## Technical details
<!-- Summary of code changes for easier review. -->
- `VentCrittersRule.cs` has been completely rewritten
- Added `Location` to the `VentCrittersRuleComponent`, this stores their spawn location.
- Added `SpawnChances` to `VentCrittersRuleComponent`. Normally the `prob` of each vent critter for the event is run against every valid vent on the station, allowing for several spawns of the same mob across the station. This is essentially a replacement for that - the prob is run against the same vent this many times. This is the main way of tuning the difficulty of the event. I found 100 to be a good default value, the average amount of mobs which will spawn is easily calculable from this point and for most spawns it's fairly balanced.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
mfw my video is 10.1mb

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed vent critters to spawn in one big horde, rather than seperately.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
