### PR TITLE
Reload On The Move

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -100,7 +100,7 @@ public abstract partial class SharedGunSystem
         // Continuous loading
         _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, component.FillDelay, new AmmoFillDoAfterEvent(), used: uid, target: args.Target, eventTarget: uid)
         {
-            BreakOnMove = true,
+            BreakOnMove = false,
             BreakOnDamage = false,
             NeedHand = true,
         });

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -100,7 +100,7 @@ public abstract partial class SharedGunSystem
         // Continuous loading
         _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, component.FillDelay, new AmmoFillDoAfterEvent(), used: uid, target: args.Target, eventTarget: uid)
         {
-            BreakOnMove = false,
+            BreakOnMove = false, // Moffstation - Reloading shotguns on the move
             BreakOnDamage = false,
             NeedHand = true,
         });


### PR DESCRIPTION
## About the PR
You can now reload shotguns and magazines while on the move

## Why / Balance
It's always felt a bit weird at how that you can do every reload step on a L6 on the move, but you struggle to shove a singular shotgun shell into a tube if you take a singular step.
Now, you can do it on the move, so shotguns can feel slightly better while reloading.
As a side effect, you can also reload magazines and shotgun drums while on the move. While I don't think that would be a huge game changer, it's still something to note.

## Technical details
Change one line from true to false.

## Media

[Base Profile 2025.09.27 - 09.14.58.611.webm](https://github.com/user-attachments/assets/e201dcb1-40b3-43c8-aa76-07124a7f3f81)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl:
- tweak: Shotguns and magazines can be reloaded on the move.