### PR TITLE
Split Quick- and Area-Pickup into their own Components

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1,6 +1,8 @@
 using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Shared._Moffstation.Storage; // Moffstation
+using Content.Shared._Moffstation.Storage.EntitySystems; // Moffstation
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CCVar;
@@ -72,6 +74,10 @@ public abstract class SharedStorageSystem : EntitySystem
     [Dependency] protected readonly SharedUserInterfaceSystem UI = default!;
     [Dependency] private   readonly TagSystem _tag = default!;
     [Dependency] protected readonly UseDelaySystem UseDelay = default!;
+    // Moffstation - Start
+    [Dependency] private   readonly AreaPickupSystem _areaPickup = default!;
+    [Dependency] private   readonly QuickPickupSystem _quickPickup = default!;
+    // Moffstation - End
 
     private EntityQuery<ItemComponent> _itemQuery;
     private EntityQuery<StackComponent> _stackQuery;
@@ -147,7 +153,7 @@ public abstract class SharedStorageSystem : EntitySystem
         SubscribeLocalEvent<StorageComponent, InteractUsingEvent>(OnInteractUsing, after: new[] { typeof(ItemSlotsSystem) });
         SubscribeLocalEvent<StorageComponent, ActivateInWorldEvent>(OnActivate);
         SubscribeLocalEvent<StorageComponent, OpenStorageImplantEvent>(OnImplantActivate);
-        SubscribeLocalEvent<StorageComponent, AfterInteractEvent>(AfterInteract);
+        // SubscribeLocalEvent<StorageComponent, AfterInteractEvent>(AfterInteract); // Moffstation
         SubscribeLocalEvent<StorageComponent, DestructionEventArgs>(OnDestroy);
         SubscribeLocalEvent<StorageComponent, BoundUserInterfaceMessageAttempt>(OnBoundUIAttempt);
         SubscribeLocalEvent<StorageComponent, BoundUIOpenedEvent>(OnBoundUIOpen);
@@ -155,8 +161,13 @@ public abstract class SharedStorageSystem : EntitySystem
         SubscribeLocalEvent<StorageComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
         SubscribeLocalEvent<StorageComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
         SubscribeLocalEvent<StorageComponent, ContainerIsInsertingAttemptEvent>(OnInsertAttempt);
-        SubscribeLocalEvent<StorageComponent, AreaPickupDoAfterEvent>(OnDoAfter);
+        // SubscribeLocalEvent<StorageComponent, AreaPickupDoAfterEvent>(OnDoAfter); // Moffstation
         SubscribeLocalEvent<StorageComponent, GotReclaimedEvent>(OnReclaimed);
+        // Moffstation - Start
+        SubscribeLocalEvent<StorageComponent, QuickPickupEvent>(OnQuickPickup);
+        SubscribeLocalEvent<StorageComponent, BeforeAreaPickupEvent>(OnBeforeAreaPickup);
+        SubscribeLocalEvent<StorageComponent, AreaPickupDoAfterEvent>(OnAreaPickupDoAfter);
+        // Moffstation - Start
 
         SubscribeLocalEvent<MetaDataComponent, StackCountChangedEvent>(OnStackCountChanged);
 
@@ -213,7 +224,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
     private void OnMapInit(Entity<StorageComponent> entity, ref MapInitEvent args)
     {
-        UseDelay.SetLength(entity.Owner, entity.Comp.QuickInsertCooldown, QuickInsertUseDelayID);
+        // UseDelay.SetLength(entity.Owner, entity.Comp.QuickInsertCooldown, QuickInsertUseDelayID);
         UseDelay.SetLength(entity.Owner, entity.Comp.OpenUiCooldown, OpenUiUseDelayID);
     }
 
@@ -512,6 +523,7 @@ public abstract class SharedStorageSystem : EntitySystem
         args.Handled = true;
     }
 
+    /* Moffstation - Start - Quick and Area pickup behavior moved to independent components.
     /// <summary>
     /// Allows a user to pick up entities by clicking them, or pick up all entities in a certain radius
     /// around a click.
@@ -664,6 +676,60 @@ public abstract class SharedStorageSystem : EntitySystem
 
         args.Handled = true;
     }
+    */
+
+    private void OnQuickPickup(Entity<StorageComponent> entity, ref QuickPickupEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        // Copy event fields because the lambda doesn't like capturing `ref` values.
+        var user = args.User;
+        var pickedUp = args.PickedUp;
+        args.Handled = _quickPickup.TryDoQuickPickup(
+            args,
+            () => PlayerInsertEntityInWorld(entity.AsNullable(), user, pickedUp)
+        );
+    }
+
+    private void OnBeforeAreaPickup(Entity<StorageComponent> entity, ref BeforeAreaPickupEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        args.Handled = _areaPickup.DoBeforeAreaPickup(
+            ref args,
+            insertedEntity => CanInsert(entity, insertedEntity, out _, entity, insertedEntity)
+        );
+    }
+
+    private void OnAreaPickupDoAfter(Entity<StorageComponent> entity, ref AreaPickupDoAfterEvent args)
+    {
+        if (args.Handled ||
+            args.Cancelled)
+            return;
+
+        // Copy event fields because the lambda doesn't like capturing `ref` values.
+        var user = args.User;
+
+        // Don't play the insertion sound if the user has the silent tag.
+        var insertionSound = _prototype.TryIndex(entity.Comp.SilentStorageUserTag, out var silentTag) && _tag.HasTag(args.User, silentTag)
+            ? null
+            : entity.Comp.StorageInsertSound;
+
+        args.Handled = _areaPickup.TryDoAreaPickup(
+            ref args,
+            entity.Owner,
+            insertionSound,
+            entityToPickUp => PlayerInsertEntityInWorld(
+                entity.AsNullable(),
+                user,
+                entityToPickUp,
+                playSound: false
+            )
+        );
+    }
+    // Moffsation - End
 
     private void OnReclaimed(EntityUid uid, StorageComponent storageComp, GotReclaimedEvent args)
     {

--- a/Content.Shared/Storage/StorageComponent.cs
+++ b/Content.Shared/Storage/StorageComponent.cs
@@ -57,6 +57,7 @@ namespace Content.Shared.Storage
         [Access(typeof(SharedStorageSystem))]
         public ProtoId<ItemSizePrototype>? MaxItemSize;
 
+        /* Moffstation - Start - Move Quick and Area Insert to indepdent components
         // TODO: Make area insert its own component.
         [DataField]
         public bool QuickInsert; // Can insert storables by clicking them with the storage entity
@@ -66,6 +67,7 @@ namespace Content.Shared.Storage
         /// </summary>
         /// <remarks>Used to prevent autoclickers spamming server with individual pickup actions.</remarks>
         public TimeSpan QuickInsertCooldown = TimeSpan.FromSeconds(0.5);
+         */// Moffstation - End
 
         /// <summary>
         /// Minimum delay between UI open actions.
@@ -87,6 +89,7 @@ namespace Content.Shared.Storage
         [DataField]
         public bool OpenOnActivate = true;
 
+        /* Moffstation - Start - Move Quick and Area Insert to indepdent components
         /// <summary>
         /// How many entities area pickup can pickup at once.
         /// </summary>
@@ -97,6 +100,7 @@ namespace Content.Shared.Storage
 
         [DataField]
         public int AreaInsertRadius = 1;
+        */// Moffstation - End
 
         /// <summary>
         /// Whitelist for entities that can go into the storage.

--- a/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Tag; // Moffstation
 using Content.Shared.Weapons.Ranged.Systems;
 using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
@@ -57,4 +58,12 @@ public sealed partial class BallisticAmmoProviderComponent : Component
     /// </summary>
     [DataField]
     public TimeSpan FillDelay = TimeSpan.FromSeconds(0.5);
+
+    // Moffstation - Start
+    /// <summary>
+    /// Entities with this tag won't trigger the insertion sound.
+    /// </summary>
+    [DataField]
+    public ProtoId<TagPrototype> SilentInsertUserTag = "SilentStorageUser";
+    // Moffstation - End
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -1,12 +1,17 @@
+using Content.Shared._Moffstation.Storage; // Moffstation
+using Content.Shared._Moffstation.Storage.EntitySystems; // Moffstation
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Storage; // Moffstation
+using Content.Shared.Tag; // Moffstation
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Prototypes; // Moffstation
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Weapons.Ranged.Systems;
@@ -15,6 +20,12 @@ public abstract partial class SharedGunSystem
 {
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    // Moffstation - Start
+    [Dependency] private readonly AreaPickupSystem _areaPickup = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly QuickPickupSystem _quickPickup = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
+    // Moffstation - End
 
 
     protected virtual void InitializeBallistic()
@@ -30,6 +41,11 @@ public abstract partial class SharedGunSystem
         SubscribeLocalEvent<BallisticAmmoProviderComponent, AfterInteractEvent>(OnBallisticAfterInteract);
         SubscribeLocalEvent<BallisticAmmoProviderComponent, AmmoFillDoAfterEvent>(OnBallisticAmmoFillDoAfter);
         SubscribeLocalEvent<BallisticAmmoProviderComponent, UseInHandEvent>(OnBallisticUse);
+        // Moffstation - Start
+        SubscribeLocalEvent<BallisticAmmoProviderComponent, QuickPickupEvent>(OnQuickPickup);
+        SubscribeLocalEvent<BallisticAmmoProviderComponent, BeforeAreaPickupEvent>(OnBeforeAreaPickup);
+        SubscribeLocalEvent<BallisticAmmoProviderComponent, AreaPickupDoAfterEvent>(OnAreaPickupDoAfter);
+        // Moffstation - End
     }
 
     private void OnBallisticUse(EntityUid uid, BallisticAmmoProviderComponent component, UseInHandEvent args)
@@ -46,6 +62,7 @@ public abstract partial class SharedGunSystem
         if (args.Handled)
             return;
 
+        /* Moffstation - Start - Extract "Try Insert" logic into a function
         if (_whitelistSystem.IsWhitelistFailOrNull(component.Whitelist, args.Used))
             return;
 
@@ -59,6 +76,10 @@ public abstract partial class SharedGunSystem
         args.Handled = true;
         UpdateBallisticAppearance(uid, component);
         DirtyField(uid, component, nameof(BallisticAmmoProviderComponent.Entities));
+        */
+        if (TryBallisticInsert((uid, component), args.Used, args.User))
+            args.Handled = true;
+        // Moffstation - End
     }
 
     private void OnBallisticAfterInteract(EntityUid uid, BallisticAmmoProviderComponent component, AfterInteractEvent args)
@@ -144,8 +165,13 @@ public abstract partial class SharedGunSystem
             }
             else
             {
-                // play sound to be cool
-                Audio.PlayPredicted(component.SoundInsert, uid, args.User);
+                // Moffstation - Start - Add silent insert user tag
+                if (!TagSystem.HasTag(args.User, component.SilentInsertUserTag))
+                {
+                    // play sound to be cool
+                    Audio.PlayPredicted(component.SoundInsert, uid, args.User);
+                }
+                // Moffstation - End
                 SimulateInsertAmmo(ent.Value, args.Target.Value, Transform(args.Target.Value).Coordinates);
             }
 
@@ -269,6 +295,100 @@ public abstract partial class SharedGunSystem
         args.Count = GetBallisticShots(component);
         args.Capacity = component.Capacity;
     }
+
+    // Moffstation - Start
+    private void OnQuickPickup(Entity<BallisticAmmoProviderComponent> entity, ref QuickPickupEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        // Copy event fields because the lambda doesn't like capturing `ref` values.
+        var user = args.User;
+        var pickedUp = args.PickedUp;
+        args.Handled = _quickPickup.TryDoQuickPickup(args, () => TryBallisticInsert(entity, pickedUp, user));
+    }
+
+    private void OnBeforeAreaPickup(Entity<BallisticAmmoProviderComponent> entity, ref BeforeAreaPickupEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        args.Handled = _areaPickup.DoBeforeAreaPickup(
+            ref args,
+            pickupCandidate => CanInsertBallistic(entity, pickupCandidate)
+        );
+    }
+
+    private void OnAreaPickupDoAfter(Entity<BallisticAmmoProviderComponent> entity, ref AreaPickupDoAfterEvent args)
+    {
+        if (args.Handled ||
+            args.Cancelled)
+            return;
+
+        // Copy event fields because the lambda doesn't like capturing `ref` values.
+        var user = args.User;
+
+        // Don't play a sound if the user has the silent user tag.
+        var insertSound = _prototype.TryIndex(entity.Comp.SilentInsertUserTag, out var tag) &&
+                          _tag.HasTag(args.User, tag)
+            ? null
+            : entity.Comp.SoundInsert;
+        args.Handled = _areaPickup.TryDoAreaPickup(
+            ref args,
+            entity.Owner,
+            insertSound,
+            entityToInsert => TryBallisticInsert(entity, entityToInsert, user, suppressInsertionSound: true)
+        );
+    }
+    // Moffstation - End
+
+    // Moffstation - Start - New Ballistic API functions
+    /// <summary>
+    /// Returns true if the given <paramref name="entity"/>'s ballistic ammunition is full, false otherwise.
+    /// </summary>
+    public bool IsFullBallistic(Entity<BallisticAmmoProviderComponent> entity)
+    {
+        return GetBallisticShots(entity.Comp) >= entity.Comp.Capacity;
+    }
+
+    /// <summary>
+    /// Returns whether or not <paramref name="inserted"/> can be inserted into <paramref name="entity"/>, based on
+    /// available space and whitelists.
+    /// </summary>
+    public bool CanInsertBallistic(Entity<BallisticAmmoProviderComponent> entity, EntityUid inserted)
+    {
+        return !_whitelistSystem.IsWhitelistFailOrNull(entity.Comp.Whitelist, inserted) &&
+               !IsFullBallistic(entity);
+    }
+
+    /// <summary>
+    /// Attempts to insert <paramref name="inserted"/> into <paramref name="entity"/> as ammunition. Returns true on
+    /// success, false otherwise.
+    /// </summary>
+    public bool TryBallisticInsert(
+        Entity<BallisticAmmoProviderComponent> entity,
+        EntityUid inserted,
+        EntityUid? user,
+        bool suppressInsertionSound = false
+    )
+    {
+        if (!CanInsertBallistic(entity, inserted))
+            return false;
+
+        entity.Comp.Entities.Add(inserted);
+        Containers.Insert(inserted, entity.Comp.Container);
+        if (!suppressInsertionSound &&
+            !(user is { } u && TagSystem.HasTag(u, entity.Comp.SilentInsertUserTag)))
+        {
+            Audio.PlayPredicted(entity.Comp.SoundInsert, entity, user);
+        }
+
+        UpdateBallisticAppearance(entity, entity.Comp);
+        DirtyField(entity.AsNullable(), nameof(BallisticAmmoProviderComponent.Entities));
+
+        return true;
+    }
+    // Moffstation - End
 
     public void UpdateBallisticAppearance(EntityUid uid, BallisticAmmoProviderComponent component)
     {

--- a/Content.Shared/_Moffstation/Storage/AreaPickupComponent.cs
+++ b/Content.Shared/_Moffstation/Storage/AreaPickupComponent.cs
@@ -1,0 +1,38 @@
+﻿using Content.Shared.Item;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Moffstation.Storage;
+
+/// <summary>
+/// This component enables "area pickup" behavior, which means while holding a storage-like item, clicking in the world
+/// will attempt to pick up items near the clicked location with a do-after delay.
+/// </summary>
+/// <seealso cref="AreaPickupSystem"/>
+/// <seealso cref="QuickPickupComponent"/>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AreaPickupComponent : Component
+{
+    /// <summary>
+    /// Minimum delay between quick/area insert actions.
+    /// </summary>
+    /// <remarks>Used to prevent autoclickers spamming server with individual pickup actions.</remarks>
+    [DataField]
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(0.5);
+
+    /// <summary>
+    /// The pickup radius, in tiles.
+    /// </summary>
+    [DataField]
+    public int Radius = 1;
+
+    /// <summary>
+    /// How many entities area pickup can pickup at once.
+    /// </summary>
+    public const int MaximumPickupLimit = 10;
+
+    /// <summary>
+    /// How long the do-after should be per <see cref="ItemSizePrototype.Weight">unit of weight</see> of all of the
+    /// items picked up.
+    /// </summary>
+    public static readonly TimeSpan DelayPerItemWeight = TimeSpan.FromSeconds(0.075);
+}

--- a/Content.Shared/_Moffstation/Storage/BeforeAreaPickupEvent.cs
+++ b/Content.Shared/_Moffstation/Storage/BeforeAreaPickupEvent.cs
@@ -1,0 +1,24 @@
+﻿using Content.Shared._Moffstation.Storage.EntitySystems;
+using Content.Shared.Item;
+using Content.Shared.Storage;
+
+namespace Content.Shared._Moffstation.Storage;
+
+/// <summary>
+/// This event is raised on an entity with <see cref="AreaPickupComponent"/> to allow storage-like systems to inform
+/// the area pickup logic which entities can actually be picked up by the entity. A storage-like system which wants to
+/// implement area pickup into its storage MUST also handle <see cref="AreaPickupDoAfterEvent"/> and SHOULD use
+/// <see cref="AreaPickupSystem.DoBeforeAreaPickup"/> to handle this event.
+/// </summary>
+/// <seealso cref="AreaPickupDoAfterEvent"/>
+/// <seealso cref="AreaPickupSystem"/>
+/// <seealso cref="AreaPickupSystem.DoBeforeAreaPickup"/>
+public sealed partial class BeforeAreaPickupEvent(
+    IReadOnlyList<Entity<ItemComponent>> pickupCandidates,
+    int maxPickups
+) : HandledEntityEventArgs
+{
+    public readonly IReadOnlyList<Entity<ItemComponent>> PickupCandidates = pickupCandidates;
+    public readonly List<Entity<ItemComponent>> EntitiesToPickUp = [];
+    public readonly int MaxPickups = maxPickups;
+}

--- a/Content.Shared/_Moffstation/Storage/EntitySystems/AreaPickupSystem.cs
+++ b/Content.Shared/_Moffstation/Storage/EntitySystems/AreaPickupSystem.cs
@@ -1,0 +1,235 @@
+﻿using System.Linq;
+using Content.Shared.DoAfter;
+using Content.Shared.Interaction;
+using Content.Shared.Item;
+using Content.Shared.Projectiles;
+using Content.Shared.Storage;
+using Content.Shared.Timing;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._Moffstation.Storage.EntitySystems;
+
+/// <summary>
+/// This system implements <see cref="AreaPickupComponent"/>'s behavior.
+/// </summary>
+public sealed partial class AreaPickupSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly SharedProjectileSystem _projectile = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly UseDelaySystem _useDelay = default!;
+
+
+    private EntityQuery<ItemComponent> _itemQuery;
+    private EntityQuery<TransformComponent> _xformQuery;
+
+    private const string DelayId = "areaPickup";
+
+    private static readonly AudioParams AudioParams = AudioParams.Default
+        .WithMaxDistance(7f)
+        .WithVolume(-2f);
+
+    public override void Initialize()
+    {
+        _itemQuery = GetEntityQuery<ItemComponent>();
+        _xformQuery = GetEntityQuery<TransformComponent>();
+
+        SubscribeLocalEvent<AreaPickupComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<AreaPickupComponent, AfterInteractEvent>(AfterInteract);
+    }
+
+    private void OnMapInit(Entity<AreaPickupComponent> entity, ref MapInitEvent args)
+    {
+        _useDelay.SetLength(entity.Owner, entity.Comp.Cooldown, DelayId);
+    }
+
+    private readonly List<EntityUid> _entitiesToPickUp = [];
+    private readonly HashSet<EntityUid> _entitiesInRange = [];
+
+    private void AfterInteract(Entity<AreaPickupComponent> entity, ref AfterInteractEvent args)
+    {
+        if (args.Handled ||
+            !args.CanReach ||
+            !_useDelay.TryResetDelay(entity, checkDelayed: true, id: DelayId))
+            return;
+
+        // Find entities near where the interaction click was.
+        _entitiesToPickUp.Clear();
+        _entitiesInRange.Clear();
+        _entityLookup.GetEntitiesInRange(
+            args.ClickLocation,
+            entity.Comp.Radius,
+            _entitiesInRange,
+            LookupFlags.Dynamic | LookupFlags.Sundries
+        );
+
+        // Filter out anything that definitely can't be picked up.
+        var pickupCandidates = new List<Entity<ItemComponent>>();
+        foreach (var entityInRange in _entitiesInRange)
+        {
+            if (entityInRange == args.User ||
+                !_itemQuery.TryGetComponent(entityInRange, out var itemComp) ||
+                !_prototype.TryIndex(itemComp.Size, out var itemSize) ||
+                !_interaction.InRangeUnobstructed(args.User, entityInRange))
+                continue;
+            pickupCandidates.Add((entityInRange, itemComp));
+        }
+
+        // No candidates to pick up.
+        if (pickupCandidates.Count == 0)
+            return;
+
+        // Ask other systems to tell us what to pick up.
+        var ev = new BeforeAreaPickupEvent(pickupCandidates, AreaPickupComponent.MaximumPickupLimit);
+        RaiseLocalEvent(entity, ev);
+        if (ev.EntitiesToPickUp.Count == 0)
+        {
+            // No systems told us to pick anything up.
+            DebugTools.Assert(!ev.Handled, "Zero entities to pickup means this event should not be handled.");
+            return;
+        }
+
+        DebugTools.Assert(ev.Handled, "Non-zero entities to pickup means this event should be handled.");
+
+        // Calculate do after delay based on combined weight of all items to pick up.
+        var delay = TimeSpan.Zero;
+        foreach (var entityToPickUp in ev.EntitiesToPickUp)
+        {
+            _entitiesToPickUp.Add(entityToPickUp);
+            var weight = _prototype.TryIndex(entityToPickUp.Comp.Size, out var itemSize) ? itemSize.Weight : 1;
+            delay += weight * AreaPickupComponent.DelayPerItemWeight;
+        }
+
+        var doAfterArgs = new DoAfterArgs(EntityManager,
+            args.User,
+            delay,
+            new AreaPickupDoAfterEvent(GetNetEntityList(_entitiesInRange)),
+            entity,
+            target: entity)
+        {
+            BreakOnDamage = true,
+            BreakOnMove = true,
+            NeedHand = true,
+        };
+        _doAfter.TryStartDoAfter(doAfterArgs);
+
+        args.Handled = true;
+    }
+
+    /// <summary>
+    /// This function helps with handling <see cref="BeforeAreaPickupEvent"/> by enforcing
+    /// <see cref="AreaPickupComponent.MaximumPickupLimit"/>. Callers need only pass in the event and
+    /// <paramref name="canPickup">a predicate indicating whether a given candidate can be picked up</paramref>. Returns
+    /// true if any items should be picked up and the event should be considered handled, false otherwise.
+    /// </summary>
+    public bool DoBeforeAreaPickup(ref BeforeAreaPickupEvent ev, Predicate<Entity<ItemComponent>> canPickup)
+    {
+        DebugTools.Assert(
+            ev.EntitiesToPickUp.Count == 0,
+            $"{nameof(BeforeAreaPickupEvent)} should not be raised with an empty {nameof(BeforeAreaPickupEvent.EntitiesToPickUp)}."
+        );
+
+        // Collect candidates which can be picked up, up to the maximum.
+        foreach (var entityInRange in ev.PickupCandidates)
+        {
+            if (!canPickup(entityInRange))
+                continue;
+
+            ev.EntitiesToPickUp.Add(entityInRange);
+
+            if (ev.EntitiesToPickUp.Count >= ev.MaxPickups)
+                break;
+        }
+
+        return ev.EntitiesToPickUp.Count > 0;
+    }
+
+    private readonly List<EntityUid> _pickedUp = [];
+    private readonly List<EntityCoordinates> _positions = [];
+    private readonly List<Angle> _angles = [];
+
+    /// <summary>
+    /// This function helps with handling <see cref="AreaPickupDoAfterEvent"/> by handling
+    /// <see cref="AnimateInsertingEntitiesEvent">animating picked up entities</see> and rechecking validity of picked
+    /// up entities while also invoking <paramref name="tryPickup"/>. Returns true if either <paramref name="args"/>
+    /// specifies to entities to pickup or if at least one entity was picked up and therefor the doafter should be
+    /// considered handled; returns false otherwise.
+    /// </summary>
+    public bool TryDoAreaPickup(
+        ref AreaPickupDoAfterEvent args,
+        Entity<AreaPickupComponent?> entity,
+        SoundSpecifier? pickupSound,
+        Func<EntityUid, bool> tryPickup
+    )
+    {
+        // Nothing to try to pick up, early return as handled.
+        if (args.Entities.Count == 0)
+            return true;
+
+        if (!_xformQuery.TryGetComponent(entity, out var pickupEntityXform))
+            return false;
+
+        _pickedUp.Clear();
+        _positions.Clear();
+        _angles.Clear();
+
+        // Collect position info for the items to pick up and try to actually pick them up.
+        var entCount = Math.Min(AreaPickupComponent.MaximumPickupLimit, args.Entities.Count);
+        foreach (var entityToPickUp in GetEntityList(args.Entities.ToList().GetRange(0, entCount)))
+        {
+            // Check again, situation may have changed for some entities, but we'll still pick up any that are valid
+            if (entityToPickUp == args.Args.User ||
+                _container.IsEntityInContainer(entityToPickUp) ||
+                !_itemQuery.HasComponent(entityToPickUp) ||
+                !_xformQuery.TryGetComponent(entityToPickUp, out var targetXform) ||
+                targetXform.MapID != pickupEntityXform.MapID)
+                continue;
+
+            if (TryComp<EmbeddableProjectileComponent>(entityToPickUp, out var embeddable))
+            {
+                _projectile.EmbedDetach(entityToPickUp, embeddable, args.User);
+            }
+
+            // Get the picked up entity's position _before_ inserting it, because that changes its position.
+            var position = _transform.ToCoordinates(
+                pickupEntityXform.ParentUid.IsValid() ? pickupEntityXform.ParentUid : entity.Owner,
+                _transform.GetMapCoordinates(targetXform)
+            );
+
+            // Actually insert the item.
+            if (!tryPickup(entityToPickUp))
+                continue;
+
+            _pickedUp.Add(entityToPickUp);
+            _positions.Add(position);
+            _angles.Add(targetXform.LocalRotation);
+        }
+
+        // Nothing actually got picked up.
+        if (_pickedUp.Count == 0)
+            return false;
+
+        // Play a sound and animate the items being picked up.
+        _audio.PlayPredicted(pickupSound, entity, args.User, AudioParams);
+        EntityManager.RaiseSharedEvent(
+            new AnimateInsertingEntitiesEvent(
+                GetNetEntity(entity),
+                GetNetEntityList(_pickedUp),
+                GetNetCoordinatesList(_positions),
+                _angles
+            ),
+            args.User
+        );
+        return true;
+    }
+}

--- a/Content.Shared/_Moffstation/Storage/EntitySystems/QuickPickupSystem.cs
+++ b/Content.Shared/_Moffstation/Storage/EntitySystems/QuickPickupSystem.cs
@@ -1,0 +1,97 @@
+﻿using Content.Shared.Interaction;
+using Content.Shared.Item;
+using Content.Shared.Projectiles;
+using Content.Shared.Storage;
+using Content.Shared.Timing;
+using Robust.Shared.Containers;
+using Robust.Shared.Map;
+
+namespace Content.Shared._Moffstation.Storage.EntitySystems;
+
+/// <summary>
+/// This system implements <see cref="QuickPickupComponent"/>'s behavior.
+/// </summary>
+public sealed partial class QuickPickupSystem : EntitySystem
+{
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedProjectileSystem _projectile = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly UseDelaySystem _useDelay = default!;
+
+    private EntityQuery<ItemComponent> _itemQuery;
+
+    private const string DelayId = "quickPickup";
+
+    public override void Initialize()
+    {
+        _itemQuery = GetEntityQuery<ItemComponent>();
+
+        SubscribeLocalEvent<QuickPickupComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<QuickPickupComponent, AfterInteractEvent>(
+            AfterInteract,
+            // Prioritize picking up a single item rather than trying to area pickup "through" an item.
+            before: [typeof(AreaPickupSystem)]
+        );
+    }
+
+    private void OnMapInit(Entity<QuickPickupComponent> entity, ref MapInitEvent args)
+    {
+        _useDelay.SetLength(entity.Owner, entity.Comp.Cooldown, DelayId);
+    }
+
+    private void AfterInteract(Entity<QuickPickupComponent> entity, ref AfterInteractEvent args)
+    {
+        if (args.Handled ||
+            args.Target is not { Valid: true } target ||
+            target == args.User ||
+            !args.CanReach ||
+            !_useDelay.TryResetDelay(entity, checkDelayed: true, id: DelayId) ||
+            _container.IsEntityInContainer(target) ||
+            !_itemQuery.TryComp(target, out var targetItemComp))
+            return;
+
+        // Let other systems decide if they want to try to pick up the item.
+        var ev = new QuickPickupEvent(entity, (target, targetItemComp), args.User);
+        RaiseLocalEvent(entity, ev);
+        args.Handled = ev.Handled;
+    }
+
+    /// <summary>
+    /// This function helps with handling <see cref="QuickPickupEvent"/> by handling
+    /// <see cref="AnimateInsertingEntitiesEvent">animating picked up entities</see> while also invoking
+    /// <paramref name="tryPickup"/>. Returns true if the entity in <paramref name="ev"/> was actually picked up and the
+    /// event should be considered handled, false otherwise.
+    /// </summary>
+    public bool TryDoQuickPickup(QuickPickupEvent ev, Func<bool> tryPickup)
+    {
+        if (!TryComp(ev.QuickPickupEntity, out TransformComponent? pickupEntityXform) ||
+            !TryComp(ev.PickedUp, out TransformComponent? targetXform))
+            return false;
+
+        if (TryComp<EmbeddableProjectileComponent>(ev.PickedUp, out var embeddable))
+        {
+            _projectile.EmbedDetach(ev.PickedUp, embeddable, ev.User);
+        }
+
+        // Get the picked up entity's position _before_ inserting it, because that changes its position.
+        var position = _transform.ToCoordinates(
+            pickupEntityXform.ParentUid.IsValid() ? pickupEntityXform.ParentUid : ev.QuickPickupEntity.Owner,
+            _transform.GetMapCoordinates(targetXform)
+        );
+
+        if (!tryPickup())
+            return false;
+
+        // Animate the item getting picked up.
+        EntityManager.RaiseSharedEvent(
+            new AnimateInsertingEntitiesEvent(
+                GetNetEntity(ev.QuickPickupEntity),
+                new List<NetEntity> { GetNetEntity(ev.PickedUp) },
+                new List<NetCoordinates> { GetNetCoordinates(position) },
+                new List<Angle> { pickupEntityXform.LocalRotation }
+            ),
+            ev.User
+        );
+        return true;
+    }
+}

--- a/Content.Shared/_Moffstation/Storage/QuickPickupComponent.cs
+++ b/Content.Shared/_Moffstation/Storage/QuickPickupComponent.cs
@@ -1,0 +1,21 @@
+﻿using Content.Shared._Moffstation.Storage.EntitySystems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Moffstation.Storage;
+
+/// <summary>
+/// This component enables "quick pickup" behavior, which means while holding a storage-like item, clicking on another
+/// item will attempt to insert the clicked item into the held one.
+/// </summary>
+/// <seealso cref="QuickPickupSystem"/>
+/// <seealso cref="AreaPickupComponent"/>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class QuickPickupComponent : Component
+{
+    /// <summary>
+    /// Minimum delay between quick/area insert actions.
+    /// </summary>
+    /// <remarks>Used to prevent autoclickers spamming server with individual pickup actions.</remarks>
+    [DataField]
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(0.5);
+}

--- a/Content.Shared/_Moffstation/Storage/QuickPickupEvent.cs
+++ b/Content.Shared/_Moffstation/Storage/QuickPickupEvent.cs
@@ -1,0 +1,22 @@
+﻿using Content.Shared._Moffstation.Storage.EntitySystems;
+using Content.Shared.Item;
+
+namespace Content.Shared._Moffstation.Storage;
+
+/// <summary>
+/// This event is raised on an entity with <see cref="QuickPickupComponent"/> when it attempts to pick up an item.
+/// Storage-like systems which want to quick pickup into their storage SHOULD handle the event using
+/// <see cref="QuickPickupSystem.TryDoQuickPickup"/>.
+/// </summary>
+/// <seealso cref="QuickPickupSystem"/>
+/// <seealso cref="QuickPickupSystem.TryDoQuickPickup"/>
+public sealed partial class QuickPickupEvent(
+    Entity<QuickPickupComponent> entity,
+    Entity<ItemComponent> pickedUp,
+    EntityUid user
+) : HandledEntityEventArgs
+{
+    public readonly Entity<QuickPickupComponent> QuickPickupEntity = entity;
+    public readonly Entity<ItemComponent> PickedUp = pickedUp;
+    public readonly EntityUid User = user;
+}

--- a/Resources/Prototypes/Entities/Objects/Fun/snap_pops.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/snap_pops.yml
@@ -48,11 +48,12 @@
   - type: Storage
     grid:
     - 0,0,4,3
-    areaInsert: true
+#    areaInsert: true # Moffstation
     maxItemSize: Tiny
   - type: StorageFill
     contents:
       - id: SnapPop
         amount: 5
   - type: Dumpable
+  - type: AreaPickup # Moffstation
 

--- a/Resources/Prototypes/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/folders.yml
@@ -277,7 +277,7 @@
   - type: Storage
     grid:
     - 0,0,4,3
-    quickInsert: true
+  - type: QuickPickup # Moffstation
   - type: StorageFill
     contents: [] #to override base clipboard fill
   - type: ItemMapper

--- a/Resources/Prototypes/Entities/Objects/Specific/Cargo/mail_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Cargo/mail_bag.yml
@@ -18,8 +18,10 @@
     maxItemSize: Normal
     grid:
     - 0,0,4,3
-    quickInsert: true
-    areaInsert: true
+  # Moffstation - Start
+#    quickInsert: true
+#    areaInsert: true
+    # Moffstation - End
     whitelist:
       components:
       - Paper
@@ -28,3 +30,7 @@
       - Document
       - Paper
   - type: Dumpable
+  # Moffstation - Start
+  - type: QuickPickup
+  - type: AreaPickup
+  # Moffstation - End

--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
@@ -18,8 +18,10 @@
     maxItemSize: Normal # allow up to 5 large beakers / 10 beakers / 10 pill canisters
     grid:
     - 0,0,4,3
-    quickInsert: true
-    areaInsert: true
+# Moffstation - Start
+#    quickInsert: true
+#    areaInsert: true
+# Moffstation - End
     whitelist:
       components:
         - FitsInDispenser
@@ -31,3 +33,7 @@
         - Syringe
         - Dropper
   - type: Dumpable
+  # Moffstation - Start
+  - type: QuickPickup
+  - type: AreaPickup
+  # Moffstation - End

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -148,10 +148,16 @@
     grid:
     - 0,0,7,4
     maxItemSize: Small
-    quickInsert: true
-    areaInsert: true
+# Moffstation - Start
+#    quickInsert: true
+#    areaInsert: true
+# Moffstation - End
     whitelist:
       components:
         - Produce
         - Seed
   - type: Dumpable
+  # Moffstation - Start
+  - type: QuickPickup
+  - type: AreaPickup
+  # Moffstation - End

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -12,8 +12,10 @@
     maxItemSize: Normal
     grid:
     - 0,0,7,5
-    quickInsert: true
-    areaInsert: true
+# Moffstation - Start
+#    quickInsert: true
+#    areaInsert: true
+# Moffstation - End
     storageOpenSound:
       collection: trashBagRustle
     storageInsertSound:
@@ -22,6 +24,10 @@
       tags:
         - Cartridge
         - Trash
+  # Moffstation - Start
+  - type: QuickPickup
+  - type: AreaPickup
+  # Moffstation - End
   - type: UseDelay
     delay: 0.5
   - type: Tag
@@ -61,9 +67,11 @@
     maxItemSize: Huge
     grid:
     - 0,0,19,9
-    quickInsert: true
-    areaInsert: true
-    areaInsertRadius: 5
+  # Moffstation - Start
+  - type: QuickPickup
+  - type: AreaPickup
+    radius: 5
+  # Moffstation - End
 
 - type: entity
   parent: TrashBag

--- a/Resources/Prototypes/Entities/Objects/Specific/Librarian/books_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Librarian/books_bag.yml
@@ -17,8 +17,10 @@
     - type: Storage
       grid:
       - 0,0,7,3
-      quickInsert: true
-      areaInsert: true
+    # Moffstation - Start
+#      quickInsert: true
+#      areaInsert: true
+    # Moffstation - End
       whitelist:
         tags:
           - Book
@@ -28,3 +30,7 @@
           - TabletopBoard
           - Write
     - type: Dumpable
+    # Moffstation - Start
+    - type: QuickPickup
+    - type: AreaPickup
+    # Moffstation - End

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -19,13 +19,19 @@
     maxItemSize: Normal
     grid:
     - 0,0,9,3
-    quickInsert: true
-    areaInsert: true
+# Moffstation - Start
+#    quickInsert: true
+#    areaInsert: true
+# Moffstation - End
     whitelist:
       tags:
         - ArtifactFragment
         - Ore
   - type: Dumpable
+  # Moffstation - Start
+  - type: QuickPickup
+  - type: AreaPickup
+  # Moffstation - End
 
 - type: entity
   parent: OreBag

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/material_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/material_bag.yml
@@ -19,11 +19,17 @@
     maxItemSize: Normal
     grid:
     - 0,0,9,3
-    quickInsert: true
-    areaInsert: true
+# Moffstation - Start
+#    quickInsert: true
+#    areaInsert: true
+# Moffstation - End
     whitelist:
       tags:
       - Sheet
       - RawMaterial
       - Ingot
   - type: Dumpable
+  # Moffstation - Start
+  - type: QuickPickup
+  - type: AreaPickup
+  # Moffstation - End

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -652,12 +652,18 @@
   - type: Storage
     grid:
     - 0,0,4,1
-    quickInsert: true
-    areaInsert: true
-    areaInsertRadius: 1
+# Moffstation - Start
+#    quickInsert: true
+#    areaInsert: true
+#    areaInsertRadius: 1
+# Moffstation - End
     storageInsertSound: /Audio/Effects/pill_insert.ogg
     storageRemoveSound: /Audio/Effects/pill_remove.ogg
     whitelist:
       tags:
       - Pill
   - type: Dumpable
+  # Moffstation - Start
+  - type: QuickPickup
+  - type: AreaPickup
+  # Moffstation - End

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/toy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/toy.yml
@@ -30,6 +30,10 @@
     layers:
       - state: boxwidetoy
       - state: shelltoy
+  # Moffstation - Start
+  - type: QuickPickup
+  - type: AreaPickup
+  # Moffstation - End
 
 - type: entity
   parent: BaseMagazineBoxMagnum


### PR DESCRIPTION
Moff-flavored version of https://github.com/space-wizards/space-station-14/pull/38420 . I tried to make the modifications to existing code easier to diff/merge by using block comments rather than line comments where possible.

Begin paste of upstream PR description:

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Split Quick- and Area-Pickup into their own Components so that they can be reused for ballistic ammo providers.
Specifically also adds quick and area pickup to the foam dart ammo box to make cleaning up foam darts less carpal-tunnel-inducing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I wanted to reuse the functionality on the foam dart ammo box which doesn't use `StorageComponent`, plus there was a TODO to split Area pickup from Storage component.

## Technical details
<!-- Summary of code changes for easier review. -->

### Area Pickup
- add `AreaPickupComponent`
- add `AreaPickupSystem`
- add `BeforeAreaPickupEvent`
  - raised by `AreaPickupSystem` to determine what to try to pick up
  - handled by storage-like systems by invoking a function on `AreaPickupSystem` with a predicate
- change `AreaPickupDoAfterEvent` to be handled by storage-like systems
  - invoke a function on `AreaPickupSystem` with a function value that actually does the picking up
- move area pickup stuff from storage component & system
- can now area pickup into `BallisticAmmoProviderComponent`
- small cleanup to `AreaPickupDoAfterEvent`

### Quick Pickup
- add `QuickPickupComponent`
- add `QuickPickupSystem`
- add `QuickPickupEvent` which allows storage-like systems to implement quick pickup behavior
  - handle by calling a function on `QuickPickupSystem` with a function value which actually does the picking up
- move area pickup stuff from storage component and system
- can now quick pickup into `BallisticAmmoProviderComponent`

### Ballistic Ammo changes
- add `SilentInsertUserTag` to match functionality from `StorageComponent`
  - only applies to insertion sounds
- add public methods to `GunSystem` for use by new interactions
  - `IsFullBallistic`
  - `CanInsertBallistic`
  - `TryBallisticInsert`

### Prototype Changes
- migrate preexisting storage quick/area insert to new components
- "box of foam darts" (`BoxDonkSoftBox`) can now area and quick pickup darts

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/9ef88137-ae68-45c9-a7a2-6e26d00f6ce6

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Quick and Area Insert behavior is no longer tied to `StorageComponent` and instead are granted by `QuickPickupComponent` and `AreaPickupComponent` respectively. To migrate existing usages to these new components, make the following changes:
(Quick insert)
```yaml
# Before
components:
- type: Storage
  quickInsert: true

# After
components:
- type: Storage
- type: QuickPickup
```

(Area insert)
```yaml
# Before
components:
- type: Storage
  areaInsert: true
  areaInsertRadius: 10 # optional

# After
components:
- type: Storage
- type: AreaPickup
  radius: 10 # optional, same default as Storage's previous default
```

There are no modifications to existing C# public APIs aside from the removal of fields on `StorageComponent`.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The Box of Foam Darts can now quickly pick up foam darts in the same way that trash bags pick up items.
