### PR TITLE
Chaplain Coat Storage

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -73,7 +73,7 @@
     sprite: _Moffstation/Clothing/OuterClothing/Misc/chef.rsi # Moffstation - (New Chef Jacket)
 
 - type: entity
-  parent: ClothingOuterStorageFoldableBase #MoffStation - (Chaplain Coats have Pockets)
+  parent: ClothingOuterStorageFoldableBase
   id: ClothingOuterHoodieBlack
   name: black hoodie
   description: Oh my God, it's a black hoodie!
@@ -82,14 +82,9 @@
     sprite: Clothing/OuterClothing/Misc/black_hoodie.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/black_hoodie.rsi
-  #Moffstation - Begin - Storage Resize
-  - type: Storage
-    grid:
-    - 0,0,1,1
-  #Moffstation - End
 
 - type: entity
-  parent: ClothingOuterStorageFoldableBase #MoffStation - (Chaplain Coats have Pockets)
+  parent: ClothingOuterStorageFoldableBase
   id: ClothingOuterHoodieGrey
   name: grey hoodie
   description: A grey hoodie.
@@ -98,11 +93,6 @@
     sprite: Clothing/OuterClothing/Misc/grey_hoodie.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/grey_hoodie.rsi
-  #Moffstation - Begin - Storage Resize
-  - type: Storage
-    grid:
-    - 0,0,1,1
-  #Moffstation - End
 
 - type: entity
   parent: ClothingOuterBase
@@ -121,7 +111,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: ClothingOuterStorageToggleableBase #Moffstation - (Chaplain Coats Have Pockets)
+  parent: ClothingOuterStorageToggleableBase
   id: ClothingOuterHoodieChaplain
   name: chaplain's hoodie
   description: Black and strict chaplain hoodie.
@@ -132,11 +122,6 @@
     sprite: Clothing/OuterClothing/Misc/chaplain_hoodie.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodChaplainHood
-  #Moffstation - Begin - Storage Resize
-  - type: Storage
-    grid:
-    - 0,0,1,1
-  #Moffstation - End
 
 - type: entity
   parent: ClothingOuterBase
@@ -152,7 +137,7 @@
     accent: SpanishAccent
 
 - type: entity
-  parent: ClothingOuterStorageBase #Moffstation - (Chaplain Coats Have Pockets)
+  parent: ClothingOuterStorageBase
   id: ClothingOuterRobesCult
   name: cult robes
   description: There's no cult without classic red/crimson cult robes.
@@ -161,7 +146,6 @@
     sprite: Clothing/OuterClothing/Misc/cultrobes.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/cultrobes.rsi
-    # Moffstation - Storage size is defined in Parent
 
 - type: entity
   parent: ClothingOuterBase
@@ -263,7 +247,7 @@
     sprite: Clothing/OuterClothing/Misc/skubbody.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase #Moffstation - (Chaplain Coats Have Pockets)
+  parent: ClothingOuterStorageBase
   id: ClothingOuterPlagueSuit
   name: plague doctor suit
   description: A bad omen.
@@ -272,10 +256,9 @@
     sprite: Clothing/OuterClothing/Misc/plaguedoctorsuit.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/plaguedoctorsuit.rsi
-    #Moffstation - Storage size is defined in parent.
 
 - type: entity
-  parent: ClothingOuterStorageBase #Moffstation - (Chaplain Coats Have Pockets)
+  parent: ClothingOuterStorageBase
   id: ClothingOuterNunRobe
   name: nun robe
   description: Maximum piety in this star system.
@@ -284,7 +267,6 @@
     sprite: Clothing/OuterClothing/Misc/nunrobe.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/nunrobe.rsi
-    #Moffstation - Storage size is defined in parent.
 
 - type: entity
   parent: ClothingOuterBase


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
This PR gives the following Chaplain coats pockets:

2x2:
- Black Hoodie
- Grey Hoodie (Even though it's not technically a Chaplain hoodie)
- Chaplain's Hoodie

3x2:
- Plague Doctor Suit
- Nun Robes
- Cultist Robes

## Why / Balance
This is merely a QoL change for the Chaplain, letting them carry **small** items like their Bible, Stamp, or even a bottle of Holy Water in an out-of-the-way place. 

I'd like to see where this goes and slowly add storage to more outer clothing types, such as aprons.

Having more granular storage options assists with organization, as well. 

The Grey Hoodie also got changed because it's basically no more than a recolor of the Black Hoodie, and it wouldn't make sense for them to stay separate.

## Technical details
<!-- Summary of code changes for easier review. -->


`ClothingOuterHoodieGrey` and `ClothingOuterHoodieBlack` have been given the parent `ClothingOuterStorageFoldableBase` to preserve their zip/unzip functionality.

`ClothingOuterHoodieChaplain` has been given the parent `ClothingOuterStorageToggleableBase`.

All three of the above have been given a storage component with a redefined grid of `0,0,1,1`. 

`ClothingOuterRobesCult`, `ClothingOuterPlagueSuit`, and `ClothingOuterNunRobe` have all been given the parent `ClothingOuterStorageBase` with *no* defined grid. This is because the inherited grid is the desired size (3x2).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="514" height="453" alt="image" src="https://github.com/user-attachments/assets/7cf37bec-ca95-4a6c-a970-2a81dfea6409" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

None.


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Plague Suit, Cult & Nun Robes, Chaplain's Hoodie and the Black & Grey hoodies now have a bit of storage.