### PR TITLE
Recoil kick doesn't apply when you're weightless

### DIFF
--- a/Content.Shared/Gravity/SharedGravitySystem.cs
+++ b/Content.Shared/Gravity/SharedGravitySystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Moffstation.Weapons.Ranged.Components; // Moffstation
 using Content.Shared.Alert;
 using Content.Shared.Inventory;
 using Content.Shared.Throwing;
@@ -43,6 +44,8 @@ public abstract partial class SharedGravitySystem : EntitySystem
         // Impulse
         SubscribeLocalEvent<GravityAffectedComponent, ShooterImpulseEvent>(OnShooterImpulse);
         SubscribeLocalEvent<GravityAffectedComponent, ThrowerImpulseEvent>(OnThrowerImpulse);
+
+        SubscribeLocalEvent<GravityAffectedComponent, RecoilKickAttemptEvent>(OnRecoilKick); // Moffstation
 
         GravityQuery = GetEntityQuery<GravityComponent>();
         _weightlessQuery = GetEntityQuery<GravityAffectedComponent>();
@@ -235,6 +238,17 @@ public abstract partial class SharedGravitySystem : EntitySystem
     {
         args.Push = true;
     }
+
+    // Moffstation - Begin
+    private void OnRecoilKick(Entity<GravityAffectedComponent> entity, ref RecoilKickAttemptEvent args)
+    {
+        // No recoil kicks while weightless, instead we just use normal `ShooterImpulse`.
+        if (entity.Comp.Weightless)
+        {
+            args.ImpulseEffectivenessFactor = 0f;
+        }
+    }
+    // Moffstation - End
 }
 
 /// <summary>

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -423,6 +423,8 @@ public abstract partial class SharedGunSystem : EntitySystem
 
         var attempt = new RecoilKickAttemptEvent();
         RaiseLocalEvent(user, ref attempt);
+        if (attempt.ImpulseEffectivenessFactor == 0.0f)
+            return false;
         var speed = kick.Impulse * attempt.ImpulseEffectivenessFactor * user.Comp.InvMass / suscept.MassFactor;
 
         var fromMap = TransformSystem.ToMapCoordinates(fromCoordinates).Position;


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Made it so that you don't get recoil kicked (the thing which throws Resomi) if you're weightless. Shooting impulse is totally unaffected.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfix

## Technical details
<!-- Summary of code changes for easier review. -->
There was already a "does anything wanna modify the kick?" event, so I just made it so that being weightless mods it down to 0;
and any time the recoil is modded down to zero, the stamina and stuff doesn't apply either.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
smol

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Resomi no longer get stunned from recoil kick while weightless or while anchored by magboots.
