### PR TITLE
Recycler Damage Change

### DIFF
--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -189,13 +189,14 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
         if (component.ReclaimMaterials)
             SpawnMaterialsFromComposition(uid, item, completion * component.Efficiency, xform: xform);
 
-        //Moffstation - recycler damage change - begin
         if (CanGib(uid, item, component))
         {
             var logImpact = HasComp<HumanoidAppearanceComponent>(item) ? LogImpact.Extreme : LogImpact.Medium;
-            _adminLogger.Add(LogType.Gib, logImpact, $"{ToPrettyString(item):victim} was ground by {ToPrettyString(uid):entity} ");
+            //Moffstation - recycler damage change - begin
+            _adminLogger.Add(LogType.Damaged, logImpact, $"{ToPrettyString(item):victim} was ground by {ToPrettyString(uid):entity} ");
             TryComp<DamageableComponent>(item, out var comp);
             _damage.TryChangeDamage(item, component.DamageOnGrind, true, true, comp);
+            //Moffstation - end
             _appearance.SetData(uid, RecyclerVisuals.Bloody, true);
         }
         else
@@ -204,6 +205,7 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
                 SpawnChemicalsFromComposition(uid, item, completion, true, component, xform);
         }
 
+        //Moffstation - recycler damage change - begin
         if(!CanGib(uid, item, component))
             QueueDel(item);
         //Moffstation - end

--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -194,7 +194,6 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
             var logImpact = HasComp<HumanoidAppearanceComponent>(item) ? LogImpact.Extreme : LogImpact.Medium;
             //Moffstation - recycler damage change - begin
             _adminLogger.Add(LogType.Damaged, logImpact, $"{ToPrettyString(item):victim} was ground by {ToPrettyString(uid):entity} ");
-            TryComp<DamageableComponent>(item, out var comp);
             _damage.TryChangeDamage(item, component.DamageOnGrind, true, true, comp);
             //Moffstation - end
             _appearance.SetData(uid, RecyclerVisuals.Bloody, true);

--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -194,7 +194,7 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
             var logImpact = HasComp<HumanoidAppearanceComponent>(item) ? LogImpact.Extreme : LogImpact.Medium;
             //Moffstation - recycler damage change - begin
             _adminLogger.Add(LogType.Damaged, logImpact, $"{ToPrettyString(item):victim} was ground by {ToPrettyString(uid):entity} ");
-            _damage.TryChangeDamage(item, component.DamageOnGrind, true, true, comp);
+            _damage.TryChangeDamage(item, component.DamageOnGrind, true);
             //Moffstation - end
             _appearance.SetData(uid, RecyclerVisuals.Bloody, true);
         }

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -144,7 +144,7 @@ public sealed partial class MaterialReclaimerComponent : Component
     /// <summary>
     /// What damage the recycler does to people when emagged, due to a bug elsewhere the damage set here is applied twice
     /// </summary>
-    [DataField] [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public DamageSpecifier DamageOnGrind = new DamageSpecifier
     {
         DamageDict = new Dictionary<string, FixedPoint2>

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Whitelist;
+﻿using Content.Shared.Damage;
+using Content.Shared.Whitelist;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -137,6 +138,14 @@ public sealed partial class MaterialReclaimerComponent : Component
     /// </remarks>
     [DataField, AutoNetworkedField]
     public int ItemsProcessed;
+
+    //Moffstaton - recycler damage change - begin
+    /// <summary>
+    /// What damage the recycler does to people when emagged
+    /// </summary>
+    [DataField(required: true)] [ViewVariables(VVAccess.ReadWrite)]
+    public DamageSpecifier DamageOnGrind = new();
+    //Moffstation - end
 }
 
 [NetSerializable, Serializable]

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Damage;
+using Content.Shared.FixedPoint; //Moffstation - recycler damage change
 using Content.Shared.Whitelist;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
@@ -141,10 +142,16 @@ public sealed partial class MaterialReclaimerComponent : Component
 
     //Moffstaton - recycler damage change - begin
     /// <summary>
-    /// What damage the recycler does to people when emagged
+    /// What damage the recycler does to people when emagged, due to a bug elsewhere the damage set here is applied twice
     /// </summary>
     [DataField] [ViewVariables(VVAccess.ReadWrite)]
-    public DamageSpecifier DamageOnGrind = new();
+    public DamageSpecifier DamageOnGrind = new DamageSpecifier
+    {
+        DamageDict = new Dictionary<string, FixedPoint2>
+        {
+            ["Slash"] = 150.0, //Initial value defined here to avoid mapping conflicts
+        },
+    };
     //Moffstation - end
 }
 

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -143,7 +143,7 @@ public sealed partial class MaterialReclaimerComponent : Component
     /// <summary>
     /// What damage the recycler does to people when emagged
     /// </summary>
-    [DataField(required: true)] [ViewVariables(VVAccess.ReadWrite)]
+    [DataField] [ViewVariables(VVAccess.ReadWrite)]
     public DamageSpecifier DamageOnGrind = new();
     //Moffstation - end
 }

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Damage;
+﻿using Content.Shared.Damage; //Moffstation - recycler damage change
 using Content.Shared.FixedPoint; //Moffstation - recycler damage change
 using Content.Shared.Whitelist;
 using JetBrains.Annotations;

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -149,7 +149,7 @@ public sealed partial class MaterialReclaimerComponent : Component
     {
         DamageDict = new Dictionary<string, FixedPoint2>
         {
-            ["Slash"] = 1000.0, //Initial value defined here to avoid mapping conflicts
+            ["Slash"] = 500.0, //Initial value defined here to avoid mapping conflicts
         },
     };
     //Moffstation - end

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -149,7 +149,7 @@ public sealed partial class MaterialReclaimerComponent : Component
     {
         DamageDict = new Dictionary<string, FixedPoint2>
         {
-            ["Slash"] = 150.0, //Initial value defined here to avoid mapping conflicts
+            ["Slash"] = 1000.0, //Initial value defined here to avoid mapping conflicts
         },
     };
     //Moffstation - end

--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -3,7 +3,7 @@ using Content.Shared.Administration.Logs;
 using Content.Shared.Audio;
 using Content.Shared.Body.Components;
 using Content.Shared.Database;
-using Content.Shared.Emag.Components;
+using Content.Shared.Damage;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Examine;
 using Content.Shared.Mobs.Components;
@@ -214,6 +214,7 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
                component.Enabled &&
                !component.Broken &&
                HasComp<BodyComponent>(victim) &&
+               HasComp<DamageableComponent>(victim) && //Moffstation - recycler damage change
                _emag.CheckFlag(uid, EmagType.Interaction);
     }
 

--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -3,7 +3,8 @@ using Content.Shared.Administration.Logs;
 using Content.Shared.Audio;
 using Content.Shared.Body.Components;
 using Content.Shared.Database;
-using Content.Shared.Damage;
+using Content.Shared.Damage; //Moffstation - recycler damage change
+using Content.Shared.Emag.Components;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Examine;
 using Content.Shared.Mobs.Components;

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -84,6 +84,11 @@
       params:
         volume: -3
     cutOffSound: false
+    #Moffstation - recycler damage change - Begin
+    damageOnGrind:
+      types:
+        Slash: 150 #Is applied twice for some reason. This will do 300 slash, which will kill but not immediately RR unintentionally
+    #Moffstation - end
   - type: MaterialStorage
     insertOnInteract: false
   - type: Conveyor

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -84,11 +84,6 @@
       params:
         volume: -3
     cutOffSound: false
-    #Moffstation - recycler damage change - Begin
-    damageOnGrind:
-      types:
-        Slash: 150 #Is applied twice for some reason. This will do 300 slash, which will kill but not immediately RR unintentionally
-    #Moffstation - end
   - type: MaterialStorage
     insertOnInteract: false
   - type: Conveyor


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
The recycler now does 1000 slash damage instead of instantly gibbing when emagged.

## Why / Balance
The recycler is so easy to accidentally RR people with that it is virtually never emagged here, with these changes it will still kill instantly, but people passed through it can still be revived. If the goal is to RR someone they can easily be run through the recycler multiple times to generate an effectively unhealable amount of damage. Hopefully with this change the recycler can be emagged without requiring DAGD.

Offmed is also removing different forms of gibbing from the game, and this is another piece of that process.

## Technical details
modifications to the MaterialReclaimerComponent and it's associated entity systems in server and shared

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: The recycler now deals a lethal amount of slash instead of instantly gibbing. If you need to RR with it grind the body multiple times.
-->
