### PR TITLE
Brain activity thresholds

### DIFF
--- a/Content.Shared/_Offbrand/Wounds/BrainDamageComponent.cs
+++ b/Content.Shared/_Offbrand/Wounds/BrainDamageComponent.cs
@@ -32,6 +32,14 @@ public sealed partial class BrainDamageComponent : Component
     /// </summary>
     [DataField(required: true), AutoNetworkedField]
     public FixedPoint2 Oxygen;
+
+    // Moffstation - Start - Offmed brain activity adjustments
+    /// <summary>
+    /// Used to multiply damage when its at certain thresholds
+    /// </summary>
+    [DataField(required: true)]
+    public SortedDictionary<FixedPoint2, float> DamageModifierThresholds;
+    // Moffstation - End
 }
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]

--- a/Content.Shared/_Offbrand/Wounds/BrainDamageSystem.cs
+++ b/Content.Shared/_Offbrand/Wounds/BrainDamageSystem.cs
@@ -212,6 +212,13 @@ public sealed partial class BrainDamageSystem : EntitySystem
         if (!rand.Prob(evt.Chance))
             return;
 
+        // Moffstation - Brain Activity adjustments
+        if (ent.Comp1.DamageModifierThresholds.HighestMatch(amount) is { } modifier)
+        {
+            amount *= modifier;
+        }
+        // Brain activity adjustments
+
         var newValue = FixedPoint2.Min(ent.Comp1.Damage + amount, ent.Comp1.MaxDamage);
         if (ent.Comp1.Damage == newValue)
             return;

--- a/Content.Shared/_Offbrand/Wounds/BrainDamageSystem.cs
+++ b/Content.Shared/_Offbrand/Wounds/BrainDamageSystem.cs
@@ -106,6 +106,13 @@ public sealed partial class BrainDamageSystem : EntitySystem
         if (!Resolve(ent, ref ent.Comp, false))
             return;
 
+        // Moffstation - Brain Activity adjustments
+        if (ent.Comp.DamageModifierThresholds.HighestMatch(amount) is { } modifier)
+        {
+            amount *= modifier;
+        }
+        // Brain activity adjustments
+
         ent.Comp.Damage = FixedPoint2.Clamp(ent.Comp.Damage + amount, FixedPoint2.Zero, ent.Comp.MaxDamage);
         Dirty(ent);
 

--- a/Resources/Prototypes/_Offbrand/base_mob.yml
+++ b/Resources/Prototypes/_Offbrand/base_mob.yml
@@ -221,6 +221,11 @@
     damage: 0
     maxOxygen: 10
     oxygen: 10
+    # Moffstation - Start - Brain activity adjustments
+    damageModifierThresholds:
+      85: 0.3
+      95: 0.1
+    # Moffstation - End
   - type: BrainDamageOxygenation
     oxygenationDamageThresholds:
       0.10: [1.0, [100, 0.75]]


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Once the brain reaches certain thesholds of activity, all incoming damage to the brain will be modified. Right now, it is used to reduce damage so that people in a critical state can last longer and take more hits before they're completely dead. 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The most common criticism of the offmed system is how quickly/easily people can be RRed if they don't get medical attention quickly. This should help provide a "buffer" so that people have more time to be brought back from a near-death state.
## Technical details
<!-- Summary of code changes for easier review. -->
this may be the most straightforward way of doing this, but someone should review to make sure there isn't a better way. Additionally, it may be made quickly obsolete by future offmed updates.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
