### PR TITLE
Make door bolting powergaming no longer relevant anymore

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -123,7 +123,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (!TryComp<AirlockComponent>(uid, out var airlock))
             return;
 
-        if (IsBolted(uid) || !airlock.Powered)
+        if (!airlock.Powered) // Moffstation - Reduce doorbolting powergaming
             return;
 
         if (door.State != DoorState.Closed)

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -67,6 +67,7 @@
       - state: syn_inhand-right
     size: Normal
   - type: Prying
+    force: true # Moffstation - Reduce doorbolting powergaming
     speedModifier: 3.0
   - type: MultipleTool
     entries:


### PR DESCRIPTION
## About the PR
Makes the syndicate jaws of life able to pry open bolted doors - if you do pry open a **bolted** door it'll stay bolted open so it'll be pretty obvious that your shit just got ransacked. If it's not bolted it'll close again like normal.

Makes the authentication disruptor able to EMAG bolted doors.

## Why / Balance
Admins had an internal discussion on what constitutes powergaming, more specifically, what can an AI do/not do in terms of bolting their core or upload. This is generally a silly rule that goes against the natural thinking of the player - if I had a law to protect myself I think I would bolt the doors to my core as well.

The reason why "bolting on green" is dissuaded is because you cannot access disrupt/pry open bolted doors, so this was the default meta for trolling syndicates. Now the playing field is evened out and it doesn't really matter if the traitor is willing to fork over some TC for the convenience of stealing stuff easily.

IMO this also gives the Syndie JOL something interesting going for it besides Jaws But Evil And Faster.

There are some concerns with the JOL/disruptor, mainly that a traitor can now sneak up on the AI core and change its laws. However this was already possible with unbolted doors which is now the default behavior so overall the experience has not changed.

## Technical details
Nukes a check in C# and flips a bool to true.

## Media
<img width="344" height="416" alt="image" src="https://github.com/user-attachments/assets/d6799c4e-2bfb-4521-8c0e-afc9b25c2716" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- tweak: The syndicate jaws of life can now pry open bolted doors. This was done to curb powergaming concerns - now it doesn't matter if you bolt doors on green.
- fix: The authentication disruptor can now disrupt bolted doors. This was done for the same reasons as the syndicate jaws of life.
