### PR TITLE
Make common channel intercom-only

### DIFF
--- a/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
+++ b/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Radio.Components;
 using Content.Shared.Radio.EntitySystems;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Radio.EntitySystems;
 
@@ -14,6 +15,8 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
 {
     [Dependency] private readonly INetManager _netMan = default!;
     [Dependency] private readonly RadioSystem _radio = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
 
     public override void Initialize()
     {
@@ -50,7 +53,10 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
     {
         if (args.Channel != null
             && TryComp(component.Headset, out EncryptionKeyHolderComponent? keys)
-            && keys.Channels.Contains(args.Channel.ID))
+            // Moffstation - start - Remove common
+            && keys.Channels.Contains(args.Channel.ID)
+            && !_prototypeManager.Index<RadioChannelPrototype>(args.Channel.ID).ReadOnly)
+            // Moffstation - end
         {
             _radio.SendRadioMessage(uid, args.Message, args.Channel, component.Headset);
             args.Channel = null; // prevent duplicate messages from other listeners.

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -218,7 +218,8 @@ public sealed partial class EncryptionKeySystem : EntitySystem
                 ? SharedChatSystem.RadioCommonPrefix.ToString()
                 : $"{SharedChatSystem.RadioChannelPrefix}{proto.KeyCode}";
 
-            examineEvent.PushMarkup(Loc.GetString(channelFTLPattern,
+            // Moffstation - Remove common
+            examineEvent.PushMarkup(Loc.GetString(proto.ReadOnly ? "examine-encryption-readonly-channel" : channelFTLPattern,
                 ("color", proto.Color),
                 ("key", key),
                 ("id", proto.LocalizedName),

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -35,4 +35,12 @@ public sealed partial class RadioChannelPrototype : IPrototype
     /// </summary>
     [DataField("longRange"), ViewVariables]
     public bool LongRange = false;
+
+    // Moffstation - Start - Remove common from headsets
+    /// <summary>
+    /// If true, the channel will be readonly by headsets, and can only be spoken into by other means.
+    /// </summary>
+    [DataField]
+    public bool ReadOnly;
+    // Moffstation - End
 }

--- a/Resources/Locale/en-US/_Moffstation/headset/headset.ftl
+++ b/Resources/Locale/en-US/_Moffstation/headset/headset.ftl
@@ -1,0 +1,1 @@
+examine-encryption-readonly-channel = [color={$color}]{$id} is read-only ({NATURALFIXED($freq, 1)})[/color]

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -4,6 +4,7 @@
   keycode: ";"
   frequency: 1459
   color: "#2cdb2c"
+  readOnly: true # Moffstation - Remove common
 
 - type: radioChannel
   id: CentCom


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
This makes the common channel read-only for headsets, intercoms can still be used to talk over common.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
There was much debate about this when brought on the discord, with the conclusion from both sides being test it and see how it goes, but to revert if it's bad. This is a pretty impactful change in many ways, so I'll provide a list of reasons why this would be a positive change.
- Right now, the most common way departments interact with eachother is over the common radio. By increasing the barrier to use it, it's more likely that departments will interact with eachother via more personal means.
- Holopads and nanochat are both more personal ways of contacting other people, but are chronically underused. This should encourage these features to be used more.
- Makes radio usage more meaningful, radio feeds will consist of more important messages which will be easier to find.
- Encourages bar usage. If there's less full conversations happening over the radio, the bar will gain more meaning as a social gathering place.
- Adds more special responsibility to command, especially Captain, HoP, and the AI to relay information between departments quickly. (should be noted that the AI can still talk to the common channel directly)
- Reduces common channel shitposting
- Rather than the whole crew being prepared the moment a single tider spots a threat to the station, I think a disconnect would create interesting gameplay where certain members of the crew have varying levels of info about whats going on.
- A similar fork to us, Impstation, has had a similar feature implemented for a while without any major issues. (They are a private MRP fork. Their pop is similar to ours, but is generally higher)
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Common radio is now read-only, and can only be spoken into via intercoms
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
