### PR TITLE
Update metacomming rules for better clarity

### DIFF
--- a/Resources/Locale/en-US/_Moffstation/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Moffstation/guidebook/guides.ftl
@@ -2,6 +2,7 @@ metashield-changes = Metashield Changes
 spacelaw-changes = Space Law Changes
 moff-ooc-rules = OOC rules
 moff-metagaming-rules = Metagaming rules
+moff-metacomming-rules = 2.2 Metacomming
 moff-powergaming-rules = Powergaming rules
 moff-rp-rules = Roleplay rules
 moff-death-and-life-rules = Death and New life rules

--- a/Resources/Prototypes/_Moffstation/Guidebook/rules.yml
+++ b/Resources/Prototypes/_Moffstation/Guidebook/rules.yml
@@ -7,6 +7,7 @@
   children:
   - MoffMetashield
   - MoffSpaceLawChanges
+  - MoffOOC
 
 - type: guideEntry
   id: MoffOOC
@@ -19,6 +20,14 @@
   name: moff-metagaming-rules
   ruleEntry: true
   text: "/ServerInfo/_Moffstation/Guidebook/ServerRules/MoffR2Metagaming.xml"
+  children:
+  - MoffMetacomming
+
+- type: guideEntry
+  id: MoffMetacomming
+  name: moff-metacomming-rules
+  ruleEntry: true
+  text: "/ServerInfo/_Moffstation/Guidebook/ServerRules/MoffMetacomming.xml"
 
 - type: guideEntry
   id: MoffPowergaming

--- a/Resources/ServerInfo/_Moffstation/Guidebook/ServerRules/MoffMetacomming.xml
+++ b/Resources/ServerInfo/_Moffstation/Guidebook/ServerRules/MoffMetacomming.xml
@@ -20,7 +20,7 @@
   - [color=#a4885c]All[/color] players (not just the ones you are talking to) are in the server lobby.
     - We encourage you to not communicate during this time, in order to include everyone in pre or post round discussion.
   - The server admins are hosting an event (ex. teaching events) and they have explicitly permitted metacomming.
-  - The server admins are hosting certain gamemodes like Gun Game or Deathmatch and they explicitly allow metacomming.
+  - The server admins are hosting certain gamemodes like Gun Game or Deathmatch and they have explicitly permitted metacomming.
 
   ## Streaming
   Streaming gameplay publically or privately is allowed, however:

--- a/Resources/ServerInfo/_Moffstation/Guidebook/ServerRules/MoffMetacomming.xml
+++ b/Resources/ServerInfo/_Moffstation/Guidebook/ServerRules/MoffMetacomming.xml
@@ -1,0 +1,43 @@
+<Document>
+  # 2.2 Metacomming
+  Do not use any external methods to communicate with other players in the same game server, or who were connected to the same server during the current round.
+  This is referred to as "metacomming" and includes any means of communication including text, voice, images, and video.
+  This includes applications such as Discord, Steam, and other platforms, along with in-person communication.
+
+  [color=red][bold]This is a zero-tolerance rule.[/bold][/color]
+  Even if information is not being shared or abused, it may still be considered a violation of this rule.
+
+  Due to the difficulty of determining if information is being shared, it will almost always be presumed that people who message another player they are in a round with, or who are in a voice call with another player during a round are sharing round information.
+
+  Due to the difficulty of determining if users are abusing information that they are sharing, it will almost always be presumed that the information is being abused.
+
+  When participating in any active voice call or channel, it is [color=red][bold]your responsibility[/bold][/color] to ensure that all players there are not playing on the server at the same time as you are.
+
+  It is best to use LOOC or OOC to share any out-of-character information with anyone else in the round, though note it is encouraged to talk as much as possible in-character about your topic before using LOOC or OOC.
+
+  ## Exceptions
+  There are a few exceptions to this rule:
+  - [color=#a4885c]All[/color] players (not just the ones you are talking to) are in the server lobby.
+    - We encourage you to not communicate during this time, in order to include everyone in pre or post round discussion.
+  - The server admins are hosting an event (ex. teaching events) and they have explicitly permitted metacomming.
+  - The server admins are hosting certain gamemodes like Gun Game or Deathmatch and they explicitly allow metacomming.
+
+  ## Streaming
+  Streaming gameplay publically or privately is allowed, however:
+  - You should ensure that players are not actively watching your stream while connencted to the server themselves.
+  - Players shouldn't be sharing any in-round information with you that wasn't obtained from the stream directly.
+
+  ## Teaching New Players
+  Teaching new players is not exempt from this rule.
+  You should be conversing with new players through entirely in-game means, if you are playing with them.
+  It is highly recommended (and easier) to have the new player stream gameplay footage to you, while you yourself are not playing, and teach that way instead.
+  Being physically present behind them (while also not playing yourself) is also allowed and encouraged.
+
+  ## Examples
+  The following are a few examples in order to clear up potential grey areas.
+
+  ### Disallowed
+  - Sitting in a discord voice channel/call with other people who are connected to the server when a round is taking place, even if you or the other members of the call are muted or deafened. This is still disallowed even if any or all members are ghosts or observing.
+  - Sharing in-round information to Discord text channels or other external means, when the round is still ongoing.
+  - Conversing with other players through means that are not in-game methods during gamemodes like Gun Game or Deathmatch when an admin has not explicitly allowed metacomming.
+</Document>

--- a/Resources/ServerInfo/_Moffstation/Guidebook/ServerRules/MoffR2Metagaming.xml
+++ b/Resources/ServerInfo/_Moffstation/Guidebook/ServerRules/MoffR2Metagaming.xml
@@ -4,7 +4,7 @@
   2.1 Do not metagame (i.e. using or sharing information that your character has no way of knowing or obtaining, such as knowledge on the exact loadouts of antagonists, or things seen or heard while dead).
   - At any point in the game if someone were to ask you why your character is doing what they're doing, you should be able to provide a reasonable in-character explanation.
 
-  2.2 Do not metacommunicate - [textlink="See the extended rule description of this rule." link="MoffMetacomming"]
+  2.2 Do not metacommunicate - [textlink="See the extended description of this rule." link="MoffMetacomming"]
 
   2.3 Do not metagrudge nor metafriend. That is, treating a character unfairly solely based on the out-of-character relationship with the player; or treating them unfairly beyond acceptable and reasonable conduct - for example, attacking on sight - because of in-character interactions in previous rounds.
 

--- a/Resources/ServerInfo/_Moffstation/Guidebook/ServerRules/MoffR2Metagaming.xml
+++ b/Resources/ServerInfo/_Moffstation/Guidebook/ServerRules/MoffR2Metagaming.xml
@@ -4,7 +4,7 @@
   2.1 Do not metagame (i.e. using or sharing information that your character has no way of knowing or obtaining, such as knowledge on the exact loadouts of antagonists, or things seen or heard while dead).
   - At any point in the game if someone were to ask you why your character is doing what they're doing, you should be able to provide a reasonable in-character explanation.
 
-  2.2 Do not metacommunicate or metacomm (communicate with other players via a method external to the game) with other players in the same game server. This includes sitting in VC muted/deafened or having active text chats with other members. If you need to say something Out Of Character (OOC), please do so in game via the Local Out Of Character (LOOC).
+  2.2 Do not metacommunicate - [textlink="See the extended rule description of this rule." link="MoffMetacomming"]
 
   2.3 Do not metagrudge nor metafriend. That is, treating a character unfairly solely based on the out-of-character relationship with the player; or treating them unfairly beyond acceptable and reasonable conduct - for example, attacking on sight - because of in-character interactions in previous rounds.
 


### PR DESCRIPTION
## About the PR
This PR changes the metacomming rules to be clearer and explicitly clarify disallowed behavior.

## Why / Balance
Apparently the rules were *not clear enough* to players. This is especially funny, considering that:
- Moffstation, as a concept, is supposed to be a community comprised of players that are capable of self-regulating in a relaxed ruleset environment, in order to enable a wider variety of roleplay.
- Multiple metacomming incidents have occurred on Moffstation, and every single time, the rules were clarified and re-asserted. Bans were not handed out on the premises that players would learn their lesson and this would *never happen again*.
- Our metacomm rules are extremely similar (and even more concise) in comparison to other MRP forks like Harmony.

This new set of rules is based concretely on the definitions defined upstream with changes for clarity and things we want to allow.

## Technical details
N/A

## Media
Read diff

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Rule 2.2 has been reworded and expanded for clarity. Be sure to read it.
