### PR TITLE
Fixed cargo arb test

### DIFF
--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -21,9 +21,11 @@ public sealed class CargoTest
     private static readonly HashSet<ProtoId<CargoProductPrototype>> Ignored =
     [
         // This is ignored because it is explicitly intended to be able to sell for more than it costs.
+        // Moffstation - Start - test fixes
         new("FunCrateGambling"),
         new("PirateSyndicateSurplusBundle"),
         new("PirateGrandLottery")
+        // Moffstation - End
     ];
 
     [Test]

--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -21,7 +21,9 @@ public sealed class CargoTest
     private static readonly HashSet<ProtoId<CargoProductPrototype>> Ignored =
     [
         // This is ignored because it is explicitly intended to be able to sell for more than it costs.
-        new("FunCrateGambling")
+        new("FunCrateGambling"),
+        new("PirateSyndicateSurplusBundle"),
+        new("PirateGrandLottery")
     ];
 
     [Test]


### PR DESCRIPTION
Pirate gambling crates weren't included in the ignore list 
