### PR TITLE
Added Swat Shoes To Hacked ClothesMate Manager Inventory

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -98,6 +98,7 @@
     ClothingMaskNeckGaiter: 2
     ClothingUniformJumpsuitTacticool: 1
     ClothingUniformJumpskirtTacticool: 1
+    ClothingShoesSwat: 2 #Moffstation - Added Swat Shoes
     ToyFigurinePassenger: 1
     ToyFigurineGreytider: 1
     FoodSnackChits: 3 # Moffstation - Added Chits


### PR DESCRIPTION
## About the PR
Added two pairs of the Swat Shoes to the ClothesMate hacked/cut manager wire inventory.

## Why / Balance
It may end the plight of people wanting jackboots, but without the contra status, or the other functions that comes with it, specifically the insertable slot.

## Technical details
Added one line to the clothesmate.yml

## Media
<img width="674" height="478" alt="image" src="https://github.com/user-attachments/assets/726641a1-a275-4c15-843f-3d6b0649718c" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**

:cl:
- add: Swat Shoes to ClothesMate manager wire