### PR TITLE
Rules requirement based on total playercount

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -349,6 +349,15 @@ namespace Content.Server.GameTicking
             return total;
         }
 
+        // Moffstation - Start - Player count calculated depending on cvar
+        public int DynamicPlayerCount()
+        {
+            return _cfg.GetCVar(CCVars.GameRulesCountReadied)
+                ? ReadyPlayerCount()
+                : _playerManager.PlayerCount;
+        }
+        // Moffstation - End
+
         public void StartRound(bool force = false)
         {
 #if EXCEPTION_TOLERANCE

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -38,12 +38,8 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
         while (query.MoveNext(out var uid, out _, out var gameRule))
         {
             var minPlayers = gameRule.MinPlayers;
-            // Moffstation - Start - total player count for rules
-            var currentPlayers = GameTicker.DynamicPlayerCount();
-
-            if (currentPlayers >= minPlayers)
+            if (GameTicker.DynamicPlayerCount() >= minPlayers)  // Moffstation - total player count for rules
                 continue;
-            // Moffstation - End
 
             if (gameRule.CancelPresetOnTooFewPlayers)
             {

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -1,7 +1,10 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Chat.Managers;
+using Content.Shared.CCVar;
 using Content.Shared.GameTicking.Components;
 using Robust.Server.GameObjects;
+using Robust.Server.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -14,9 +17,13 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
     [Dependency] protected readonly GameTicker GameTicker = default!;
     [Dependency] protected readonly IGameTiming Timing = default!;
 
+
     // Not protected, just to be used in utility methods
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
     [Dependency] private readonly MapSystem _map = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;    // Moffstation
+    [Dependency] private readonly IPlayerManager _playerManager = default!;     // Moffstation
+
 
     public override void Initialize()
     {
@@ -38,8 +45,14 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
         while (query.MoveNext(out var uid, out _, out var gameRule))
         {
             var minPlayers = gameRule.MinPlayers;
-            if (args.Players.Length >= minPlayers)
+            // Moffstation - Start - total player count for rules
+            var currentPlayers = _cfg.GetCVar(CCVars.GameRulesCountReadied)
+                ? args.Players.Length
+                : _playerManager.PlayerCount;
+
+            if (currentPlayers >= minPlayers)
                 continue;
+            // Moffstation - End
 
             if (gameRule.CancelPresetOnTooFewPlayers)
             {

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -1,10 +1,7 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Chat.Managers;
-using Content.Shared.CCVar;
 using Content.Shared.GameTicking.Components;
 using Robust.Server.GameObjects;
-using Robust.Server.Player;
-using Robust.Shared.Configuration;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -17,13 +14,9 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
     [Dependency] protected readonly GameTicker GameTicker = default!;
     [Dependency] protected readonly IGameTiming Timing = default!;
 
-
     // Not protected, just to be used in utility methods
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
     [Dependency] private readonly MapSystem _map = default!;
-    [Dependency] private readonly IConfigurationManager _cfg = default!;    // Moffstation
-    [Dependency] private readonly IPlayerManager _playerManager = default!;     // Moffstation
-
 
     public override void Initialize()
     {
@@ -46,9 +39,7 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
         {
             var minPlayers = gameRule.MinPlayers;
             // Moffstation - Start - total player count for rules
-            var currentPlayers = _cfg.GetCVar(CCVars.GameRulesCountReadied)
-                ? args.Players.Length
-                : _playerManager.PlayerCount;
+            var currentPlayers = GameTicker.DynamicPlayerCount();
 
             if (currentPlayers >= minPlayers)
                 continue;

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Random;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
+using Robust.Server.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Configuration;
@@ -21,6 +22,8 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+
 
     private string _ruleCompName = default!;
 
@@ -74,7 +77,11 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     private bool TryPickPreset(ProtoId<WeightedRandomPrototype> weights, [NotNullWhen(true)] out GamePresetPrototype? preset)
     {
         var options = _prototypeManager.Index(weights).Weights.ShallowClone();
-        var players = GameTicker.ReadyPlayerCount();
+        // Moffstation - Start - total player count for rules
+        var players = _configurationManager.GetCVar(CCVars.GameRulesCountReadied)
+            ? GameTicker.ReadyPlayerCount()
+            : _playerManager.PlayerCount;
+        // Moffstation - End
 
         GamePresetPrototype? selectedPreset = null;
         var sum = options.Values.Sum();
@@ -132,7 +139,11 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     /// </summary>
     public bool CanPickAny(IEnumerable<ProtoId<GamePresetPrototype>> protos)
     {
-        var players = GameTicker.ReadyPlayerCount();
+        // Moffstation - Start - total player count for rules
+        var players = _configurationManager.GetCVar(CCVars.GameRulesCountReadied)
+            ? GameTicker.ReadyPlayerCount()
+            : _playerManager.PlayerCount;
+        // Moffstation - End
         foreach (var id in protos)
         {
             if (!_prototypeManager.TryIndex(id, out var selectedPreset))

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -8,7 +8,6 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Random;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
-using Robust.Server.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Configuration;
@@ -22,8 +21,6 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
-    [Dependency] private readonly IPlayerManager _playerManager = default!;
-
 
     private string _ruleCompName = default!;
 
@@ -77,11 +74,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     private bool TryPickPreset(ProtoId<WeightedRandomPrototype> weights, [NotNullWhen(true)] out GamePresetPrototype? preset)
     {
         var options = _prototypeManager.Index(weights).Weights.ShallowClone();
-        // Moffstation - Start - total player count for rules
-        var players = _configurationManager.GetCVar(CCVars.GameRulesCountReadied)
-            ? GameTicker.ReadyPlayerCount()
-            : _playerManager.PlayerCount;
-        // Moffstation - End
+        var players = GameTicker.DynamicPlayerCount();  // Moffstation - total player count for rules
 
         GamePresetPrototype? selectedPreset = null;
         var sum = options.Values.Sum();
@@ -140,9 +133,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     public bool CanPickAny(IEnumerable<ProtoId<GamePresetPrototype>> protos)
     {
         // Moffstation - Start - total player count for rules
-        var players = _configurationManager.GetCVar(CCVars.GameRulesCountReadied)
-            ? GameTicker.ReadyPlayerCount()
-            : _playerManager.PlayerCount;
+        var players = GameTicker.DynamicPlayerCount();
         // Moffstation - End
         foreach (var id in protos)
         {

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -132,9 +132,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     /// </summary>
     public bool CanPickAny(IEnumerable<ProtoId<GamePresetPrototype>> protos)
     {
-        // Moffstation - Start - total player count for rules
-        var players = GameTicker.DynamicPlayerCount();
-        // Moffstation - End
+        var players = GameTicker.DynamicPlayerCount();  // Moffstation - total player count for rules
         foreach (var id in protos)
         {
             if (!_prototypeManager.TryIndex(id, out var selectedPreset))

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -109,14 +109,6 @@ public sealed partial class CCVars
     public static readonly CVarDef<bool>
         GameRoleTimers = CVarDef.Create("game.role_timers", true, CVar.SERVER | CVar.REPLICATED);
 
-    // Moffstation - Begin
-    /// <summary>
-    /// If role loadout items should be restricted based on time.
-    /// </summary>
-    public static readonly CVarDef<bool>
-        GameRoleLoadoutTimers = CVarDef.Create("game.role_loadout_timers", true, CVar.SERVER | CVar.REPLICATED);
-    // Moffstation - End
-
     /// <summary>
     ///     Override default role requirements using a <see cref="JobRequirementOverridePrototype"/>
     /// </summary>
@@ -411,4 +403,18 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> GameHostnameInTitlebar =
         CVarDef.Create("game.hostname_in_titlebar", true, CVar.SERVER | CVar.REPLICATED);
+
+    // Moffstation - Begin
+    /// <summary>
+    /// If role loadout items should be restricted based on time.
+    /// </summary>
+    public static readonly CVarDef<bool>
+        GameRoleLoadoutTimers = CVarDef.Create("game.role_loadout_timers", true, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    /// if true, the player count check for rules will be based on the number of players readied, versus the total number in the lobby.
+    /// </summary>
+    public static readonly CVarDef<bool>
+        GameRulesCountReadied = CVarDef.Create("game.rules_count_readied", false, CVar.SERVER | CVar.REPLICATED);
+    // Moffstation - End
 }

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -415,6 +415,6 @@ public sealed partial class CCVars
     /// if true, the player count check for rules will be based on the number of players readied, versus the total number in the lobby.
     /// </summary>
     public static readonly CVarDef<bool>
-        GameRulesCountReadied = CVarDef.Create("game.rules_count_readied", false, CVar.SERVER | CVar.REPLICATED);
+        GameRulesCountReadied = CVarDef.Create("game.rules_count_readied", false, CVar.SERVERONLY);
     // Moffstation - End
 }


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Adds a new cvar that changes the minimum player requirement for rules to be based on the total number of players, rather than just the ones readied up. This defaults to reading the total count rather than the readied count.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
We have many players who prefer latejoining, and we often lack enough readied players to meet the requirements for some of the gamerules people like. This addresses that by allowing the check to be run against the total player count.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Gamerules now check total playercount rather than readycount when seeing if they can be fired.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
