### PR TITLE
small departmental economy additions

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -102,6 +102,10 @@
         paper_label: !type:ContainerSlot
     - type: StaticPrice
       price: 250
+    # Moffstation - Start - department sellables
+    - type: OverrideSell
+      overrideAccount: Science
+    # Moffstation - End
 
 - type: entity
   parent: BaseStorageItem
@@ -193,3 +197,7 @@
     delay: 0.3
   - type: StaticPrice
     price: 250
+  # Moffstation - Start - department sellables
+  - type: OverrideSell
+    overrideAccount: Science
+  # Moffstation - End

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -486,9 +486,17 @@
           bounds: "-0.3,-0.4,0.3,0.19"
         density: 50
         mask:
-        - CrateMask #this is so they can go under plastic flaps
+        #- CrateMask # Moffstation - department sellables
+        - Impassable
         layer:
         - MachineLayer
+  # Moffstation - Start - department sellables
+  - type: EntityStorage
+    whitelist:
+      components:
+      - Item
+      - GasCanister
+  # Moffstation - End
 
 - type: entity
   id: CrateLockBoxEngineering


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Let gas canisters fit into department lockboxes, and tagged artifact containers to direct funds to science.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With the addition of departmental economy, departments were given methods to directly contribute to their specific department's budget, based on the actions they performed. However, This was limited to handhelds that could actually /fit/ inside the box, and as a result experienced atmos techs could not effectively sell gases on behalf of their department. Additionally, scientists with their artifacts could not profit off of their research as effectively either, as these larger space rocks did not fit within the lockbox. This pull request addresses both of these issues, by allowing canisters to fit inside of lockboxes, and direct artifacts sold in their artifact containers (which is how they should be sold) to contribute directly to the science fund.

## Technical details
<!-- Summary of code changes for easier review. -->
For the gas canister issue, we added an entity storage whitelist, allowing 'items' and 'GasCanisters' to be held within the lockbox. Additionally, changed the mask on the lockbox to remove collision between the lockbox and canister.

For the artifact boxes, we added the OverrideSell component, pointing to the science account.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="305" height="263" alt="image" src="https://github.com/user-attachments/assets/1f13cc9f-5404-44bd-8a0d-cc87b78ccb46" />

_Putting the canister in the box..._

<img width="303" height="223" alt="image" src="https://github.com/user-attachments/assets/23548758-e408-40c4-92b6-ec30d263e3d9" />

_Profit._

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: Gas canisters now fit in lockboxes.
- tweak: Artifact containers now direct funds to the science account.