### PR TITLE
Increase Big Iron damage and switch its default fill to disabler rounds

### DIFF
--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -18,7 +18,7 @@
       tags:
       - CartridgeBigIron
       - SpeedLoaderBigIron
-    proto: CartridgeBigIronLethal
+    proto: CartridgeBigIronDisabler
     capacity: 6
     chambers: [ True, True, True, True, True, True ]
     ammoSlots: [ null, null, null, null, null, null ]

--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Weapons/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Weapons/Projectiles/projectiles.yml
@@ -5,7 +5,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: StaminaDamageOnCollide
-    damage: 35
+    damage: 40
   - type: Projectile
     damage:
       types:
@@ -21,4 +21,4 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 20
+        Heat: 35


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
Increases the Big Iron's disabler damage from 35 to 40 to match stun batons, and increases its lethal rounds from 20 heat to 35 heat to match .45 magnum's damage.  Alongside this the Big Iron will spawn loaded with disabler rounds instead of lethal rounds.

## Why / Balance
The lethal round was severely underperforming compared to other energy weapons and revolvers in general.  The initial ammo loaded is mostly for QoL.

## Technical details
changed the damage numbers on the Big Iron projectiles
changed the ammo prototype on the Big Iron itself

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: The Big Iron now does 35 heat on its lethal rounds and starts loaded with nonlethals
-->
