### PR TITLE
Revert "added ability to pick cat ears and cat tail as human"

### DIFF
--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -40,7 +40,7 @@
   id: MobHumanMarkingLimits
   points:
     Special: # the cat ear joke
-      points: 1 # Moffstation - Human Cat Ears
+      points: 0
       required: false
     Hair:
       points: 1
@@ -52,7 +52,7 @@
       points: 1
       required: false
     Tail: # the cat tail joke
-      points: 1 # Moffstation - Human Cat Ears
+      points: 0
       required: false
     HeadTop:
       points: 1


### PR DESCRIPTION
Reverts moff-station/moff-station-14#211
Merged before the vote ended and I had bigger plans.

## Why
Generally I don't like cat ears/tails for base humans. It's a pretty generic meme addition and doesn't really lead to any super interesting roleplay or better character story other than "haha look at me im a catgirl meow meow".

I'd much rather look forward to a port of Tajarans or Felinids, which have character design and character customization available to them, which is much better in terms of player customizability compared to just giving humans and tails cat ears.

If people like the change then I'll keep it until Tajarans or Felinids are merged. Then they can be reverted.