### PR TITLE
Malds the [Mald PR] Plushie sound 1984

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
@@ -19,7 +19,7 @@
   - type: EmitSoundOnTrigger
     sound: *BasePlushieSound
   # - type: UseDelay # MoffStation: Reverts Plushie nerf
-  #   delay: 3.0
+  #   delay: 3.0 # MoffStation: Reverts Plushie nerf
   - type: MeleeWeapon
     # attackRate: 0.333 # MoffStation: Reverts Plushie nerf
     wideAnimationRotation: 180

--- a/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
@@ -18,7 +18,10 @@
     sound: *BasePlushieSound
   - type: EmitSoundOnTrigger
     sound: *BasePlushieSound
+  # - type: UseDelay # MoffStation: Reverts Plushie nerf
+  #   delay: 3.0
   - type: MeleeWeapon
+    # attackRate: 0.333 # MoffStation: Reverts Plushie nerf
     wideAnimationRotation: 180
     soundHit: *BasePlushieSound
     damage:

--- a/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
@@ -18,10 +18,7 @@
     sound: *BasePlushieSound
   - type: EmitSoundOnTrigger
     sound: *BasePlushieSound
-  - type: UseDelay
-    delay: 3.0
   - type: MeleeWeapon
-    attackRate: 0.333
     wideAnimationRotation: 180
     soundHit: *BasePlushieSound
     damage:


### PR DESCRIPTION
## About the PR
Reverts the UseDelay and Attack Cooldown changes to all plushies allowing them be used normally. Moff doesn't have a significant amount of players compared to upstream and is therefore not much of a problem there.

This keeps the Plushie sound decreases however.

## Why / Balance
As Above

## Technical details
Removes the UseDelay and attackRate in MeleeWeapon in BasePlushie

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Changed Plushies attack and useDelay back to normal. They still remain a bit quieter!
