### PR TITLE
Fix Actions activation not being Validated

### DIFF
--- a/Content.Shared/Actions/Components/EntityTargetActionComponent.cs
+++ b/Content.Shared/Actions/Components/EntityTargetActionComponent.cs
@@ -1,5 +1,4 @@
-using Content.Shared.Actions;
-﻿using Content.Shared.Whitelist;
+using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
@@ -45,4 +44,10 @@ public sealed partial class EntityTargetActionComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool CanTargetSelf = true;
+
+    /// <summary>
+    /// Whether to make the user face towards the direction where they targeted this action.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool RotateOnUse = true;
 }

--- a/Content.Shared/Actions/Components/WorldTargetActionComponent.cs
+++ b/Content.Shared/Actions/Components/WorldTargetActionComponent.cs
@@ -1,5 +1,4 @@
-using Content.Shared.Actions;
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Actions.Components;
@@ -13,6 +12,7 @@ namespace Content.Shared.Actions.Components;
 /// </remarks>
 [RegisterComponent, NetworkedComponent, Access(typeof(SharedActionsSystem))]
 [EntityCategory("Actions")]
+[AutoGenerateComponentState]
 public sealed partial class WorldTargetActionComponent : Component
 {
     /// <summary>
@@ -20,4 +20,10 @@ public sealed partial class WorldTargetActionComponent : Component
     /// </summary>
     [DataField(required: true), NonSerialized]
     public WorldTargetActionEvent? Event;
+
+    /// <summary>
+    /// Whether to make the user face towards the direction where they targeted this action.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool RotateOnUse = true;
 }

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -58,6 +58,7 @@ public abstract class SharedActionsSystem : EntitySystem
         SubscribeLocalEvent<ActionsComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<ActionsComponent, ComponentGetState>(OnGetState);
 
+        SubscribeLocalEvent<ActionComponent, ActionValidateEvent>(OnValidate);
         SubscribeLocalEvent<InstantActionComponent, ActionValidateEvent>(OnInstantValidate);
         SubscribeLocalEvent<EntityTargetActionComponent, ActionValidateEvent>(OnEntityValidate);
         SubscribeLocalEvent<WorldTargetActionComponent, ActionValidateEvent>(OnWorldValidate);
@@ -316,19 +317,9 @@ public abstract class SharedActionsSystem : EntitySystem
 
     private void OnValidate(Entity<ActionComponent> ent, ref ActionValidateEvent args)
     {
-        if (ent.Comp.CheckConsciousness && !_actionBlocker.CanConsciouslyPerformAction(args.User))
-        {
+        if ((ent.Comp.CheckConsciousness && !_actionBlocker.CanConsciouslyPerformAction(args.User))
+            || (ent.Comp.CheckCanInteract && !_actionBlocker.CanInteract(args.User, null)))
             args.Invalid = true;
-            return;
-        }
-
-        if (ent.Comp.CheckCanInteract && !_actionBlocker.CanInteract(args.User, null))
-        {
-            args.Invalid = true;
-            return;
-        }
-
-        // Event is not set here, only below
     }
 
     private void OnInstantValidate(Entity<InstantActionComponent> ent, ref ActionValidateEvent args)
@@ -357,7 +348,9 @@ public abstract class SharedActionsSystem : EntitySystem
         var target = GetEntity(netTarget);
 
         var targetWorldPos = _transform.GetWorldPosition(target);
-        _rotateToFace.TryFaceCoordinates(user, targetWorldPos);
+
+        if (ent.Comp.RotateOnUse)
+            _rotateToFace.TryFaceCoordinates(user, targetWorldPos);
 
         if (!ValidateEntityTarget(user, target, ent))
             return;
@@ -378,7 +371,9 @@ public abstract class SharedActionsSystem : EntitySystem
 
         var user = args.User;
         var target = GetCoordinates(netTarget);
-        _rotateToFace.TryFaceCoordinates(user, target.ToMapPos(EntityManager, _transform));
+
+        if (ent.Comp.RotateOnUse)
+            _rotateToFace.TryFaceCoordinates(user, _transform.ToMapCoordinates(target).Position);
 
         if (!ValidateWorldTarget(user, target, ent))
             return;


### PR DESCRIPTION
Reverts the following files to their states on Wizden as of a77c24cc864a926e3dc103ca8bf0a9996d6648e4
- EntityTargetActionComponent.cs
- SharedActionsSystem.cs
- WorldTargetActionComponent.cs

(ie. something went wrong in an upstream merge)

Fixes https://discord.com/channels/1322447119252062260/1385806856869384204