### PR TITLE
Hourly playtime/localtime notices

### DIFF
--- a/Content.Client/Content.Client.csproj
+++ b/Content.Client/Content.Client.csproj
@@ -23,9 +23,6 @@
     <ProjectReference Include="..\RobustToolbox\Robust.Client\Robust.Client.csproj" />
     <ProjectReference Include="..\Content.Shared\Content.Shared.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="_Moffstation\Commands\" />
-  </ItemGroup>
   <Import Project="..\RobustToolbox\MSBuild\Robust.Properties.targets" />
   <Import Project="..\RobustToolbox\MSBuild\XamlIL.targets" />
 </Project>

--- a/Content.Client/Playtime/ClientsidePlaytimeTrackingManager.cs
+++ b/Content.Client/Playtime/ClientsidePlaytimeTrackingManager.cs
@@ -124,18 +124,6 @@ public sealed class ClientsidePlaytimeTrackingManager
     {
         var hourlyNoticeCts = new CancellationTokenSource();
 
-        try
-        {
-            hourlyNoticeCts?.Cancel();
-            hourlyNoticeCts?.Dispose();
-        }
-        catch
-        {
-            // l plus ratio
-        }
-
-        hourlyNoticeCts = new CancellationTokenSource();
-
         var now = DateTime.Now;
         var nextHour = new DateTime(now.Year, now.Month, now.Day, now.Hour, 0, 0, now.Kind).AddHours(1);
         var delay = nextHour - now;


### PR DESCRIPTION
## About the PR
Adds hourly playtime notices. They get posted to the chat window as a server message, telling you your current in-game playtime and local time.

## Why / Balance
Both admins and players fall into the "Just One More Round" fallacy and end up staying up till 2AM on a game server that will probably be here tomorrow. It's unhealthy and just plain addiction. Informing players and admins how deep they're in allows them to make better informed choices - either wrap up the round and cryo or truly play their last round for the day.

## Technical details
Absolutely horrible code. We just set up a timer every hour that pulls the client's current local time and game stats. Then we grab the chat window and tell it to process a message we give it in the format of a server message.

## Media
<img width="1280" height="295" alt="image" src="https://github.com/user-attachments/assets/0950a10e-4a64-430b-890c-e14231c0c11d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- add: Added hourly playtime reminders, which tell you how long you've played in-game as well as your local time every hour.
