### PR TITLE
Consistent 3 second grenade fuses.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -557,8 +557,10 @@
   components:
   - type: Sprite
     sprite: Objects/Weapons/Grenades/metalfoam.rsi
-  - type: TimerTrigger
-    delay: 5
+  # Moffstation - Begin (Consistent Grenade Fusing) We inherit 3s fuse from the parent.
+  #- type: TimerTrigger
+    #delay: 5
+  # Moffstation - End
   - type: SmokeOnTrigger
     keysIn:
     - timer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -85,7 +85,7 @@
   - type: TimerTrigger
     initialBeepDelay: 0
     beepInterval: 2
-    delay: 3.5
+    delay: 3 # Moffstation - (Consistent Grenade Fusing) Set from 3.5s to 3s for consistency.
   - type: TimerTriggerVisuals
     primingSound:
       path: /Audio/Effects/countdown.ogg
@@ -112,7 +112,7 @@
         volume: 5
     initialBeepDelay: 0
     beepInterval: 2
-    delay: 3.5
+    delay: 3 # Moffstation - (Consistent Grenade Fusing) Set from 3.5s to 3s for consistency.
   - type: EmitSoundOnTrigger
     keysIn:
     - timer
@@ -144,7 +144,7 @@
         volume: 5
     initialBeepDelay: 0
     beepInterval: 2
-    delay: 3.5
+    delay: 3 # Moffstation - (Consistent Grenade Fusing) Set from 3.5s to 3s for consistency.
   - type: EmitSoundOnTrigger
     keysIn:
     - timer


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Set the few 3.5 second fuse grenades to 3 seconds. Of course, unique fuses like the Minibomb's 5 second fuse are not changed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Having to adjust your cooking between two extremely similar times is quite annoying, and it contributes to the huge skill gap with grenade use. This should improve it.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Nox38
- tweak: Changed 3.5 second grenade fuses to 3 seconds.
