### PR TITLE
Fix typo in Secret Gamemode weights

### DIFF
--- a/Resources/Prototypes/_Moffstation/secret_weights.yml
+++ b/Resources/Prototypes/_Moffstation/secret_weights.yml
@@ -6,4 +6,4 @@
     Zombie: 0.05
     Revolutionary: 0.05
     Extended: 0.09
-    Surival: 0.01
+    Survival: 0.01


### PR DESCRIPTION
Fixes 1/100 test fail:

<img width="707" height="148" alt="image" src="https://github.com/user-attachments/assets/fec0ec96-bdab-407f-acb5-dbfe7b7b7329" />
