### PR TITLE
Revert science cyborg modules back to generalized use

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -105,6 +105,7 @@
           - BorgModuleGeneric
           - BorgModuleSyndicate
           - BorgModuleSyndicateAssault
+          - BorgModuleScience #Moffstation - Generic borg is not sciborg
       hasMindState: synd_sec_e
       noMindState: synd_sec
     - type: InteractionPopup
@@ -137,6 +138,7 @@
           - BorgModuleGeneric
           - BorgModuleMedical
           - BorgModuleSyndicate
+          - BorgModuleScience #Moffstation - Generic borg is not sciborg
       hasMindState: synd_medical_e
       noMindState: synd_medical
     - type: ShowHealthBars
@@ -176,6 +178,7 @@
           - BorgModuleGeneric
           - BorgModuleEngineering
           - BorgModuleSyndicate
+          - BorgModuleScience #Moffstation - Generic borg is not sciborg
       hasMindState: synd_engi_e
       noMindState: synd_engi
     - type: ShowHealthBars
@@ -210,6 +213,7 @@
     moduleWhitelist:
       tags:
       - BorgModuleGeneric
+      - BorgModuleScience #Moffstation - Generic borg is not sciborg
     hasMindState: derelict_e
     noMindState: derelict_e_r
   - type: Construction
@@ -247,6 +251,7 @@
       tags:
       - BorgModuleGeneric
       - BorgModuleEngineering
+      - BorgModuleScience #Moffstation - Generic borg is not sciborg
     hasMindState: engineer_e
     noMindState: engineer_e_r
 
@@ -281,6 +286,7 @@
       tags:
       - BorgModuleGeneric
       - BorgModuleJanitor
+      - BorgModuleScience #Moffstation - Generic borg is not sciborg
     hasMindState: janitor_e
     noMindState: janitor_e_r
 
@@ -315,6 +321,7 @@
       tags:
       - BorgModuleGeneric
       - BorgModuleMedical
+      - BorgModuleScience #Moffstation - Generic borg is not sciborg
     hasMindState: medical_e
     noMindState: medical_e_r
   - type: SolutionScanner
@@ -356,6 +363,7 @@
       tags:
       - BorgModuleGeneric
       - BorgModuleCargo
+      - BorgModuleScience #Moffstation - Generic borg is not sciborg
     hasMindState: miner_e
     noMindState: miner_e_r
 
@@ -383,6 +391,7 @@
       - BorgModuleGeneric
       - BorgModuleSyndicate
       - BorgModuleSyndicateAssault
+      - BorgModuleScience #Moffstation - Generic borg is not sciborg
     hasMindState: synd_sec_derelict_e
     noMindState: synd_sec_derelict
   - type: Construction

--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -41,6 +41,8 @@
   - BorgModuleAdvancedClowning
   - BorgModuleAdvancedChemical
   - BorgModuleAdvancedMining
+  - BorgModuleAnomaly #Moffstation - Generic borg is not sciborg
+  - BorgModuleArtifact #Moffstation - Generic borg is not sciborg
 
 - type: latheRecipePack
   id: MechParts

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -27,6 +27,7 @@
   - AnomalyLocatorWide
   - APECircuitboard
   - AnomalyVesselCircuitboard
+  - BorgModuleAnomaly #Moffstation - Generic borg is not sciborg
 
 - type: technology
   id: BasicXenoArcheology
@@ -41,6 +42,7 @@
   - NodeScanner
   - AnalysisComputerCircuitboard
   - ArtifactAnalyzerMachineCircuitboard
+  - BorgModuleArtifact #Moffstation - Generic borg is not sciborg
 
 - type: technology
   id: AlternativeResearch

--- a/Resources/Prototypes/_Moffstation/Recipes/Lathes/robot_modules.yml
+++ b/Resources/Prototypes/_Moffstation/Recipes/Lathes/robot_modules.yml
@@ -1,0 +1,11 @@
+﻿# Science Modules
+
+- type: latheRecipe
+  parent: BaseGoldBorgModuleRecipe
+  id: BorgModuleAnomaly
+  result: BorgModuleAnomaly
+
+- type: latheRecipe
+  parent: BaseGoldBorgModuleRecipe
+  id: BorgModuleArtifact
+  result: BorgModuleArtifact

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -15,8 +15,8 @@
   defaultModules:
   - BorgModuleTool
   - BorgModuleInflatable
-  - BorgModuleArtifact
-  - BorgModuleAnomaly
+#  - BorgModuleArtifact #Moffstation - Generic borg is not sciborg
+#  - BorgModuleAnomaly #Moffstation - Generic borg is not sciborg
   radioChannels:
   - Science
 
@@ -53,6 +53,7 @@
     tags:
     - BorgModuleGeneric
     - BorgModuleEngineering
+    - BorgModuleScience #Moffstation - Generic borg is not sciborg
 
   defaultModules:
   - BorgModuleTool
@@ -97,6 +98,7 @@
     tags:
     - BorgModuleGeneric
     - BorgModuleCargo
+    - BorgModuleScience #Moffstation - Generic borg is not sciborg
 
   defaultModules:
   - BorgModuleTool
@@ -142,6 +144,7 @@
     tags:
     - BorgModuleGeneric
     - BorgModuleJanitor
+    - BorgModuleScience #Moffstation - Generic borg is not sciborg
 
   defaultModules:
   - BorgModuleTool
@@ -186,6 +189,7 @@
     tags:
     - BorgModuleGeneric
     - BorgModuleMedical
+    - BorgModuleScience #Moffstation - Generic borg is not sciborg
 
   defaultModules:
   - BorgModuleTool
@@ -244,6 +248,7 @@
     tags:
     - BorgModuleGeneric
     - BorgModuleService
+    - BorgModuleScience #Moffstation - Generic borg is not sciborg
 
   defaultModules:
   - BorgModuleTool


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Removed science cyborg modules base generic cyborg, and re-enabled their use for all cyborg types.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Generic borgs are not science borgs, it's that simple. Generic borgs are characterized by trading off specialized modules for an increased total module capacity, with the intention of increasing their overall flexibility. Now while this ideal may not be fully realized at this time, as borgs currently suffer from a lack of generic modules to choose from, binding the science modules explicitly to the generic chassis is not the way to support this concept. This PR fixes this this, by restoring science modules back to their research trees, and allows all borgs to accept science modules.

## Technical details
<!-- Summary of code changes for easier review. -->
- Added 'BorgModuleScience' whitelist tags to all borg models.
- Removed 'BorgModuleAnomaly' and 'BorgModuleArtifact' from generic chassis.
- readded 'BorgModuleAnomaly' and 'BorgModuleArtifact' to experiemental research and exosuit fabricator lathe dynamic pack.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="648" height="450" alt="image" src="https://github.com/user-attachments/assets/c83fe22f-a264-488f-b6bb-bc192f1aa17a" />

_A distinguished Makeshifter with an anomaly module, like the founders of Nanotrasen intended._

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- remove: Generic borgs no longer start with science modules.
- add: Science modules can now be crafted again, and fit into any borg.