### PR TITLE
fix nightvisioncomponent test fails

### DIFF
--- a/Content.Client/_Moffstation/Overlay/Systems/NightVisionSystem.cs
+++ b/Content.Client/_Moffstation/Overlay/Systems/NightVisionSystem.cs
@@ -94,7 +94,7 @@ public sealed class NightVisionSystem : EntitySystem
             return;
 
         _overlayMan.RemoveOverlay(Overlay);
-        QueueDel(_effect);
+        PredictedQueueDel(_effect);
         _effect = null;
     }
 }


### PR DESCRIPTION
## About the PR
fixed nightvisioncomponent/system spamming test fails

## Why / Balance
nightvisioncomponent/system is a client-sided system
when tests attempt to delete anything with a nightvisioncomponent (like a resomi being spawned/deleted for whatever reason) nightvisionsystem will attempt to remove the effect tied to the resomi

this fails because we are attempting to delete a networked entity (the effect associated with the entity)

to fix this we just use predictedqueuedelete

## Technical details
n/a

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
n/a
