### PR TITLE
High Value Target

### DIFF
--- a/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
+++ b/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.GameTicking.Rules;
 using Content.Server.Revolutionary.Components;
 using Robust.Shared.Random;
 using System.Linq;
+using Content.Server._Moffstation.Objectives.Systems; // Moffstation - Adding high value targets
 
 namespace Content.Server.Objectives.Systems;
 
@@ -19,6 +20,7 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly TraitorRuleSystem _traitorRule = default!;
 
+    [Dependency] private readonly HighValueTargetSelectionSystem _hvtSystem = default!; // Moffstation - Adding high-value targets
     public override void Initialize()
     {
         base.Initialize();
@@ -91,7 +93,11 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
             return;
         }
 
-        _target.SetTarget(ent.Owner, _random.Pick(allHumans), target);
+        // Moffstation - Start - Added high-value target
+        _hvtSystem.SelectTarget(ent.Owner, null, allHumans.ToList(), out var selectedHuman);
+
+        _target.SetTarget(ent.Owner, selectedHuman, target);
+        // Moffstation - End
     }
 
     private void OnRandomHeadAssigned(Entity<PickRandomHeadComponent> ent, ref ObjectiveAssignedEvent args)
@@ -125,7 +131,11 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
         if (allHeads.Count == 0)
             allHeads = allHumans; // fallback to non-head target
 
-        _target.SetTarget(ent.Owner, _random.Pick(allHeads), target);
+        // Moffstation - Start - Adding high-value targets
+        _hvtSystem.SelectTarget(ent.Owner, null, allHumans.ToList(), out var selectedHuman);
+
+        _target.SetTarget(ent.Owner, selectedHuman, target);
+        // Moffstation - end
     }
 
     private void OnRandomTraitorProgressAssigned(Entity<RandomTraitorProgressComponent> ent, ref ObjectiveAssignedEvent args)

--- a/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
+++ b/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.GameTicking.Rules;
 using Content.Server.Revolutionary.Components;
 using Robust.Shared.Random;
 using System.Linq;
+using Content.Server._Moffstation.Objectives.Components;
 using Content.Server._Moffstation.Objectives.Systems; // Moffstation - Adding high value targets
 
 namespace Content.Server.Objectives.Systems;
@@ -94,7 +95,9 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
         }
 
         // Moffstation - Start - Added high-value target
-        _hvtSystem.SelectTarget(ent.Owner, null, allHumans.ToList(), out var selectedHuman);
+        var selectedHuman = _random.Pick(allHumans);
+        if (TryComp<HighValueTargetSelectionComponent>(ent.Owner, out var hvt))
+            selectedHuman = _hvtSystem.SelectTarget((ent.Owner, hvt), allHumans);
 
         _target.SetTarget(ent.Owner, selectedHuman, target);
         // Moffstation - End
@@ -132,7 +135,9 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
             allHeads = allHumans; // fallback to non-head target
 
         // Moffstation - Start - Adding high-value targets
-        _hvtSystem.SelectTarget(ent.Owner, null, allHumans.ToList(), out var selectedHuman);
+        var selectedHuman = _random.Pick(allHeads);
+        if (TryComp<HighValueTargetSelectionComponent>(ent.Owner, out var hvt))
+            selectedHuman = _hvtSystem.SelectTarget((ent.Owner, hvt), allHeads);
 
         _target.SetTarget(ent.Owner, selectedHuman, target);
         // Moffstation - end

--- a/Content.Server/_Moffstation/Objectives/Components/HighValueTargetSelectionComponent.cs
+++ b/Content.Server/_Moffstation/Objectives/Components/HighValueTargetSelectionComponent.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Moffstation.Objectives.Components;
+
+/// <summary>
+/// This is used to mark objectives which select random people and prioritize high value targets
+/// </summary>
+[RegisterComponent]
+public sealed partial class HighValueTargetSelectionComponent : Component
+{
+    /// <summary>
+    /// The antag prototype selected from each possible target's preferences
+    /// </summary>
+    [DataField, Required]
+    public ProtoId<AntagPrototype> HighValueTargetPrototype = "HighValueTarget";
+
+    /// <summary>
+    /// If the selected individual is not a high value target, how likely are they to be re-rolled?
+    /// </summary>
+    [DataField]
+    public float RerollProbability = 0.8f;
+}

--- a/Content.Server/_Moffstation/Objectives/Components/HighValueTargetSelectionComponent.cs
+++ b/Content.Server/_Moffstation/Objectives/Components/HighValueTargetSelectionComponent.cs
@@ -17,8 +17,8 @@ public sealed partial class HighValueTargetSelectionComponent : Component
     public ProtoId<AntagPrototype> HighValueTargetPrototype = "HighValueTarget";
 
     /// <summary>
-    /// If the selected individual is not a high value target, how likely are they to be re-rolled?
+    /// If the selected individual is not a high value target, how likely are they to be selected anyway?
     /// </summary>
     [DataField]
-    public float RerollProbability = 0.8f;
+    public float NonTargetSelectionProbability = 0.5f;
 }

--- a/Content.Server/_Moffstation/Objectives/Components/HighValueTargetSelectionComponent.cs
+++ b/Content.Server/_Moffstation/Objectives/Components/HighValueTargetSelectionComponent.cs
@@ -20,5 +20,5 @@ public sealed partial class HighValueTargetSelectionComponent : Component
     /// If the selected individual is not a high value target, how likely are they to be selected anyway?
     /// </summary>
     [DataField]
-    public float NonTargetSelectionProbability = 0.5f;
+    public float NonTargetSelectionProbability = 0.3f;
 }

--- a/Content.Server/_Moffstation/Objectives/Systems/HighValueTargetSelectionSystem.cs
+++ b/Content.Server/_Moffstation/Objectives/Systems/HighValueTargetSelectionSystem.cs
@@ -1,0 +1,54 @@
+using Content.Server._Moffstation.Objectives.Components;
+using Content.Server.Preferences.Managers;
+using Content.Shared.Mind;
+using Content.Shared.Preferences;
+using Robust.Shared.Random;
+
+namespace Content.Server._Moffstation.Objectives.Systems;
+
+/// <summary>
+/// This handles selecting a high-value target for any systems that select random targets.
+/// </summary>
+public sealed class HighValueTargetSelectionSystem : EntitySystem
+{
+    [Dependency] private readonly IServerPreferencesManager _pref = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    /// <summary>
+    /// Selects a target from the list of possible targets with a priority on those with
+    /// the High Value Target role selected.
+    /// </summary>
+    public bool SelectTarget(
+        EntityUid rule,
+        HighValueTargetSelectionComponent? component,
+        List<Entity<MindComponent>> allPossibleTargets,
+        out Entity<MindComponent> target)
+    {
+        if (!Resolve(rule, ref component))
+        {
+            target = _random.Pick(allPossibleTargets);
+            return true;
+        }
+
+        _random.Shuffle(allPossibleTargets);
+        var targetQueue = new Queue<Entity<MindComponent>>(allPossibleTargets);
+
+        while (targetQueue.Count > 1)
+        {
+            var mind = targetQueue.Dequeue();
+            if (mind.Comp.UserId is not { } userId)
+                continue;
+
+            var pref = (HumanoidCharacterProfile) _pref.GetPreferences(userId).SelectedCharacter;
+            if (!pref.AntagPreferences.Contains(component.HighValueTargetPrototype)
+                && _random.Prob(component.RerollProbability))
+                continue;
+
+            target = mind;
+            return true;
+        }
+
+        target = targetQueue.Peek();
+        return true;
+    }
+}

--- a/Resources/Locale/en-US/_Moffstation/roles/antags.ftl
+++ b/Resources/Locale/en-US/_Moffstation/roles/antags.ftl
@@ -69,3 +69,8 @@ lpo-existing = [color=Crimson]Syndicate Listening Outpost[/color]
 lpo-list-start = The outpost was operated by:
 lpo-list-name = [color=White]{$name}[/color]
 lpo-list-name-user = [color=White]{$name}[/color] ([color=gray]{$user}[/color])
+
+# High Value Target
+
+roles-high-value-target = High Value Target
+roles-high-value-target-objective = You are a high-value target for the syndicate. Contracts are more likely to target you than other crew members.

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -91,6 +91,7 @@
   - type: TargetObjective
     title: objective-condition-maroon-person-title
   - type: PickRandomPerson
+  - type: HighValueTargetSelection # Moffstation - Add High Value Target
   - type: KillPersonCondition
     requireMaroon: true
 
@@ -107,6 +108,7 @@
   - type: TargetObjective
     title: objective-condition-kill-maroon-title
   - type: PickRandomHead
+  - type: HighValueTargetSelection # Moffstation - Add High Value Target
   - type: KillPersonCondition
     # don't count missing evac as killing as heads are higher profile, so you really need to do the dirty work
     # if ce flies a shittle to centcom you better find a way onto it

--- a/Resources/Prototypes/_Moffstation/Objectives/open_objectives.yml
+++ b/Resources/Prototypes/_Moffstation/Objectives/open_objectives.yml
@@ -123,6 +123,7 @@
   - type: TargetObjective
     title: objective-condition-teach-lesson
   - type: PickRandomPerson
+  - type: HighValueTargetSelection
   - type: EscapeShuttleCondition
 
 ## gather intel on someone
@@ -139,6 +140,7 @@
   - type: TargetObjective
     title: objective-condition-gather-intel
   - type: PickRandomPerson
+  - type: HighValueTargetSelection
   - type: EscapeShuttleCondition
 
 # Open-ended objective to leave a calling card
@@ -177,6 +179,7 @@
   - type: TargetObjective
     title: objective-condition-leave-card-on-person
   - type: PickRandomPerson
+  - type: HighValueTargetSelection
   - type: EscapeShuttleCondition
   - type: ObjectiveBlacklistRequirement
     blacklist:

--- a/Resources/Prototypes/_Moffstation/Roles/Antags/syndicate.yml
+++ b/Resources/Prototypes/_Moffstation/Roles/Antags/syndicate.yml
@@ -15,3 +15,14 @@
     shoes: ClothingShoesBootsLaceup
     id: SyndiPDA
     pocket2: WeaponPistolViper
+
+# High value target preference
+# Not actually given out, but used when determining targets for antags.
+- type: antag
+  id: HighValueTarget
+  name: roles-high-value-target
+  setPreference: true
+  objective: roles-high-value-target-objective
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 50h


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->

Adds the ability for people to set themselves as high value targets for the syndicate which will increase their odds of being selected as targets for any objectives which target random people.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Some people prefer to be targeted more, while others prefer to be targeted less by antags, this helps provide the former with a method to somewhat protect the latter.

## Technical details
<!-- Summary of code changes for easier review. -->

Adds a component called `HighValueTargetComponent` which can be added to objective prototypes to enable this feature. 
The `SelectRandomPerson` and `SelectRandomHead` methods have been given a call to `HighValueTargetSystem` which performs the selection based on the component, if the component is missing then it simply returns a random person like usual.

This can also in theory be used to have syndicate objectives target other roles as well, anything that's a valid role prototype would work and can be selected in the component. 

The actual method this uses to select someone randomly is that it first takes a shuffled list of all valid targets, then dequeues the first one, if that player has the High Value Target preference set, then they are immediately selected as the target. If not, then a die is rolled to determine whether to still return that person, or dequeue another person and repeat the process. The value of the die role is also configurable in the component so some objectives can be set to have higher bias towards high value targets than others. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Southbridge
- add: You can now set yourself as a high-value target, causing the syndicate to target you more often.
