### PR TITLE
Forbid AI-generated contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,20 @@ As a base, we expect you to follow the [Space Station 14 Contribution Guidelines
 >
 >We highly recommend you use an IDE like [Jetbrains Rider](https://www.jetbrains.com/rider/). It's free for non-commercial use, and it basically holds your hand.
 
+## AI-generated content
+The Moffstation project does not accept any low-effort or wholesale AI-generated contributions.
+This includes the following, but is not limited to:
+- Any code (C#, YAML, XML, etc.) generated from tools like ChatGPT, Github Copilot, Cursor, and whatever ChatGPT wrapper that's currently the hottest thing on the block.
+- Any artwork, sound files, or other assets.
+- Auto-generated documentation, GitHub's issue/PR changes summarization tools, among other tools.
+
+Exceptions to this are simple tools, for example:
+- Machine learning-assisted full line code completion.
+- Intellisense/ReSharper machine learning-sorted autocompletion suggestions (or any other ML-assisted sorting operation).
+- Machine learning-assisted grammar error correction.
+
+Maintainers still hold the right to deny contributions that have been created by AI, even if they only appear as such.
+
 ## Moffstation-exclusive content
 Space Station 14 allows separate content to be added to the game that is not part of the upstream project in a clean and easy way. Separate content is placed in a new subfolder namespace, `_Moffstation`. This is to avoid conflicts with upstream content.
 


### PR DESCRIPTION
## About the PR
Adds section to contribution guidelines stating that AI contributions are disallowed

## Why / Balance
The lying machine loves to lie and it is a waste of everyone's time to determine if AI generated content is actually good. At best it's easy to close because it violates a quadrillion coding style guidelines, at worst it leaves a bomb of a bug in the repo that has to be entirely pulled out by the roots later. AI is only useful if you actually know what you're doing which is how it's never actually used, and even then the previously mentioned caveats still apply.

## Technical details
n/a

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
n/a
