### PR TITLE
Exclude Pirate shuttles from being returned by StationSystem.GetStationInMap

### DIFF
--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Chat.Systems;
 using Content.Server.GameTicking;
 using Content.Server.Station.Components;
 using Content.Server.Station.Events;
+using Content.Shared._Moffstation.Pirate.Components; // Moffstation
 using Content.Shared.CCVar;
 using Content.Shared.Station;
 using Content.Shared.Station.Components;
@@ -500,6 +501,11 @@ public sealed partial class StationSystem : SharedStationSystem
         var query = EntityQueryEnumerator<StationDataComponent>();
         while (query.MoveNext(out var uid, out _))
         {
+            // Moffstation - Start - Pirate stations aren't _really_ stations, so don't return them here.
+            if (HasComp<PirateStationComponent>(uid))
+                continue;
+            // Moffstation - End
+
             stations.Add(uid);
         }
 
@@ -512,6 +518,11 @@ public sealed partial class StationSystem : SharedStationSystem
         var query = EntityQueryEnumerator<StationDataComponent>();
         while (query.MoveNext(out var uid, out _))
         {
+            // Moffstation - Start - Pirate stations aren't _really_ stations, so don't return them here.
+            if (HasComp<PirateStationComponent>(uid))
+                continue;
+            // Moffstation - End
+
             stations.Add(uid);
         }
 
@@ -543,6 +554,11 @@ public sealed partial class StationSystem : SharedStationSystem
         var query = EntityQueryEnumerator<StationDataComponent>();
         while (query.MoveNext(out var uid, out var data))
         {
+            // Moffstation - Start - Pirate stations aren't _really_ stations, so don't return them here.
+            if (HasComp<PirateStationComponent>(uid))
+                continue;
+            // Moffstation - End
+
             foreach (var gridUid in data.Grids)
             {
                 if (Transform(gridUid).MapID == map)

--- a/Content.Server/_Moffstation/GameTicking/Rules/Components/PiratesRuleComponent.cs
+++ b/Content.Server/_Moffstation/GameTicking/Rules/Components/PiratesRuleComponent.cs
@@ -1,4 +1,3 @@
-using Content.Server.GameTicking.Rules;
 using Content.Server.Station;
 using Robust.Shared.Prototypes;
 

--- a/Content.Shared/_Moffstation/Pirate/Components/PirateShuttleComponent.cs
+++ b/Content.Shared/_Moffstation/Pirate/Components/PirateShuttleComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameStates;
+﻿using JetBrains.Annotations;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._Moffstation.Pirate.Components;
 
@@ -13,3 +14,9 @@ public sealed partial class PirateShuttleComponent : Component
     [AutoNetworkedField]
     public EntityUid AssociatedRule;
 }
+
+/// <summary>
+/// Tags an entity as a pirate station, which may be made of many grids.
+/// </summary>
+[RegisterComponent, NetworkedComponent, UsedImplicitly]
+public sealed partial class PirateStationComponent : Component;

--- a/Resources/Prototypes/_Moffstation/Entities/Stations/pirate.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Stations/pirate.yml
@@ -30,4 +30,5 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: Transform
+    - type: PirateStation
 


### PR DESCRIPTION
... and similar functions within which enumerate over all stations.

<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Just had a round where station-bound anomaly generator dropped an electric anomaly on the pirate's ship, which wasn't very fun for them.

## Technical details
<!-- Summary of code changes for easier review. -->
- add `PirateStation` marker component
- add said component to pirate station component registry thingy used when spawning pirates
  - (ie. this doesn't affect the shuttle inherently, it only affects it when is used with the rule)
- Modify usages of `EntityQueryEnumerator<[^>]*StationDataComponent[^>]*>` to `continue` if the entity has this component

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Anomaly generators will no longer generate anomalies on pirate shuttles unless the anomaly generator is, itself, on the shuttle.
