### PR TITLE
Revert stamina resistance

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -23,10 +23,6 @@
         Heat: 0.80
   - type: ExplosionResistance
     damageCoefficient: 0.90
-  # Moffstation - Begin (Stamina Resistance) - Armor gets 20%.
-  - type: StaminaResistance
-    damageCoefficient: 0.8
-  # Moffstation - End
 
 #Standard armor vest, allowed for security and bartenders
 - type: entity
@@ -124,10 +120,6 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
-  # Moffstation - Begin (Stamina Resistance) - Armor gets 20%.
-  - type: StaminaResistance
-    damageCoefficient: 0.8
-  # Moffstation - End
   - type: HeldSpeedModifier
   - type: GroupExamine
 
@@ -177,10 +169,6 @@
         Heat: 0.9
   - type: ExplosionResistance
     damageCoefficient: 0.9
-  # Moffstation - Begin (Stamina Resistance) - Armor gets 20%.
-  - type: StaminaResistance
-    damageCoefficient: 0.8
-  # Moffstation - End
   - type: StaticPrice
     price: 1500
 
@@ -209,10 +197,6 @@
         Caustic: 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  # Moffstation - Begin (Stamina Resistance) - Armor gets 20%.
-  - type: StaminaResistance
-    damageCoefficient: 0.8
-  # Moffstation - End
   - type: FireProtection
     reduction: 0.85
   - type: StaticPrice
@@ -341,10 +325,6 @@
         Caustic: 0.9
   - type: ExplosionResistance
     damageCoefficient: 0.9
-  #Moffstation - Begin (Stamina Resistance) - Riot/Advanced armor gets 40%.
-  - type: StaminaResistance
-    damageCoefficient: 0.6
-  #Moffstation - End
   - type: GroupExamine
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -130,10 +130,6 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.7
-  # Moffstation - Begin (Stamina Resistance) - Armor gets 20%.
-  - type: StaminaResistance
-    damageCoefficient: 0.8
-  # Moffstation - End
   - type: Armor
     modifiers:
       coefficients:
@@ -244,10 +240,6 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.4
-  # Moffstation - Begin (Stamina Resistance) - Armor gets 20%.
-  - type: StaminaResistance
-    damageCoefficient: 0.8
-  # Moffstation - End
   - type: Armor
     modifiers:
       coefficients:
@@ -282,10 +274,6 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
-  # Moffstation - Begin (Stamina Resistance) - Armor gets 20%.
-  - type: StaminaResistance
-    damageCoefficient: 0.8
-  # Moffstation - End
   - type: Armor
     modifiers:
       coefficients:
@@ -315,10 +303,6 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.4
-  # Moffstation - Begin (Stamina Resistance) - Riot/Advanced armor gets 40%.
-  - type: StaminaResistance
-    damageCoefficient: 0.6
-  # Moffstation - End
   - type: Armor
     modifiers:
       coefficients:
@@ -504,10 +488,6 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  # Moffstation - Begin (Stamina Resistance) - Armor gets 20%.
-  - type: StaminaResistance
-    damageCoefficient: 0.8
-  # Moffstation - End
   - type: Armor
     modifiers:
       coefficients:
@@ -865,10 +845,6 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  # Moffstation - Begin (Stamina Resistance) - Armor gets 20%.
-  - type: StaminaResistance
-    damageCoefficient: 0.8
-  # Moffstation - End
   - type: Armor
     modifiers:
       coefficients:
@@ -1035,10 +1011,6 @@
     coolingCoefficient: 0.001
   - type: ExplosionResistance
     damageCoefficient: 0.7
-  # Moffstation - Begin (Stamina Resistance) - Riot/Advanced armor gets 40%.
-  - type: StaminaResistance
-    damageCoefficient: 0.6
-  # Moffstation - End
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -290,7 +290,7 @@
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide
-    damage: 26 # Moffstation - (Stamina Resistance) - This keeps the disabler not too strong with a 4 hit stun against unarmored and 5 hit against any sort of armor.
+    damage: 33
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:
@@ -1135,7 +1135,7 @@
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide
-    damage: 18 # Moffstation - (Stamina Resistance) - This makes the energy shotgun barely a 2-shot stamcrit against unarmored, but any armor brings it up to three shots.
+    damage: 15
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -41,10 +41,10 @@
     angle: 60
     animation: WeaponArcThrust
   - type: StaminaDamageOnHit
-    damage: 42 # Moffstation - (Stamina Resistance) - This keeps the bantong as a 3-hit against anything except advanced armor.
+    damage: 35
     sound: /Audio/Weapons/egloves.ogg
   - type: StaminaDamageOnCollide
-    damage: 42 # Moffstation - (Stamina Resistance) - This keeps the bantong as a 3-hit against anything except advanced armor.
+    damage: 35
     sound: /Audio/Weapons/egloves.ogg
   - type: LandAtCursor # it deals stamina damage when thrown
   - type: Battery

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -33,7 +33,7 @@
   equipment:
     eyes: ClothingEyesGlassesSecurity
     id: WardenPDA
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetAltSecurity # Moffstation - (Give Warden Command Comms)
     pocket1: WeaponPistolMk58
   storage:
     back:

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -33,7 +33,7 @@
   equipment:
     eyes: ClothingEyesGlassesSecurity
     id: WardenPDA
-    ears: ClothingHeadsetAltSecurity # Moffstation - (Give Warden Command Comms)
+    ears: ClothingHeadsetSecurity
     pocket1: WeaponPistolMk58
   storage:
     back:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
This reverts the two previous stamina resistance PRs, as upstream now has their own functional (and far simpler) stamina resistance system.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This has been requested a few times by maintainers to reduce the complexity of upstream pulls, and isn't really needed since we have nukie stamina resistance upstream now. However, the disabler SMG will unfortunately go back to not being very viable as a result of this - id like to make a PR to increase its capacity and firerate later.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Nox38
- tweak: Reverted stamina resistance and damage to match upstream.
