### PR TITLE
Add the crew monitor blade server

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -518,6 +518,7 @@
   components:
     - type: MachineBoard
       prototype: CrewMonitoringServer
+      bladeServerPrototype: CrewMonitoringBladeServer # Moffstation - Blade Server construction
       stackRequirements:
         Steel: 1
         Cable: 2

--- a/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CrewMonitoringServer
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [ BaseCrewMonitoringServer, BaseMachinePowered, ConstructibleMachine ] # Moffstation - Add abstract crewmon server parent
   name: crew monitoring server
   description: Receives and relays the status of all active suit sensors on the station.
   components:
@@ -27,21 +27,26 @@
       containers:
         machine_board: !type:Container
         machine_parts: !type:Container
-    - type: CrewMonitoringServer
-    - type: SingletonDeviceNetServer
-    - type: DeviceNetwork
-      deviceNetId: Wireless
-      transmitFrequencyId: CrewMonitor
-      receiveFrequencyId: SuitSensor
-      autoConnect: false
-    - type: WirelessNetworkConnection
-      range: 10000 # Moffstation - Exended range for Listening outpost
-    #- type: StationLimitedNetwork # Moffstation
-    - type: ApcPowerReceiver
-      powerLoad: 200
-    - type: ExtensionCableReceiver
-    - type: WiresPanel
-    - type: WiresVisuals
+    # Moffstation - Begin - Add abstract crewmon server parent.
+    #     Changes to this section must be carefully considered: if the change should apply to the machine variant, leave
+    #     it on this proto. If it should apply to the machine variant AND the blade server variant, comment out the
+    #     change here and duplicate it to the abstract parent.
+#    - type: CrewMonitoringServer
+#    - type: SingletonDeviceNetServer
+#    - type: DeviceNetwork
+#      deviceNetId: Wireless
+#      transmitFrequencyId: CrewMonitor
+#      receiveFrequencyId: SuitSensor
+#      autoConnect: false
+#    - type: WirelessNetworkConnection
+#      range: 10000 # Moffstation - Exended range for Listening outpost
+#    #- type: StationLimitedNetwork # Moffstation
+#    - type: ApcPowerReceiver
+#      powerLoad: 200
+#    - type: ExtensionCableReceiver
+#    - type: WiresPanel
+#    - type: WiresVisuals
+    # Moffstation - End
     - type: Destructible
       thresholds:
         - trigger:
@@ -64,13 +69,18 @@
                 SheetSteel1:
                   min: 1
                   max: 2
-    - type: Appearance
-    - type: GenericVisualizer
-      visuals:
-        enum.PowerDeviceVisuals.Powered:
-          enum.PowerDeviceVisualLayers.Powered:
-            True: {visible: true}
-            False: {visible: false}
+  # Moffstation - Begin - Add abstract crewmon server parent.
+  #     Changes to this section must be carefully considered: if the change should apply to the machine variant, leave
+  #     it on this proto. If it should apply to the machine variant AND the blade server variant, comment out the
+  #     change here and duplicate it to the abstract parent.
+#    - type: Appearance
+#    - type: GenericVisualizer
+#      visuals:
+#        enum.PowerDeviceVisuals.Powered:
+#          enum.PowerDeviceVisualLayers.Powered:
+#            True: {visible: true}
+#            False: {visible: false}
+  # Moffstation - End
     - type: AmbientOnPowered
     - type: AmbientSound
       volume: -9
@@ -78,6 +88,11 @@
       enabled: false
       sound:
         path: /Audio/Ambience/Objects/server_fans.ogg
-    - type: GuideHelp
-      guides:
-      - Medical
+  # Moffstation - Begin - Add abstract crewmon server parent.
+  #     Changes to this section must be carefully considered: if the change should apply to the machine variant, leave
+  #     it on this proto. If it should apply to the machine variant AND the blade server variant, comment out the
+  #     change here and duplicate it to the abstract parent.
+#    - type: GuideHelp
+#      guides:
+#      - Medical
+  # Moffstation - End

--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Devices/BladeServers/blade-servers.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Devices/BladeServers/blade-servers.yml
@@ -4,6 +4,8 @@
   parent: BaseItem
   components:
   - type: BladeServer
+  - type: Machine
+  - type: InnerCableReceiver
   - type: ContainerContainer
     containers:
       machine_board: !type:Container
@@ -14,6 +16,43 @@
     containers:
     - machine_parts
     - machine_board
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 2
+  - type: Sprite
+    sprite: _Moffstation/Structures/Machines/blade_server.rsi
+    layers:
+    - state: frame
+    - state: stripe
+      visible: false
+      map: [ "enum.BladeServerVisuals.StripeLayer" ]
+    - state: cover
+    - state: powered
+      visible: false
+      shader: unshaded
+      map: [ "enum.PowerDeviceVisualLayers.Powered" ]
+    - state: maintenance-panel
+      visible: false
+      map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
   - type: Item
     size: Huge
     sprite: _Moffstation/Structures/Machines/blade_server.rsi
@@ -40,43 +79,16 @@
   components:
   - type: BladeServer
     stripeColor: "#A331B9FF"
-  - type: Sprite
-    sprite: _Moffstation/Structures/Machines/blade_server.rsi
-    layers:
-    - state: frame
-    - state: stripe
-      visible: false
-      map: [ "enum.BladeServerVisuals.StripeLayer" ]
-    - state: cover
-    - state: powered
-      visible: false
-      shader: unshaded
-      map: [ "enum.PowerDeviceVisualLayers.Powered" ]
-    - state: maintenance-panel
-      visible: false
-      map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
-  - type: InnerCableReceiver
   - type: Machine
     board: ResearchAndDevelopmentServerMachineCircuitboard
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 600
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          SheetSteel1:
-            min: 1
-            max: 2
+
+- type: entity
+  id: CrewMonitoringBladeServer
+  parent: [ BaseCrewMonitoringServer, ConstructibleBladeServer ]
+  name: crew monitoring blade server
+  description: Receives and relays the status of all active suit sensors on the station.
+  components:
+  - type: BladeServer
+    stripeColor: "#008C30FF"
+  - type: Machine
+    board: CrewMonitoringServerMachineCircuitboard

--- a/Resources/Prototypes/_Moffstation/Entities/Structures/Machines/crew_monitoring_server.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Structures/Machines/crew_monitoring_server.yml
@@ -1,18 +1,22 @@
 ﻿# This was peeled off of upstream's `ResearchAndDevelopmentServer`. Changes to that prototype from upstream should be
 # carefully considered to be added here or there, depending on whether it should affect just the machine variant, or all
-# variants of the R&D server.
+# variants of the crewmon server.
 - type: entity
-  id: BaseResearchAndDevelopmentServer
+  id: BaseCrewMonitoringServer
   abstract: true
-  name: abstract R&D server
+  name: abstract crew monitoring server
+  description: Receives and relays the status of all active suit sensors on the station.
   components:
-  - type: ResearchServer
-  - type: TechnologyDatabase
-    supportedDisciplines:
-    - Industrial
-    - Arsenal
-    - Experimental
-    - CivilianServices
+  - type: CrewMonitoringServer
+  - type: SingletonDeviceNetServer
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    transmitFrequencyId: CrewMonitor
+    receiveFrequencyId: SuitSensor
+    autoConnect: false
+  - type: WirelessNetworkConnection
+    range: 10000 # Moffstation - Exended range for Listening outpost
+  #- type: StationLimitedNetwork # Moffstation
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: ExtensionCableReceiver
@@ -27,4 +31,4 @@
           False: { visible: false }
   - type: GuideHelp
     guides:
-    - Science
+    - Medical


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Make a Crew Monitoring Blade Server variant.
I am astonished that this seems to work with zero C# changes to the crewmon. (I tested with and without another crewmon; the thing where you have two and turn off the one that's actually doing something and the backup flips on to being used, etc.)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
wow wouldn't it be cool if blade servers were worth building??

## Technical details
<!-- Summary of code changes for easier review. -->
Split the crewmon server proto into abstract/machine like the R&D server. Add blade server variant.

I also rearranged the base blade server proto so that defining new blade servers is really easy.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="996" height="1600" alt="image" src="https://github.com/user-attachments/assets/66d3186c-3bb3-4616-a8c7-a0ba9d48fc31" />

_Monitoring the crew with a blade_

<img width="1204" height="1198" alt="image" src="https://github.com/user-attachments/assets/3c58fbb5-68d4-49cd-ba50-0b1668410e1d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
no

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: The crew monitoring server can now be built as a blade server.