### PR TITLE
Give Rust Removal a shorter Doafter

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -513,7 +513,7 @@
         - to: wall
           steps:
             - tool: Brushing
-              doAfter: 3
+              doAfter: 4
 
     - node: reinforcedWallRust
       entity: WallReinforcedRust
@@ -521,7 +521,7 @@
         - to: reinforcedWall
           steps:
             - tool: Welding
-              doAfter: 2
+              doAfter: 1
         - to: reinforcedWall
           steps:
             - tool: Brushing


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
Brushing off rust now takes 4 seconds - 1/3 of the time - and welding it off now takes 1 second. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Let's be real, here. 12 seconds to brush ONE wall free of rust? Good luck making a dent in any of the run-down maps, like Elkridge. This is such a simple change and impacts gameplay in basically zero way apart from convenience.

## Technical details
<!-- Summary of code changes for easier review. -->
Welding and Brushing doafters for rusted solid and reinforced walls lowered from 5 and 12 to 1 and 4 respectively.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Exempt.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No breaking changes.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed doafters for both welding and brushing rust from walls from 5 and 12 seconds to 1 and 4 seconds, respectively.
