### PR TITLE
Add guards so that map vote rollovers can't throw

### DIFF
--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -34,7 +34,7 @@ public sealed class GameMapManager : IGameMapManager
 
     private ISawmill _log = default!;
 
-    private Dictionary<GameMapPrototype, int> _rollOverVotes = new();   // Moffstation - Rollover votes stored here
+    private readonly Dictionary<GameMapPrototype, int> _rollOverVotes = new();   // Moffstation - Rollover votes stored here
 
     public void Initialize()
     {
@@ -249,11 +249,14 @@ public sealed class GameMapManager : IGameMapManager
     // Moffstation - Start - setters and getters for the rollover votes
     public int GetRollOverVotes(GameMapPrototype map)
     {
-        return _rollOverVotes[map];
+        Debug.Assert(_rollOverVotes.ContainsKey(map),
+            $"Attempted to get rollover votes for unknown map \"{map.MapName}\"");
+        return _rollOverVotes.GetValueOrDefault(map);
     }
 
     public void SetRollOverVotes(GameMapPrototype map, int votes)
     {
+        Debug.Assert(_rollOverVotes.ContainsKey(map), $"Attempted to set rollover votes for unknown map \"{map.MapName}\"");
         _rollOverVotes[map] = votes;
     }
     // Moffstation - End

--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -249,8 +249,7 @@ public sealed class GameMapManager : IGameMapManager
     // Moffstation - Start - setters and getters for the rollover votes
     public int GetRollOverVotes(GameMapPrototype map)
     {
-        Debug.Assert(_rollOverVotes.ContainsKey(map),
-            $"Attempted to get rollover votes for unknown map \"{map.MapName}\"");
+        Debug.Assert(_rollOverVotes.ContainsKey(map), $"Attempted to get rollover votes for unknown map \"{map.MapName}\"");
         return _rollOverVotes.GetValueOrDefault(map);
     }
 


### PR DESCRIPTION
I was seeing some jank in tests on #284 and adding this made the jank stop.
It seems like maybe this is an interaction between removing Tram/Waterjug and the rollover votes. I can't figure out how it would be possible that removed maps' votes could show up in the dictionary (since they're not persisted in the DB across invocations of the server running, right?), but still this is a nice safeguard.