### PR TITLE
Revert "Disposals damage (#431)"

### DIFF
--- a/Content.Server/Disposal/Tube/DisposalTubeComponent.cs
+++ b/Content.Server/Disposal/Tube/DisposalTubeComponent.cs
@@ -32,7 +32,7 @@ public sealed partial class DisposalTubeComponent : Component
     {
         DamageDict = new()
         {
-            { "Blunt", 3.0 }, // Moffstation - Blunt damage from dispos
+            { "Blunt", 0.0 },
         }
     };
 }

--- a/Content.Server/Disposal/Unit/DisposableSystem.cs
+++ b/Content.Server/Disposal/Unit/DisposableSystem.cs
@@ -2,11 +2,8 @@ using Content.Server.Atmos.EntitySystems;
 using Content.Server.Disposal.Tube;
 using Content.Shared.Body.Components;
 using Content.Shared.Damage;
-using Content.Shared.Damage.Components; // Moffstation
 using Content.Shared.Disposal.Components;
 using Content.Shared.Item;
-using Content.Shared.Mobs;  // Moffstation
-using Content.Shared.Mobs.Components;   // Moffstation
 using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
@@ -200,11 +197,7 @@ namespace Content.Server.Disposal.Unit
             {
                 foreach (var ent in holder.Container.ContainedEntities)
                 {
-                    // Moffstation - Start - Only apply damage to mobs, and stop after they're dead
-                    if (TryComp<MobStateComponent>(ent, out var mobState) &&
-                        mobState.CurrentState != MobState.Dead)
-                        _damageable.TryChangeDamage(ent, to.DamageOnTurn);
-                    // Moffstation - End
+                    _damageable.TryChangeDamage(ent, to.DamageOnTurn);
                 }
                 _audio.PlayPvs(to.ClangSound, toUid);
             }


### PR DESCRIPTION
This reverts commit 06767906e8f628fcd7cdb8bab5a148a22281bfe3.

## About the PR
After a month of this being active on Moffstation a number of issues with the change were identified.
These included but were not limited to:
*Unintentional murder of small animals.
*Inconsistency of damage depending on map and location ranging from mild inconvenience to instant death.
*Damage applied to dedicated transport tubes like to AI sat depending on map.
*Identified as too easy method of killing and disposing of bodies. 
*Forcibly limits interactions with silicons who cannot ask crew to use damaging transport systems.

While a number of solutions were suggested to fix these issues, they revolved mostly around making upstream map changes, overhauling, changing the max amount of damage or overhauling the source of the damage. A discord poll also showed that 66% of responders (sample size 48) wanted to lower or remove the damage.

After the public stage meeting on 2025-09-13, discussion was had regarding this feature and determined that the reasons for adding/keeping it were outweighed by issues it presented and the effort required to solve them. 

This PR reverts these changes in their current implemented form.

## Why / Balance
As above.

## Technical details
Reversion of files changed in #431 

## Media
N/A

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- remove: Reverted disposal damage. #431 
