### PR TITLE
Engi-Borgs Regain Recharging RCD

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -742,20 +742,12 @@
     - state: icon-rcd
   - type: ItemBorgModule
     hands:
-    - item: RCD # Moffstation - Death of Engineering Cyborg
+    - item: RCDRecharging
     - item: BorgFireExtinguisher
     - item: BorgHandheldGPSBasic
     - item: GasAnalyzer
     - item: HolofanProjectorBorg
     - item: GeigerCounter
-    # Moffstation - Start - Death of Engineering Cyborg
-    - hand:
-        emptyRepresentative: RCDAmmo
-        emptyLabel: borg-slot-rcd-ammo-empty
-        whitelist:
-          components:
-          - RCDAmmo
-    # Moffstation - End
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: rcd-module }
 


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->

Reverts Borg RCDs to the recharging variant instead of the base one that requires ammo.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

It pretty much boils down to, the original # 1 claim from https://github.com/moff-station/moff-station-14/pull/610 just isn't true, and second, the change honestly just wasn't needed. 

1. From https://github.com/moff-station/moff-station-14/pull/610 _"When RCDs were first given to engineering cyborgs, they were given a recharge feature was solely based on technical limitations"_

I do not know where this came from but you can see the PRs where RCDs were added to borgs https://github.com/space-wizards/space-station-14/pull/18136 and technically https://github.com/space-wizards/space-station-14/pull/22799 - they were always supposed to recharge, this was not necessarily a coding limitation and isn't mentioned as such anywhere.

The second reason this was changed was due to 'engineering borgs being too strong'. My points to that are:

1. The change is almost entirely a QoL hit and doesn't affect the 'power' of the engi borg.
2. People generally pick borgs based on the job they wanna do, not how strong they are - I don't think we need to worry about that nitty gritty balance too much. 
3. The rechargable RCD already had a downside of taking a long time to recharge once the charges are used. It is mainly a convenience factor since borgs don't have a bag to hold a lot of RCD fuel - the 1 hand slot in the current version isn't enough, you have to go get more constantly in comparison - and so you're not stealing all the RCD fuel from other engis / their lockers.  

But I mainly go "hey has this meaningfully changed my experience as an engiborg in a positive way or has it changed the balance of engiborg to accomplish the goal of making it weaker" and I would say no on both counts - it's mainly just an annoyance to gameplay.

## Technical details
<!-- Summary of code changes for easier review. -->

Borg Item went from RCD to RCDRecharging
Got rid of hand for RCD ammo.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
- tweak: Borg RCDs are self-recharging again.

