### PR TITLE
Re-Balance the Hypereutactic Blade and Add an Admeme Version

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -375,8 +375,8 @@
         Structural: 40 #Moffstation adjustment - previously 20
   - type: MeleeRequiresWield
   - type: HeldSpeedModifier #slowdown is what balances this compared to a dsword
-    walkModifier: 0.6
-    sprintModifier: 0.6
+    walkModifier: 0.70 #Moffstation adjustment - previously .6
+    sprintModifier: 0.70 #Moffstation adjustment - previously .6
   - type: UseDelay
     delay: 1.5
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -372,11 +372,11 @@
       types:
         Slash: 20
         Heat: 20
-        Structural: 20
+        Structural: 40 #Moffstation adjustment - previously 20
   - type: MeleeRequiresWield
   - type: HeldSpeedModifier #slowdown is what balances this compared to a dsword
-    walkModifier: 0.65 #Moffstation adjustment - prev .6
-    sprintModifier: 0.65 #Moffstation adjustment - prev .6
+    walkModifier: 0.6
+    sprintModifier: 0.6
   - type: UseDelay
     delay: 1.5
   - type: Sprite
@@ -397,7 +397,7 @@
     size: Small
     sprite: Objects/Weapons/Melee/hypereutactic_blade_inhands.rsi
   - type: Reflect
-    reflectProb: .60 #Moffstation adjustment - no longer 100% reflect. 
+    reflectProb: .75 #Moffstation adjustment - no longer 100% reflect. 
     spread: 75
 
 # Borgs

--- a/Resources/Prototypes/_Moffstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Moffstation/Catalog/uplink_catalog.yml
@@ -24,6 +24,6 @@
     Telecrystal: 8
   productEntity: HyperEutacticBlade
   cost:
-    Telecrystal: 15
+    Telecrystal: 14
   categories:
   - UplinkWeaponry

--- a/Resources/Prototypes/_Moffstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Moffstation/Catalog/uplink_catalog.yml
@@ -24,6 +24,6 @@
     Telecrystal: 8
   productEntity: HyperEutacticBlade
   cost:
-    Telecrystal: 16
+    Telecrystal: 15
   categories:
   - UplinkWeaponry

--- a/Resources/Prototypes/_Moffstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Moffstation/Catalog/uplink_catalog.yml
@@ -24,6 +24,6 @@
     Telecrystal: 8
   productEntity: HyperEutacticBlade
   cost:
-    Telecrystal: 14
+    Telecrystal: 16
   categories:
   - UplinkWeaponry

--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -1,0 +1,52 @@
+- type: entity #admeme version of Hypereutactic Blade
+  parent: HyperEutacticBlade
+  id: GodSlayer
+  suffix: Admeme
+  name: The God Slayer
+  description: Dread it. Run from it. Destiny still arrives.
+  components:
+  - type: MeleeWeapon
+    wideAnimationRotation: 180
+    attackRate: 0.8 
+    angle: 100
+    range: 2.0
+    damage:
+      types:
+        Blunt: 4.5
+  - type: ItemToggleMeleeWeapon
+    activatedSoundOnSwing:
+      path: /Audio/Weapons/eblademiss.ogg
+      params:
+        volume: -3
+        variation: 0.250
+    activatedDamage:
+      types:
+        Slash: 100
+        Heat: 100
+        Structural: 300 
+  - type: MeleeRequiresWield
+  - type: HeldSpeedModifier 
+    walkModifier: 0.15
+    sprintModifier: 0.15
+  - type: UseDelay
+    delay: 1.5
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/hypereutactic_blade.rsi
+    layers:
+    - state: hypereutactic
+    - state: hypereutactic_blade
+      color: "#FFFFFF"
+      visible: false
+      shader: unshaded
+      map: [ "blade" ]
+    - state: hypereutactic_gem
+      color: "#FFFFFF"
+      visible: false
+      shader: unshaded
+      map: [ "gem" ]
+  - type: Item
+    size: Small
+    sprite: Objects/Weapons/Melee/hypereutactic_blade_inhands.rsi
+  - type: Reflect
+    reflectProb: 1
+    spread: 20


### PR DESCRIPTION
## About the PR

Wowie I'm changing the stats on the big sword after playtesting.

Deflect: 60% -> 75%
Slowdown: 35% -> 30%
Structural: 20 -> 40


Admeme Version:
"The God Slayer"
100% Deflect
85% slowdown
Probably one shots you unless you have godly armor.
Deflects back in a way smaller cone


## Why / Balance

I've tried to play with it as much as I can in actual matches these past 3 weeks or so but....it's just kinda...really bad, definitely fun, but bad. Feedback I also got from people varied from it being straight up un-usuable, to just kinda okay, but it was mainly seen as an ineffective meme. 

You just sorta get shot and die and can't do much cause of the slowdown, especially in a game like SS14 where movement is king. It was just wayyyyy less effective than I thought it'd be, especially compared to higher TC options similar to it. I saw it work legitimately 1 time out of around 12. 

I also always meant for it to have more structural damage than the energy sword. 
- Since it swings slower, it breaks stuff in just about the same amount of time with this change (just a tiny bit faster). Before, it just broke stuff wayyy slower which kinda made no sense given its profile and description. I literally just forgot to change the value the first time around. 

These changes are also based on us having a similar version to this for 3 months with it being a non-meta option as well as Impstation having the same experience. But at least with these changes it'd be viable instead of a meme

## Technical details
I changed some values, added a new e-sword file in the moffstation objects directory for the admeme version. 

## Media
I don't think media is needed, self explanatory changes.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Tweaked the Hypereutactic Blade...again!

