### PR TITLE
Fix bonux CMO backpack loadouts

### DIFF
--- a/Resources/Prototypes/_Moffstation/Loadouts/Non-Antags/clothing-medical.yml
+++ b/Resources/Prototypes/_Moffstation/Loadouts/Non-Antags/clothing-medical.yml
@@ -1,42 +1,34 @@
-
-
 # Virology bags
 - type: loadout
   id: VirologyBackpack
-  storage:
-    back:
-    - ClothingBackpackVirology
+  equipment:
+    back: ClothingBackpackVirology
 
 - type: loadout
   id: VirologySatchel
-  storage:
-    back:
-    - ClothingBackpackSatchelVirology
+  equipment:
+    back: ClothingBackpackSatchelVirology
 
 - type: loadout
   id: VirologyDuffel
-  storage:
-    back:
-    - ClothingBackpackDuffelVirology
+  equipment:
+    back: ClothingBackpackDuffelVirology
 
 # Genetic Bags
 - type: loadout
   id: GeneticsBackpack
-  storage:
-    back:
-    - ClothingBackpackGenetics
+  equipment:
+    back: ClothingBackpackGenetics
 
 - type: loadout
   id: GeneticsSatchel
-  storage:
-    back:
-    - ClothingBackpackSatchelGenetics
+  equipment:
+    back: ClothingBackpackSatchelGenetics
 
 - type: loadout
   id: GeneticsDuffel
-  storage:
-    back:
-    - ClothingBackpackDuffelGenetics
+  equipment:
+    back: ClothingBackpackDuffelGenetics
 
 # Nurse jumpskirt
 - type: loadout


### PR DESCRIPTION
Fix syntax for CMO extra backpack loadouts so that it puts the backpacks on your back rather than trying to put them into the preexisting backpack.

I tried to do a whole-repo search on similar issues, but didn't find any, so maybe this is it.

[Related Discord bug report](https://discord.com/channels/1322447119252062260/1380974717191590039).

:cl:
- fix: All CMO backpack options spawn properly now.