### PR TITLE
Avali Racial Trait: EMP Weakness

### DIFF
--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -11,7 +11,7 @@ namespace Content.Server.StationEvents.Events;
 public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
 {
     [Dependency] private readonly IonStormSystem _ionStorm = default!;
-    [Dependency] private readonly SharedEmpVulnerableSystem _empVulnerable = default!;
+    [Dependency] private readonly SharedEmpVulnerableSystem _empVulnerable = default!; //Moffstation - EMP Vulnerability
 
     protected override void Started(EntityUid uid, IonStormRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {

--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -4,7 +4,7 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Station.Components;
 //Moffstation - EMP Vulnerability - Begin
-using Content.Shared._Moffstation.Traits;
+using Content.Shared._Moffstation.Traits.Components;
 using Content.Shared._Moffstation.Traits.EntitySystems;
 //Moffstation - End
 

--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -3,8 +3,10 @@ using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Station.Components;
+//Moffstation - EMP Vulnerability - Begin
 using Content.Shared._Moffstation.Traits;
-using Content.Shared._Moffstation.Traits.EntitySystems; //Moffstation - EMP Vulnerability
+using Content.Shared._Moffstation.Traits.EntitySystems;
+//Moffstation - End
 
 namespace Content.Server.StationEvents.Events;
 

--- a/Content.Server/_Moffstation/Traits/EntitySystems/EmpVulnerableSystem.cs
+++ b/Content.Server/_Moffstation/Traits/EntitySystems/EmpVulnerableSystem.cs
@@ -1,0 +1,20 @@
+using Content.Shared._Moffstation.Traits.EntitySystems;
+using Content.Shared._Moffstation.Traits;
+using Content.Server.Emp;
+
+namespace Content.Server._Moffstation.Traits.EntitySystems;
+
+public sealed class EmpVulnerableSystem: SharedEmpVulnerableSystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EmpVulnerableComponent, EmpPulseEvent>(OnEmpPulse);
+    }
+
+    private void OnEmpPulse(EntityUid uid, EmpVulnerableComponent component, EmpPulseEvent ev)
+    {
+        Disrupt(uid, component.EmpStunDuration, component.SlowTo);
+    }
+}

--- a/Content.Server/_Moffstation/Traits/EntitySystems/EmpVulnerableSystem.cs
+++ b/Content.Server/_Moffstation/Traits/EntitySystems/EmpVulnerableSystem.cs
@@ -4,7 +4,7 @@ using Content.Server.Emp;
 
 namespace Content.Server._Moffstation.Traits.EntitySystems;
 
-public sealed class EmpVulnerableSystem: SharedEmpVulnerableSystem
+public sealed class EmpVulnerableSystem : SharedEmpVulnerableSystem
 {
     public override void Initialize()
     {
@@ -13,8 +13,8 @@ public sealed class EmpVulnerableSystem: SharedEmpVulnerableSystem
         SubscribeLocalEvent<EmpVulnerableComponent, EmpPulseEvent>(OnEmpPulse);
     }
 
-    private void OnEmpPulse(EntityUid uid, EmpVulnerableComponent component, EmpPulseEvent ev)
+    private void OnEmpPulse(Entity<EmpVulnerableComponent> entity, ref EmpPulseEvent ev)
     {
-        Disrupt(uid, component.EmpStunDuration);
+        Disrupt(entity, entity.Comp.EmpStunDuration, entity.Comp.SlowTo);
     }
 }

--- a/Content.Server/_Moffstation/Traits/EntitySystems/EmpVulnerableSystem.cs
+++ b/Content.Server/_Moffstation/Traits/EntitySystems/EmpVulnerableSystem.cs
@@ -15,6 +15,6 @@ public sealed class EmpVulnerableSystem: SharedEmpVulnerableSystem
 
     private void OnEmpPulse(EntityUid uid, EmpVulnerableComponent component, EmpPulseEvent ev)
     {
-        Disrupt(uid, component.EmpStunDuration, component.SlowTo);
+        Disrupt(uid, component.EmpStunDuration);
     }
 }

--- a/Content.Server/_Moffstation/Traits/EntitySystems/EmpVulnerableSystem.cs
+++ b/Content.Server/_Moffstation/Traits/EntitySystems/EmpVulnerableSystem.cs
@@ -1,6 +1,6 @@
 using Content.Shared._Moffstation.Traits.EntitySystems;
-using Content.Shared._Moffstation.Traits;
 using Content.Server.Emp;
+using Content.Shared._Moffstation.Traits.Components;
 
 namespace Content.Server._Moffstation.Traits.EntitySystems;
 
@@ -15,6 +15,6 @@ public sealed class EmpVulnerableSystem : SharedEmpVulnerableSystem
 
     private void OnEmpPulse(Entity<EmpVulnerableComponent> entity, ref EmpPulseEvent ev)
     {
-        Disrupt(entity, entity.Comp.EmpStunDuration, entity.Comp.SlowTo);
+        Disrupt(entity, entity.Comp.EmpStunDuration);
     }
 }

--- a/Content.Shared/_Moffstation/Traits/Components/EmpVulnerableComponent.cs
+++ b/Content.Shared/_Moffstation/Traits/Components/EmpVulnerableComponent.cs
@@ -20,10 +20,4 @@ public sealed partial class EmpVulnerableComponent: Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public TimeSpan EmpStunDuration = TimeSpan.FromSeconds(10);
-
-    /// <summary>
-    /// Movement speed multiplier for slowing down the target while they are disrupted, assuming they are not stunned
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public float SlowTo = 0.5f;
 }

--- a/Content.Shared/_Moffstation/Traits/Components/EmpVulnerableComponent.cs
+++ b/Content.Shared/_Moffstation/Traits/Components/EmpVulnerableComponent.cs
@@ -1,7 +1,7 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
-namespace Content.Shared._Moffstation.Traits;
+namespace Content.Shared._Moffstation.Traits.Components;
 
 /// <summary>
 /// Entities with this component will have debilitating effects applied to them when under the effects of a recent ion storm or EMP

--- a/Content.Shared/_Moffstation/Traits/Components/EmpVulnerableComponent.cs
+++ b/Content.Shared/_Moffstation/Traits/Components/EmpVulnerableComponent.cs
@@ -1,0 +1,29 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Moffstation.Traits;
+
+/// <summary>
+/// Entities with this component will have debilitating effects applied to them when under the effects of a recent ion storm or EMP
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class EmpVulnerableComponent: Component
+{
+    /// <summary>
+    /// Time the entity will be disrupted from an ion storm
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan IonStunDuration = TimeSpan.FromSeconds(5);
+
+    ///<summary>
+    /// Time the entity will be disrupted from an EMP
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan EmpStunDuration = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Movement speed multiplier for slowing down the target while they are disrupted, assuming they are not stunned
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float SlowTo = 0.5f;
+}

--- a/Content.Shared/_Moffstation/Traits/EntitySystems/SharedEmpVulnerableSystem.cs
+++ b/Content.Shared/_Moffstation/Traits/EntitySystems/SharedEmpVulnerableSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Moffstation.Traits.Components;
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Stunnable;

--- a/Content.Shared/_Moffstation/Traits/EntitySystems/SharedEmpVulnerableSystem.cs
+++ b/Content.Shared/_Moffstation/Traits/EntitySystems/SharedEmpVulnerableSystem.cs
@@ -50,7 +50,6 @@ public abstract class SharedEmpVulnerableSystem: EntitySystem
         else
         {
             _stun.TryCrawling(target, time: duration);
-            //_movementMod.TryUpdateMovementSpeedModDuration(target, MovementModStatusSystem.FlashSlowdown, duration, slowTo);
         }
 
         _audio.PlayPredicted(_disruptSound, target, null);

--- a/Content.Shared/_Moffstation/Traits/EntitySystems/SharedEmpVulnerableSystem.cs
+++ b/Content.Shared/_Moffstation/Traits/EntitySystems/SharedEmpVulnerableSystem.cs
@@ -1,11 +1,9 @@
 using Content.Shared.Eye.Blinding.Systems;
-using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Stunnable;
 using Content.Shared.Jittering;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Prototypes;
 
 
 namespace Content.Shared._Moffstation.Traits.EntitySystems;
@@ -16,7 +14,6 @@ public abstract class SharedEmpVulnerableSystem: EntitySystem
 
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
-    [Dependency] private readonly MovementModStatusSystem _movementMod = default!;
     [Dependency] private readonly StatusEffect.StatusEffectsSystem _statusEffectsSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedJitteringSystem _jittering = default!;
@@ -27,7 +24,7 @@ public abstract class SharedEmpVulnerableSystem: EntitySystem
     /// <param name="ent"></param>
     public void IonStormTarget(Entity<EmpVulnerableComponent> ent)
     {
-        Disrupt(ent, ent.Comp.IonStunDuration, ent.Comp.SlowTo, false);
+        Disrupt(ent, ent.Comp.IonStunDuration, false);
     }
 
     /// <summary>
@@ -37,7 +34,7 @@ public abstract class SharedEmpVulnerableSystem: EntitySystem
     /// <param name="duration">The duration of both the blindness and stun/slow effect</param>
     /// <param name="slowTo">The slow modifier if the entity is to be slowed</param>
     /// <param name="doStun">If the target should be stunned or just slowed</param>
-    protected void Disrupt(EntityUid target, TimeSpan duration, float slowTo, bool doStun = true)
+    protected void Disrupt(EntityUid target, TimeSpan duration, bool doStun = true)
     {
         if(_statusEffectsSystem.CanApplyEffect(target, TemporaryBlindnessSystem.BlindingStatusEffect))
             _statusEffectsSystem.TryAddStatusEffect(target, TemporaryBlindnessSystem.BlindingStatusEffect, duration, true, TemporaryBlindnessSystem.BlindingStatusEffect);

--- a/Content.Shared/_Moffstation/Traits/EntitySystems/SharedEmpVulnerableSystem.cs
+++ b/Content.Shared/_Moffstation/Traits/EntitySystems/SharedEmpVulnerableSystem.cs
@@ -1,0 +1,60 @@
+using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Stunnable;
+using Content.Shared.Jittering;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Prototypes;
+
+
+namespace Content.Shared._Moffstation.Traits.EntitySystems;
+
+public abstract class SharedEmpVulnerableSystem: EntitySystem
+{
+    private readonly SoundSpecifier _disruptSound = new SoundCollectionSpecifier("sparks");
+
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly MovementModStatusSystem _movementMod = default!;
+    [Dependency] private readonly StatusEffect.StatusEffectsSystem _statusEffectsSystem = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedJitteringSystem _jittering = default!;
+
+    /// <summary>
+    /// Subjects the entity to disruptive effects due to a recent ion storm
+    /// </summary>
+    /// <param name="ent"></param>
+    public void IonStormTarget(Entity<EmpVulnerableComponent> ent)
+    {
+        Disrupt(ent, ent.Comp.IonStunDuration, ent.Comp.SlowTo, false);
+    }
+
+    /// <summary>
+    /// Blinds and Stuns/Slows the target for the given duration
+    /// </summary>
+    /// <param name="target">The entity to be affected</param>
+    /// <param name="duration">The duration of both the blindness and stun/slow effect</param>
+    /// <param name="slowTo">The slow modifier if the entity is to be slowed</param>
+    /// <param name="doStun">If the target should be stunned or just slowed</param>
+    protected void Disrupt(EntityUid target, TimeSpan duration, float slowTo, bool doStun = true)
+    {
+        if(_statusEffectsSystem.CanApplyEffect(target, TemporaryBlindnessSystem.BlindingStatusEffect))
+            _statusEffectsSystem.TryAddStatusEffect(target, TemporaryBlindnessSystem.BlindingStatusEffect, duration, true, TemporaryBlindnessSystem.BlindingStatusEffect);
+
+        _jittering.DoJitter(target, duration, true);
+        if (doStun)
+        {
+            _stun.TryUpdateParalyzeDuration(target, duration);
+        }
+        else
+        {
+            _stun.TryCrawling(target, time: duration);
+            //_movementMod.TryUpdateMovementSpeedModDuration(target, MovementModStatusSystem.FlashSlowdown, duration, slowTo);
+        }
+
+        _audio.PlayPredicted(_disruptSound, target, null);
+        _popup.PopupEntity(Loc.GetString("emp-vulnerable-component-disrupted"), target, target, PopupType.MediumCaution);
+
+    }
+}

--- a/Resources/Locale/en-US/_Moffstation/emp-vulnerable/emp-vulnerable.ftl
+++ b/Resources/Locale/en-US/_Moffstation/emp-vulnerable/emp-vulnerable.ftl
@@ -1,0 +1,1 @@
+emp-vulnerable-component-disrupted = Your cybernetics fail due to electromagetic interference!

--- a/Resources/Prototypes/_CD/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_CD/Entities/Mobs/Species/avali.yml
@@ -82,6 +82,7 @@
     shiveringHeatRegulation: 2000
     normalBodyTemperature: 296.15
     thermalRegulationTemperatureThreshold: 10
+  - type: EmpVulnerable #Moffstation - EMP Vulnerability
 
 - type: entity
   parent: BaseSpeciesDummy


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
Avali will now have their cybernetics disrupted by EMPs and ion storms, causing a short blindness effect and movement restriction (knockdown for ion storms, full stun for EMPs).

## Why / Balance
We need more distinguishing traits between Avali and Resomi, this idea didn't get pushback when I proposed it in the Avali Improvements thread, and it makes thematic sense as Avali have extensive cybernetics in the lore.

## Technical details
modified existing code:
- IonStormRule.cs: added a dependency and made it call the new SharedEmpVulnerableSystem
- avali.yml: gave the base avali the new EmpVulnerable component

new code:
- EmpVulnerableComponent.cs
- SharedEmpVulnerableSystem.cs
- EmpVulnerableSystem.cs (this one's in Content.Server because I needed access to EMP events)
- emp-vulnerable.ftl

## Media
<img width="309" height="234" alt="image" src="https://github.com/user-attachments/assets/533d8490-9263-4223-91ec-ca1704160def" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Avali will now be temporarily fried by ion storms and EMPs
-->
