### PR TITLE
Craftable Brass Floor Can Actually Be Placed As a Floor Tile

### DIFF
--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -194,7 +194,7 @@
   id: FloorBrassFilled
   name: tiles-brass-floor-filled
   sprite: /Textures/Tiles/Misc/clockwork/clockwork_floor_filled.png
-  baseTurf: PlatingBrass
+  baseTurf: Plating #Moffstation Change - Changed from PlatingBrass to allow placement as floor tiles instead of just on lattice
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -206,7 +206,7 @@
   id: FloorBrassReebe
   name: tiles-brass-floor-reebe
   sprite: /Textures/Tiles/Misc/clockwork/reebe.png
-  baseTurf: PlatingBrass
+  baseTurf: Plating #Moffstation Change - Changed from PlatingBrass to allow placement as floor tiles instead of just on lattice
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
Before the craft-able brass floor tiles could only be placed on lattice, now they can be placed on lattice AS WELL AS like any other normal floor tile in the entire game, wow! There was no indication that they could only be placed on lattice before, and they are way cooler if they are able to be placed as floor tiles too without making every pipe go over it and needing to RCD every single tile for a cool clockwork room. TLDR - was inconsistent with every other floor tile in the crafting menu for no good reason and was annoying. 

## Why / Balance
It caused me pain trying to make swanky brass room. 

## Technical details
I changed 2 lines of code. I know. Master programmer

## Media
![example](https://github.com/user-attachments/assets/286608a1-7792-471e-bd03-dc0a3f917202)
Left was placed on normal crowbarred floor, right was placed on lattice after an RCD. :)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Made brass floors behave like other floor tiles (You no longer have to RCD the entire room). 


