### PR TITLE
Gamerules adjustments

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -169,7 +169,7 @@
     weight: 6.5
     earliestStart: 40
     reoccurrenceDelay: 20
-    minimumPlayers: 20
+    minimumPlayers: 30  # Moffstation - Tune down antags
     duration: null
   - type: SpaceSpawnRule
     spawnDistance: 0
@@ -253,7 +253,7 @@
     duration: null
     earliestStart: 20
     reoccurrenceDelay: 20
-    minimumPlayers: 15
+    minimumPlayers: 20  # Moffstation - Tune down antags
   - type: ParadoxCloneRule
     objectiveBlacklist:
       tags:
@@ -303,7 +303,7 @@
     duration: 1
     earliestStart: 30
     reoccurrenceDelay: 60
-    minimumPlayers: 10
+    minimumPlayers: 30  # Moffstation - Tune down antags
   - type: AntagSelection
     agentName: wizard-round-end-name
     definitions:
@@ -543,7 +543,7 @@
   - type: StationEvent
     earliestStart: 35
     weight: 5.5
-    minimumPlayers: 20
+    minimumPlayers: 30 # Moffstation - Tune down antags
     duration: null # LoneOpsSpawn needs an infinite duration so that it inherits the NukeOpsRule things of an actually appropriate end scrreen (not always "Neutral outcome!") and... ending the game if the station is nuked.
   - type: RuleGrids
   - type: LoadMapRule
@@ -582,7 +582,7 @@
   - type: StationEvent
     earliestStart: 30
     weight: 8
-    minimumPlayers: 15
+    minimumPlayers: 25  # Moffstation - Tune down antags
     maxOccurrences: 1 # can only happen once per round
     startAnnouncement: station-event-communication-interception
     startAudio:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -16,11 +16,10 @@
 
 - type: entity
   parent: BaseGameRule
-  id: SubGamemodesRule
+  id: SubGamemodesRuleUpstream  # Moffstation - Moved to our namespace
   components:
   - type: SubGamemodes
     rules:
-    # Moffstation - Start
     - id: Thief
       prob: 0.3
     - id: BloodBrothers
@@ -31,22 +30,6 @@
       prob: 0.15
     - id: SubWizard
       prob: 0.05
-
-- type: entity
-  parent: BaseGameRule
-  id: SubGamemodesRuleNoWizard
-  components:
-  - type: SubGamemodes
-    rules:
-    - id: Thief
-      prob: 0.3
-    - id: BloodBrothers
-      prob: 0.3
-    - id: SyndicateListeningOutpost
-      prob: 0.2
-    - id: Pirates
-      prob: 0.2
-    # Moffstation - End
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_Moffstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/roundstart.yml
@@ -1,0 +1,31 @@
+- type: entity
+  parent: BaseGameRule
+  id: SubGamemodesRule
+  components:
+  - type: SubGamemodes
+    rules:
+    - id: Thief
+      prob: 0.3
+    - id: BloodBrothers
+      prob: 0.3
+    - id: SyndicateListeningOutpost
+      prob: 0.20
+    - id: Pirates
+      prob: 0.15
+    - id: SubWizard
+      prob: 0.05
+
+- type: entity
+  parent: BaseGameRule
+  id: SubGamemodesRuleNoWizard
+  components:
+  - type: SubGamemodes
+    rules:
+    - id: Thief
+      prob: 0.3
+    - id: BloodBrothers
+      prob: 0.3
+    - id: SyndicateListeningOutpost
+      prob: 0.2
+    - id: Pirates
+      prob: 0.2

--- a/Resources/Prototypes/_Moffstation/secret_weights.yml
+++ b/Resources/Prototypes/_Moffstation/secret_weights.yml
@@ -1,0 +1,10 @@
+- type: weightedRandom
+  id: Secret
+  weights:
+    Nukeops: 0.20
+    Traitor: 0.60
+    Zombie: 0.05
+    Revolutionary: 0.05
+    Extended: 0.05
+    Greenshift: 0.04
+    Surival: 0.01

--- a/Resources/Prototypes/_Moffstation/secret_weights.yml
+++ b/Resources/Prototypes/_Moffstation/secret_weights.yml
@@ -5,6 +5,5 @@
     Traitor: 0.60
     Zombie: 0.05
     Revolutionary: 0.05
-    Extended: 0.05
-    Greenshift: 0.04
+    Extended: 0.09
     Surival: 0.01

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -40,6 +40,7 @@
     - Revolutionary
     - Zombie
     - Wizard
+    - Pirates # Moffstation
     - KesslerSyndromeScheduler
     - RampingStationEventScheduler
     - SpaceTrafficControlEventScheduler
@@ -61,6 +62,7 @@
     - Revolutionary
     - Zombie
     - Wizard
+    - Pirates # Moffstation
     - BasicStationEventScheduler
     - KesslerSyndromeScheduler
     - MeteorSwarmMildScheduler
@@ -234,22 +236,6 @@
   - Wizard
   - DummyNonAntagChance
   - SubGamemodesRuleNoWizard #No Dual Wizards at the start, midround is fine
-  - BasicStationEventScheduler
-  - MeteorSwarmScheduler
-  - SpaceTrafficControlEventScheduler
-  - BasicRoundstartVariation
-
-- type: gamePreset
-  id: Pirates
-  alias:
-  - pirates
-  name: pirates-title
-  description: pirates-description
-  showInVote: false
-  rules:
-  - Pirates
-  - DummyNonAntagChance
-  - SubGamemodesRule
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,9 +1,9 @@
 - type: weightedRandom
-  id: Secret
+  id: SecretUpstream  # Moffstation - Moved to our namespace
   weights:
     Nukeops: 0.20
-    Traitor: 0.60 # Moffstation - remove wizard from natural spawn
+    Traitor: 0.60
     Zombie: 0.05
     Survival: 0.10
     Revolutionary: 0.05
-#    Wizard: 0.05 # Why not, should probably be lower # Moffstation - remove wizard from natural spawn
+    Wizard: 0.05 # Why not, should probably be lower


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
This PR does a few different things:
- Makes many of the midround antags require a higher playercount to spawn.
- Makes survival extremely rare
- Adds extended and greenshift to the rotation
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As a lowpop server, sec often gets swamped from midround antags compounding ontop of the normal antags. This should help mitigate that.
Additionally, it seems like most people don't enjoy survival shifts, especially sec and command. People may say the extended or greenshifts are "boring" but I honestly think we need more low-intensity shifts, also they're a good chance for people to relax and RP.
## Technical details
<!-- Summary of code changes for easier review. -->
Namespaced some of our stuff
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Tweaked midround antag weights
- tweak: Replaced survival with extended and greenshift
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
