### PR TITLE
Update powergaming rules

### DIFF
--- a/Resources/ServerInfo/_Moffstation/Guidebook/ServerRules/MoffR3Powergaming.xml
+++ b/Resources/ServerInfo/_Moffstation/Guidebook/ServerRules/MoffR3Powergaming.xml
@@ -1,28 +1,44 @@
 <Document>
   # Section 3: Powergaming
 
-  3.1 Do not powergame. That is, minmaxing to try and achieve the best possible results to the point of being detrimental to roleplay, rushing to acquire strong or useful equipment you do not need, performing meta tricks and exploits that are unfair or unfit for a roleplay environment, and so forth.
+  ## Background
+  Powergaming is a complex rule. Its reasons for its existence are hard for people to understand initially, as it goes against the logic of a video game and the natural urges of a player playing a video game.
 
-  3.2 Greytiding (ignoring ones job duties to instead gather materials, "loot", and generally be delinquent or perform petty crime) as a non-antagonist is allowed so long as it is not to an excessive degree. This is largely dependent on the role you are playing in the round. Generally, jobs with higher esteem, responsibilities, and obligations are expected to greytide much less than others.
-  - It is unreasonable for members of command to greytide, but they may request a member of their department to do so.
+  Generally speaking, the rule against powergaming is a [bold]band-aid rule[/bold].
+  This means that the rule is trying to stop unwanted behavior that has little to no mechanical discouragement or prevention.
 
-  3.3  Do not rush for, hoard, or prepare equipment unrelated to your job or that you do not need. If you, in your given role, require items that do not fall within your job’s usual parameters or that you do not necessarily need, seek in-character roleplay-friendly methods and/or explanations to obtain them and as for why you need or want them.
+  Powergaming is a balance issue.
+  If there is a problem with people hoarding equipment to the point where it is unfun for the other side, then that equipment should be tuned to make it more discouraging to hoard or prepare.
+
+  ## Definition
+  [bold]3.1[/bold] Do not powergame. Powergaming is generally defined as intentionally minmaxxing your equipment, gear, or stats to attempt to achieve the best possible loadout for a future threat that has not occurred yet, to the point where you are playing to win, instead of roleplaying.
+
+  The definition of powergaming is highly flexible and boils down to the actions you take and the circumstances regarding your actions.
+  Generally, if you have a valid in-character reason for the equipment you have, you can have that equipment.
+  These reasons should be [bold]based on the events you have currently experienced in-round, and not on your character's lore or background[/bold].
+
+  For example, it is valid to wear riot armor and carry a riot shield to the bar in the context of revolutionaries, traitor activity, or a large spike in creatures aboard the station.
+  It is not valid when nothing but meteors have been pelting the station—you are effectively playing to win instead of roleplaying.
+
+  This rule is effectively enforced as a component to rule [bold]4.4[/bold] (playing to win). If you are locking up all antagonists, shooting to kill in hostage situations, or pushing hard for executions for people who are attempting to roleplay, you are shutting down roleplay opportunities and playing to win.
+
+  3.2  Do not rush for, hoard, or prepare equipment unrelated to your job or that you do not need. If you, in your given role, require items that do not fall within your job’s usual parameters or that you do not necessarily need, seek in-character roleplay-friendly methods and/or explanations to obtain them and as for why you need or want them.
   - Permits stamped by the head of your department, the Head of Personnel, or the Captain are roleplay-friendly methods.
 
-  3.4 As a non-antagonist, manufacturing dangerous, powerful or/and out-of-the-norm items such as weapons, bombs, deadly poisons, specialized machinery, or obstructive structures without reasonable emergency or need, is liable to be considered powergaming behavior. Seek in-character, roleplay-friendly methods and/or explanations to obtain them and as for why you need or want them outside of emergency or strict need.
+  3.3 As a non-antagonist, manufacturing dangerous, powerful, or/and out-of-the-norm items such as weapons, bombs, deadly poisons, specialized machinery, or obstructive structures without reasonable emergency or need is liable to be considered powergaming behavior. Seek in-character, roleplay-friendly methods and/or explanations to obtain them and as for why you need or want them outside of emergency or strict need.
 
-  3.5 As a non-antagonist, don't intentionally hide antagonist objectives in unreasonable locations. If you are an antagonist, refrain from stealing these items unless you actually intend on using them, or have one as your objective.
+  3.4 As a non-antagonist, don't intentionally hide antagonist objectives in unreasonable locations.
   - For example, handing a possible antagonist objective to another member of your department is fine, while handing it to a member of a different department is not.
   - It is reasonable to assume that an item such as the handheld crew monitor or hypospray may be in the possession of another member of the medical staff, but not an engineer.
   - Hiding a possible antagonist objective somewhere in your room is okay, hiding it in a room where it cannot be reasonably found by someone looking for it is not.
 
-  3.6 While it is allowed for the crew to know the details around the various antagonist functions, it is forbidden to act on that information without valid motive (for example, evidence strongly suggesting a member of the crew is an antagonist, or reliable witnesses of a serious crime). Everyone is always expected to presume innocence until proven guilty.
+  3.5 While it is allowed for the crew to know the details around the various antagonist functions, it is forbidden to act on that information without a valid motive (for example, evidence strongly suggesting a member of the crew is an antagonist, or reliable witnesses of a serious crime). Everyone is always expected to presume innocence until proven guilty.
   - For example, you shouldn't check someone's PDA unless there is enough evidence or motive to assume the person is a traitor.
 
-  3.7 Do not exploit game mechanics, bugs, tricks or unintended features to circumvent roleplay, to make things much easier for oneself and more unfair for others, or in any malicious capacity.
+  3.6 Do not exploit game mechanics, bugs, tricks, or unintended features to circumvent roleplay, to make things much easier for oneself and more unfair for others, or in any malicious capacity.
   - For example, utilizing cryo, ghost, and death mechanics to antag roll, hiding in cryo to escape from Security, or ghosting solely to fish for antagonist roles.
 
-  3.8 Do not intentionally breach nor metagame roleplay in order to gain unfair advantages.
+  3.7 Do not intentionally breach nor metagame roleplay in order to gain unfair advantages.
   - Such as, engaging someone in combat when they are busy typing something out directed at another person.
   - Fake typing to bait somebody to get closer.
   - Using roleplay as an excuse to circumvent rules


### PR DESCRIPTION
## About the PR
This PR updates the powergaming rules to be more clear for players. The goal is to generally establish that the rule is a band-aid trying to block undesirable behavior that has no in-game mechanical limiter or discouragement. It details how the rule is usually enforced and what it's trying to prevent.

### Changes
- Powergaming is now defined as a generalized concept that is enforced in-tandem with "playing to win" because that is what powergaming is.
	- Examples were intentionally not included because the example war is a deeply annoying thing to fight.
- The rule involving antagonists being required to leave items that they don't need to steal has been removed. Reasons include:
	- Absolute landmine for any player wanting to play the game normally and logically.
	- Absolute landmine for an admin to enforce.
	- Antagonists are supposed to cause conflict.
	- Traitors are allowed to backstab or betray their fellow traitors. This rules makes it so that they cannot withhold objective items from other traitors in exchange for money or friendship.
	- If you didn't get to the item before someone else, too slow, go faster.

If the item being stolen is such a problem (like circuit boards) then those circuit boards should be able to be produced instead of being items that cannot be replaced (big surprise: this is something that is directly mentioned that should not be happening in the core game design principles in upstream, no clue why we haven't brought it up as a problem yet).

## Why / Balance
Powergaming rules were unclear and annoying to enforce.

## Media
See diff

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- tweak: Powergaming is now defined as a generalized concept that is enforced in-tandem with "playing to win" because that is what powergaming is.
- remove: The rule involving antagonists being required to leave items that they don't need to steal has been removed.

