### PR TITLE
Bugfix - Posters are now destructable

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -18,7 +18,7 @@
         acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
-        damage: 5
+        damage: 15 # Moffstation - Posters are destructable
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -31,6 +31,11 @@
             min: 1
             max: 1
         offset: 0
+  # Moffstation - Start - Posters are destructable
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Card
+  # Moffstation - End
 
 - type: entity
   parent: BaseSign


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Posters can now be destroyed, again.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In upstream PR https://github.com/space-wizards/space-station-14/pull/34329 , prototype 'BaseSign' was changed to parent off of 'BaseWallmountMetallic', giving bar signs structure resistance. However, posters also parent off of BaseSign, turning these adverts into annoyances. This pull request addresses this issue by overriding the Damagable component on 'PosterBase' to give them Card damage modifiers, bringing them back in line with their audio and visual references.

## Technical details
<!-- Summary of code changes for easier review. -->
added the following component override to PosterBase:
```
  - type: Damageable
    damageContainer: StructuralInorganic
    damageModifierSet: Card
```
additionally, changed the damage trigger variable from 5 to 15, so you can't simply punch the poster off the wall with a single swing.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="326" height="271" alt="image" src="https://github.com/user-attachments/assets/d7745bc3-eb01-41a1-91a0-c20b1689fdbd" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- fix: reduced nanotrasen's advertisement budget, posters are now made of cardstock instead of metal.