### PR TITLE
New Playtime reminders

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -225,17 +225,16 @@ namespace Content.Client.Lobby
             {
                 Lobby!.PlaytimeComment.Visible = true;
 
-                var hoursToday = Math.Round(minutesToday / 60f, 1);
+                // Moffstation - Start - Custom playtime remarks
+                var chosenString =
+                    minutesToday < 720
+                        ? "chat-manager-client-hourly-playtime-notice"
+                        : "lobby-state-playtime-comment-too-much";
 
-                var chosenString = minutesToday switch
-                {
-                    < 180 => "lobby-state-playtime-comment-normal",
-                    < 360 => "lobby-state-playtime-comment-concerning",
-                    < 720 => "lobby-state-playtime-comment-grasstouchless",
-                    _ => "lobby-state-playtime-comment-selfdestructive"
-                };
-
-                Lobby.PlaytimeComment.SetMarkup(Loc.GetString(chosenString, ("hours", hoursToday)));
+                var playtime = TimeSpan.FromMinutes(minutesToday);
+                var localTime = DateTime.Now.ToString("t");
+                Lobby.PlaytimeComment.SetMarkup(Loc.GetString(chosenString, ("hours", playtime.Hours), ("minutes", playtime.Minutes), ("time", localTime)));
+                // Moffstation - End
             }
             else
                 Lobby!.PlaytimeComment.Visible = false;

--- a/Resources/Locale/en-US/_Moffstation/playtime/playtime-reminder.ftl
+++ b/Resources/Locale/en-US/_Moffstation/playtime/playtime-reminder.ftl
@@ -1,0 +1,9 @@
+lobby-state-playtime-comment-too-much =
+    You've played {$hours} { $hours ->
+    [1]hour
+    *[other]hours
+        } and {$minutes} { $minutes ->
+    [1]minute
+    *[other]minutes
+        } today. It's currently {$time}.
+    Please take a shower!


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Changes the playtime reminder to match the chat one, except for when you've played for over 12 hours
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As said before I'm not a fan of the snark from the old ones, this one has the same text as the playtime reminder that appears every hour in chat, which I believe is a more effective way of encouraging people to take breaks.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="685" height="140" alt="image" src="https://github.com/user-attachments/assets/6df42b4e-22ba-4c5b-b70f-30512a519be8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
