### PR TITLE
Allow trinkets to be inserted into Survival Box

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/base_clothinghands.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/base_clothinghands.yml
@@ -72,6 +72,7 @@
   - type: Tag
     tags:
     - Ring
+    - SurvivalBoxInsertable #Moffstation - allow trinkets to be placed in Survival Box
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -54,6 +54,13 @@
   - type: Construction
     graph: flowerwreath
     node: flowerwreath
+  # Moffstation - Start - allow trinkets to be placed in Survival Box
+  - type: Tag
+    tags:
+    - ClothMade
+    - WhitelistChameleon
+    - SurvivalBoxInsertable
+# Moffstation - End
 
 - type: entity
   parent: ClothingHeadLightBase
@@ -368,6 +375,13 @@
     sprite: Clothing/Head/Misc/hairflower.rsi
   - type: Clothing
     sprite: Clothing/Head/Misc/hairflower.rsi
+  # Moffstation - Start - allow trinkets to be placed in Survival Box
+  - type: Tag
+    tags:
+    - ClothMade
+    - WhitelistChameleon
+    - SurvivalBoxInsertable
+  # Moffstation - End
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
@@ -9,13 +9,13 @@
     sprite: Clothing/Multiple/towel.rsi
   - type: Clothing
     sprite: Clothing/Multiple/towel.rsi
-    slots: 
+    slots:
     - BELT
     - INNERCLOTHING
     - HEAD
     femaleMask: UniformTop
-    equipSound: 
-    unequipSound: 
+    equipSound:
+    unequipSound:
   - type: Spillable
     solution: absorbed
     spillWhenThrown: false
@@ -39,6 +39,14 @@
   - type: DnaSubstanceTrace
   - type: Item
     size: Small
+  # Moffstation - Start - allow trinkets to be placed in Survival Box
+  - type: Tag
+    tags:
+    - ClothMade
+    - WhitelistChameleon
+    - Recyclable
+    - SurvivalBoxInsertable
+  # Moffstation - End
 
 - type: entity
   id: TowelColorWhite
@@ -163,7 +171,7 @@
         color: "#0089EF"
   - type: Fiber
     fiberColor: fibers-blue
-    
+
 - type: entity
   id: TowelColorDarkBlue
   name: dark blue towel
@@ -766,4 +774,3 @@
         color: "#535353"
   - type: Fiber
     fiberColor: fibers-black
-    

--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -11,6 +11,14 @@
     sprite: Clothing/Neck/Misc/pins.rsi
   - type: Clothing
     sprite: Clothing/Neck/Misc/pins.rsi
+  # Moffstation - Start - allow trinkets to be placed in Survival Box
+  - type: Tag
+    tags:
+    - ClothMade
+    - WhitelistChameleon
+    - Recyclable
+    - SurvivalBoxInsertable
+  # Moffstation - End
 
 - type: entity
   parent: ClothingNeckPinBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -39,6 +39,7 @@
     tags:
     - CigPack
     - Trash
+    - SurvivalBoxInsertable #Moffstation - allow "trinkets" to be placed in Survival Box
   - type: PhysicalComposition
     materialComposition:
       Steel: 50

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -15,6 +15,7 @@
   - type: Tag
     tags:
     - Trash
+    - SurvivalBoxInsertable #Moffstation - allow trinkets to be placed in Survival Box
   - type: SpaceGarbage
   - type: StaticPrice
     price: 5

--- a/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
@@ -48,6 +48,11 @@
     tags:
     - Payload
     - ClothMade
+    - SurvivalBoxInsertable # Moffstation - allow trinkets to be placed in Survival Box
+  # Moffstation - Start - allow trinkets to be placed in Survival Box
+  - type: Item
+    size: Small
+  # Moffstation - End
 
 - type: entity
   parent: BasePlushie

--- a/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
@@ -356,6 +356,7 @@
     sprite: Objects/Fun/Plushies/lizard.rsi
     state: icon
   - type: Item
+    size: Small # Moffstation - allow trinkets to be placed in Survival Box
     sprite: Objects/Fun/Plushies/lizard.rsi
   - type: EmitSoundOnUse
     sound: &PlushieLizardSound
@@ -405,6 +406,7 @@
     - Payload
     - ClothMade
     - PlushieLizard
+    - SurvivalBoxInsertable # Moffstation - allow trinkets to be placed in Survival Box
 
 - type: entity
   parent: BasePlushie
@@ -416,6 +418,7 @@
     sprite: Objects/Fun/Plushies/expi.rsi
     state: icon
   - type: Item
+    size: Small # Moffstation - allow trinkets to be placed in Survival Box
     sprite: Objects/Fun/Plushies/expi.rsi
     inhandVisuals:
       left:
@@ -459,6 +462,7 @@
     tags:
     - Payload
     - ClothMade
+    - SurvivalBoxInsertable # Moffstation - allow trinkets to be placed in Survival Box
 
 - type: entity
   parent: PlushieLizard
@@ -479,6 +483,7 @@
       - state: rainbowlizardplush-equipped-HELMET
         shader: unshaded
   - type: Item
+    size: Small # Moffstation - allow trinkets to be placed in Survival Box
     inhandVisuals:
       left:
       - state: rainbowlizardplush-inhand-left
@@ -506,6 +511,7 @@
     sprite: Objects/Fun/Plushies/lizard.rsi
     state: plushie_spacelizard
   - type: Item
+    size: Small # Moffstation - allow trinkets to be placed in Survival Box
     sprite: Objects/Fun/Plushies/lizard.rsi
     heldPrefix: spacelizard
   - type: EmitSoundOnUse
@@ -549,6 +555,7 @@
   - type: Sprite
     state: plushie_lizard_inversed
   - type: Item
+    size: Small # Moffstation - allow trinkets to be placed in Survival Box
     heldPrefix: plushielizardinversed
   - type: EmitSoundOnUse
     sound: &PlushieLizardInversedSound
@@ -814,6 +821,7 @@
     sprite: Objects/Fun/Plushies/carp.rsi
     state: carpplush
   - type: Item
+    size: Small # Moffstation - allow trinkets to be placed in Survival Box
     sprite: Objects/Fun/Plushies/carp.rsi
     heldPrefix: carpplush
     storedRotation: -90
@@ -860,6 +868,7 @@
   - type: Sprite
     state: magicplush
   - type: Item
+    size: Small # Moffstation - allow trinkets to be placed in Survival Box
     inhandVisuals:
       left:
       - state: magicarpplush-inhand-left
@@ -905,6 +914,7 @@
   - type: Sprite
     state: holoplush
   - type: Item
+    size: Small # Moffstation - allow trinkets to be placed in Survival Box
     inhandVisuals:
       left:
       - state: holocarpplush-inhand-left
@@ -930,6 +940,7 @@
     sprite: _Moffstation/Objects/Fun/Plushies/slime.rsi
     state: icon
   - type: Item
+    size: Small # Moffstation - allow trinkets to be placed in Survival Box
     sprite: _Moffstation/Objects/Fun/Plushies/slime.rsi
   #  Moffstation - End
   - type: EmitSoundOnUse
@@ -967,6 +978,7 @@
     sprite: Objects/Fun/Plushies/snake.rsi
     state: icon
   - type: Item
+    size: Small # Moffstation - allow trinkets to be placed in Survival Box
     heldPrefix: plushiesnake
   - type: EmitSoundOnUse
     sound:

--- a/Resources/Prototypes/Entities/Objects/Misc/candles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/candles.yml
@@ -7,6 +7,7 @@
     - type: Tag
       tags:
       - Candle
+      - SurvivalBoxInsertable #Moffstation - Allow trinkets to be placed in Survival Box
     - type: Sprite
       noRot: true
       sprite: Objects/Misc/candles.rsi

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -89,6 +89,11 @@
     color: orange
   - type: ItemTogglePointLight
   - type: PhysicalComposition
+  # Moffstation - Start - allow trinkets to be placed in Survival Box
+  - type: Tag
+    tags:
+    - SurvivalBoxInsertable
+  # Moffstation - End
 
 - type: entity
   name: cheap lighter
@@ -609,6 +614,7 @@
     tags:
     - DonkPocket
     - Meat
+    - SurvivalBoxInsertable #Moffstation - Allow trinkets to be placed in Survival Box
   - type: SolutionContainerManager
     solutions:
       Welder:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
added sizing and whitelist tag to select trinkets - most of which are available roundstart.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Another change to follow the removal of the nutribrick; while many folks will start with a survival guide, they'll likely want something to fill that space after they toss it into disposals. This allows for crew members to put most (but not all!) trinkets they can obtain from their loadout into the box, as these items generally tend to be small, as well as a few select items that are tangential to these loadouts (like rings, or other small plushies).

## Technical details
<!-- Summary of code changes for easier review. -->
Identified and added the following to select items:

```
  - type: Item
    size: Small
```

```
  - type: Tag
    tags:
    - SurvivalBoxInsertable
```

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="140" height="109" alt="image" src="https://github.com/user-attachments/assets/0e532a45-a0b4-47a3-b029-093e7d68eadb" />

Weh!

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

🆑 
-tweak: Whitelisted many roundstart trinkets to be placed within the Survival Box!
