### PR TITLE
Obfuscate xenoarcheology

### DIFF
--- a/Resources/Locale/en-US/_Moffstation/xenoarcheology/artifact-hints.ftl
+++ b/Resources/Locale/en-US/_Moffstation/xenoarcheology/artifact-hints.ftl
@@ -1,0 +1,10 @@
+﻿## See upstream guidelines for xenoarcheology hints and triggers; reuse what you can, and effects should be more vague than triggers.
+
+## Effects
+
+## Triggers
+xenoarch-trigger-tip-cleaner = Cleaning solution
+xenoarch-trigger-tip-euphoria = Liquid euphoria
+xenoarch-trigger-tip-lube = Lubrication
+xenoarch-trigger-tip-narcotics = Illegal stimulants
+xenoarch-trigger-tip-tropical-drink = Tropical cocktail

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -603,7 +603,7 @@
 - type: entity
   id: XenoArtifactHeatWave
   parent: BaseXenoArtifactEffect
-  description: Energy release # Moffstation - Obfuscate xenoarcheology
+  description: Exothermic action # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAETemperature
     targetTemp: 500

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -229,14 +229,14 @@
 - type: entity
   id: XenoArtifactPhasing
   parent: BaseOneTimeXenoArtifactEffect
-  description: Becomes phased
+  description: Structural phasing # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAERemoveCollision
 
 - type: entity
   id: XenoArtifactWandering
   parent: BaseOneTimeXenoArtifactEffect
-  description: Starts to move sporadically
+  description: Metaphysical displacement # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     components:
@@ -249,7 +249,7 @@
 - type: entity
   id: XenoArtifactSolutionStorage
   parent: BaseOneTimeXenoArtifactEffect
-  description: Obtains ability of container for chemical solutions
+  description: Internal chamber # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     components:
@@ -280,7 +280,7 @@
 - type: entity
   id: XenoArtifactSpeedUp
   parent: BaseOneTimeXenoArtifactEffect
-  description: Improves holder movement speed
+  description: Temporal acceleration # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     components:
@@ -291,7 +291,7 @@
 - type: entity
   id: XenoArtifactDrill
   parent: BaseOneTimeXenoArtifactEffect
-  description: Obtains ability of drill
+  description: Serrated rotator # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     components:
@@ -354,7 +354,7 @@
 - type: entity
   id: XenoArtifactGhost
   parent: BaseOneTimeXenoArtifactEffect
-  description: Becomes sentient
+  description: Cerebral influence # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     components:
@@ -374,7 +374,7 @@
 - type: entity
   id: XenoArtifactOmnitool
   parent: BaseOneTimeXenoArtifactEffect
-  description: Obtains ability of omnitool
+  description: Utility conglomerate # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     components:
@@ -421,7 +421,7 @@
 - type: entity
   id: XenoArtifactEffectBadFeeling
   parent: BaseXenoArtifactEffect
-  description: Broadcasts sublime message
+  description: Cerebral influence # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAETelepathic
     messages:
@@ -451,7 +451,7 @@
 - type: entity
   id: XenoArtifactEffectGoodFeeling
   parent: BaseXenoArtifactEffect
-  description: Broadcasts sublime message
+  description: Cerebral influence # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAETelepathic
     messages:
@@ -480,7 +480,7 @@
 - type: entity
   id: XenoArtifactEffectJunkSpawn
   parent: BaseXenoArtifactEffect
-  description: Create recyclable junk
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -503,14 +503,14 @@
 - type: entity
   id: XenoArtifactEffectLightFlicker
   parent: BaseXenoArtifactEffect
-  description: Minor electromagnetic interference
+  description: Electrical interference # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAELightFlicker
 
 - type: entity
   id: XenoArtifactPotassiumWave
   parent: BaseXenoArtifactEffect
-  description: Produces potassium
+  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -537,7 +537,7 @@
 - type: entity
   id: XenoArtifactFloraSpawn
   parent: BaseXenoArtifactEffect
-  description: Produces flora
+  description: Entity translocation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -552,13 +552,13 @@
 - type: entity
   id: XenoArtifactChemicalPuddle
   parent: BaseXenoArtifactEffect
-  description: Produces puddle of chemical mixture # todo: make description say what exact chemical is produced, maybe add mixes into possible chemicals
+  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAECreatePuddle
     chemAmount:
       min: 1
       max: 3
-    replaceDescription: true
+    replaceDescription: false # Moffstation - Obfuscate xenoarcheology
     chemicalSolution:
       maxVol: 500
       canReact: false
@@ -588,14 +588,14 @@
 - type: entity
   id: XenoArtifactThrowThingsAround
   parent: BaseXenoArtifactEffect
-  description: Minor implosion
+  description: Environmental disruption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEThrowThingsAround
 
 - type: entity
   id: XenoArtifactColdWave
   parent: BaseXenoArtifactEffect
-  description: Cools down surrounding gas
+  description: Energy consumption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAETemperature
     targetTemp: 50
@@ -603,7 +603,7 @@
 - type: entity
   id: XenoArtifactHeatWave
   parent: BaseXenoArtifactEffect
-  description: Heats up surrounding gas greatly
+  description: Energy release # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAETemperature
     targetTemp: 500
@@ -611,10 +611,10 @@
 - type: entity
   id: XenoArtifactFoamMild
   parent: BaseXenoArtifactEffect
-  description: Produces chemical foam # todo: separate in 1 for each chemical for description? actually sounds like a very good idea
+  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEFoam
-    replaceDescription: true
+    replaceDescription: false # Moffstation - Obfuscate xenoarcheology
     reagents:
     - Oxygen
     - Plasma
@@ -631,7 +631,7 @@
 - type: entity
   id: XenoArtifactRandomInstrumentSpawn
   parent: BaseXenoArtifactEffect
-  description: Creates musical instrument
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 2
@@ -651,7 +651,7 @@
 - type: entity
   id: XenoArtifactMonkeySpawn
   parent: BaseXenoArtifactEffect
-  description: Creates primate
+  description: Entity translocation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 3
@@ -674,7 +674,7 @@
 - type: entity
   id: XenoArtifactRadioactive
   parent: BaseOneTimeXenoArtifactEffect
-  description: Becomes mildly radioactive
+  description: Energy release # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -687,7 +687,7 @@
 - type: entity
   id: XenoArtifactChargeBattery
   parent: BaseXenoArtifactEffect
-  description: Charges up batteries
+  description: Energy release # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEChargeBattery
   - type: XAETelepathic
@@ -697,7 +697,7 @@
 - type: entity
   id: XenoArtifactKnock
   parent: BaseXenoArtifactEffect
-  description: Mild electromagnetic interference
+  description: Electrical interference # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEKnock
   - type: XAELightFlicker
@@ -705,7 +705,7 @@
 - type: entity
   id: XenoArtifactMagnet
   parent: BaseOneTimeXenoArtifactEffect
-  description: Create small gravity well
+  description: Magnetic waves # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -719,7 +719,7 @@
 - type: entity
   id: XenoArtifactMagnetNegative
   parent: BaseOneTimeXenoArtifactEffect
-  description: Create small gravity well
+  description: Magnetic waves # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -733,7 +733,7 @@
 - type: entity
   id: XenoArtifactStealth
   parent: BaseOneTimeXenoArtifactEffect
-  description: Create light interference
+  description: Visual distortions # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     components:
@@ -776,7 +776,7 @@
 - type: entity
   id: XenoArtifactRareMaterialSpawnSilver
   parent: BaseXenoArtifactEffect
-  description: Create rare materials
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 4
@@ -799,7 +799,7 @@
 - type: entity
   id: XenoArtifactRareMaterialSpawnPlasma
   parent: BaseXenoArtifactEffect
-  description: Create plasma
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 4
@@ -822,7 +822,7 @@
 - type: entity
   id: XenoArtifactRareMaterialSpawnGold
   parent: BaseXenoArtifactEffect
-  description: Create gold
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 3
@@ -845,7 +845,7 @@
 - type: entity
   id: XenoArtifactRareMaterialSpawnUranium
   parent: BaseXenoArtifactEffect
-  description: Create uranium
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 4
@@ -868,7 +868,7 @@
 - type: entity
   id: XenoArtifactAngryCarpSpawn
   parent: BaseXenoArtifactEffect
-  description: Create hostile fish
+  description: Entity translocation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 3
@@ -891,7 +891,7 @@
 - type: entity
   id: XenoArtifactFaunaSpawn
   parent: BaseXenoArtifactEffect
-  description: Create fauna # Moffstation - Revert artifact mob change
+  description: Entity translocation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 4
@@ -979,7 +979,7 @@
 - type: entity
   id: XenoArtifactCashSpawn
   parent: BaseXenoArtifactEffect
-  description: Create money
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 2
@@ -1008,7 +1008,7 @@
 - type: entity
   id: XenoArtifactShatterWindows
   parent: BaseXenoArtifactEffect
-  description: Break windows
+  description: Environmental disruption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 3
@@ -1027,7 +1027,7 @@
 - type: entity
   id: XenoArtifactFoamGood
   parent: BaseXenoArtifactEffect
-  description: Creates wave of helpful foam
+  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 7
@@ -1035,7 +1035,7 @@
       min: 0
       max: 5
   - type: XAEFoam
-    replaceDescription: true
+    replaceDescription: false # Moffstation - Obfuscate xenoarcheology
     reagents:
     - Dermaline
     - Arithrazine
@@ -1048,12 +1048,12 @@
 - type: entity
   id: XenoArtifactFoamDangerous
   parent: BaseXenoArtifactEffect
-  description: Creates wave of harmful foam
+  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEFoam
     minFoamAmount: 20
     maxFoamAmount: 30
-    replaceDescription: true
+    replaceDescription: false # Moffstation - Obfuscate xenoarcheology
     reagents:
     - Tritium
     - Plasma
@@ -1070,13 +1070,13 @@
 - type: entity
   id: XenoArtifactPuddleRare
   parent: BaseXenoArtifactEffect
-  description: Creates puddle of helpful chemicals
+  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAECreatePuddle
     chemAmount:
       min: 1
       max: 3
-    replaceDescription: true
+    replaceDescription: false # Moffstation - Obfuscate xenoarcheology
     chemicalSolution:
       maxVol: 500
       canReact: false
@@ -1100,7 +1100,7 @@
 - type: entity
   id: XenoArtifactAnomalySpawn
   parent: BaseOneTimeXenoArtifactEffect
-  description: Creates anomaly
+  description: Environmental disruption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -1115,7 +1115,7 @@
 - type: entity
   id: XenoArtifactIgnite
   parent: BaseXenoArtifactEffect
-  description: Pyrokinesis
+  description: Energy release # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEIgnite
     range: 7
@@ -1126,14 +1126,14 @@
 - type: entity
   id: XenoArtifactTeleport
   parent: BaseXenoArtifactEffect
-  description: Teleportation
+  description: Metaphysical displacement # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAERandomTeleportInvoker
 
 - type: entity
   id: XenoArtifactEmp
   parent: BaseXenoArtifactEffect
-  description: Dangerous electromagnetic interference
+  description: Energy consumption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 5
@@ -1145,14 +1145,14 @@
 - type: entity
   id: XenoArtifactPolyMonkey
   parent: BaseXenoArtifactEffect
-  description: Temporarily reshape flesh to fur
+  description: Transmogrificational activity # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEPolymorph
 
 - type: entity
   id: XenoArtifactPolyLizard
   parent: BaseXenoArtifactEffect
-  description: Temporarily reshape flesh to scale
+  description: Transmogrificational activity # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEPolymorph
     polymorphPrototypeName: ArtifactLizard
@@ -1160,7 +1160,7 @@
 - type: entity
   id: XenoArtifactPolyLuminous
   parent: BaseXenoArtifactEffect
-  description: Temporarily reshape flesh to light
+  description: Transmogrificational activity # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEPolymorph
     polymorphPrototypeName: ArtifactLuminous
@@ -1168,7 +1168,7 @@
 - type: entity
   id: XenoArtifactRadioactiveStrong
   parent: BaseOneTimeXenoArtifactEffect
-  description: Becomes highly radioactive
+  description: Energy release # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -1181,7 +1181,7 @@
 - type: entity
   id: XenoArtifactMaterialSpawnGlass
   parent: BaseXenoArtifactEffect
-  description: Create glass
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -1196,7 +1196,7 @@
 - type: entity
   id: XenoArtifactMaterialSpawnSteel
   parent: BaseXenoArtifactEffect
-  description: Create steel
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -1211,7 +1211,7 @@
 - type: entity
   id: XenoArtifactMaterialSpawnPlastic
   parent: BaseXenoArtifactEffect
-  description: Create plastic
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -1226,14 +1226,14 @@
 - type: entity
   id: XenoArtifactPortal
   parent: BaseXenoArtifactEffect
-  description: Create short-living bluespace portal
+  description: Metaphysical displacement # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEPortal
 
 - type: entity
   id: XenoArtifactArtifactSpawn
   parent: BaseXenoArtifactEffect
-  description: Create artifact
+  description: Entity translocation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 2
@@ -1253,7 +1253,7 @@
 - type: entity
   id: XenoArtifactShuffle
   parent: BaseXenoArtifactEffect
-  description: Switch places of sentient beings #not ALL beings, but oh well...
+  description: Metaphysical displacement # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEShuffle
   - type: XAETelepathic
@@ -1264,7 +1264,7 @@
 - type: entity
   id: XenoArtifactHealAll
   parent: BaseXenoArtifactEffect
-  description: Miraclous healing
+  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEDamageInArea
     damageChance: 1
@@ -1310,7 +1310,7 @@
 - type: entity
   id: XenoArtifactExplosionScary
   parent: BaseOneTimeXenoArtifactEffect
-  description: Small scale high-speed nuclear reaction
+  description: Environmental disruption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAETriggerExplosives
   - type: Explosive
@@ -1325,7 +1325,7 @@
 - type: entity
   id: XenoArtifactBoom
   parent: BaseOneTimeXenoArtifactEffect
-  description: Explosion
+  description: Environmental disruption # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAETriggerExplosives
   - type: Explosive
@@ -1339,7 +1339,7 @@
 - type: entity
   id: XenoArtifactEffectCreationGasPlasma
   parent: BaseXenoArtifactEffect
-  description: Expels plasma
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAECreateGas
     gases:
@@ -1348,7 +1348,7 @@
 - type: entity
   id: XenoArtifactEffectCreationGasTritium
   parent: BaseXenoArtifactEffect
-  description: Expels tritium
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAECreateGas
     gases:
@@ -1357,7 +1357,7 @@
 - type: entity
   id: XenoArtifactEffectCreationGasAmmonia
   parent: BaseXenoArtifactEffect
-  description: Expels ammonia
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAECreateGas
     gases:
@@ -1366,7 +1366,7 @@
 - type: entity
   id: XenoArtifactEffectCreationGasFrezon
   parent: BaseXenoArtifactEffect
-  description: Expels frezon
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAECreateGas
     gases:
@@ -1375,7 +1375,7 @@
 - type: entity
   id: XenoArtifactEffectCreationGasNitrousOxide
   parent: BaseXenoArtifactEffect
-  description: Expels nitrous oxide
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAECreateGas
     gases:
@@ -1384,7 +1384,7 @@
 - type: entity
   id: XenoArtifactEffectCreationGasCarbonDioxide
   parent: BaseXenoArtifactEffect
-  description: Expels carbon dioxide
+  description: Matter creation # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAECreateGas
     gases:

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -1168,7 +1168,7 @@
 - type: entity
   id: XenoArtifactRadioactiveStrong
   parent: BaseOneTimeXenoArtifactEffect
-  description: Energy release # Moffstation - Obfuscate xenoarcheology
+  description: Exothermic action # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -674,7 +674,7 @@
 - type: entity
   id: XenoArtifactRadioactive
   parent: BaseOneTimeXenoArtifactEffect
-  description: Energy release # Moffstation - Obfuscate xenoarcheology
+  description: Exothermic action # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -1115,7 +1115,7 @@
 - type: entity
   id: XenoArtifactIgnite
   parent: BaseXenoArtifactEffect
-  description: Energy release # Moffstation - Obfuscate xenoarcheology
+  description: Exothermic action # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEIgnite
     range: 7

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -1133,7 +1133,7 @@
 - type: entity
   id: XenoArtifactEmp
   parent: BaseXenoArtifactEffect
-  description: Energy consumption # Moffstation - Obfuscate xenoarcheology
+  description: Endothermic action # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XenoArtifactNode
     maxDurability: 5

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -595,7 +595,7 @@
 - type: entity
   id: XenoArtifactColdWave
   parent: BaseXenoArtifactEffect
-  description: Energy consumption # Moffstation - Obfuscate xenoarcheology
+  description: Endothermic action # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAETemperature
     targetTemp: 50

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -687,7 +687,7 @@
 - type: entity
   id: XenoArtifactChargeBattery
   parent: BaseXenoArtifactEffect
-  description: Energy release # Moffstation - Obfuscate xenoarcheology
+  description: Exothermic action # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAEChargeBattery
   - type: XAETelepathic

--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -27,6 +27,13 @@
     TriggerThrow: 1
     TriggerDeath: 1
     TriggerMagnet: 1
+#   Moffstation - Start - Obfuscate xenoarcheology
+    TriggerCleaner: 0.5
+    TriggerEuphoria: 0.1
+    TriggerLube: 0.5
+    TriggerNarcotics: 0.1
+    TriggerTropicalDrink: 0.25
+#   Moffstation - End
 
 - type: xenoArchTrigger
   id: TriggerMusic

--- a/Resources/Prototypes/_Moffstation/XenoArch/triggers.yml
+++ b/Resources/Prototypes/_Moffstation/XenoArch/triggers.yml
@@ -1,0 +1,49 @@
+﻿- type: xenoArchTrigger
+  id: TriggerCleaner
+  tip: xenoarch-trigger-tip-cleaner
+  components:
+  - type: XATReactive
+    reagents:
+    - SpaceCleaner
+    - Bleach
+
+- type: xenoArchTrigger
+  id: TriggerEuphoria
+  tip: xenoarch-trigger-tip-euphoria
+  components:
+  - type: XATReactive
+    reagents:
+    - Happiness
+    - Laughter
+    - Psicodine
+
+- type: xenoArchTrigger
+  id: TriggerLube
+  tip: xenoarch-trigger-tip-lube
+  components:
+  - type: XATReactive
+    reagents:
+    - SpaceLube
+
+- type: xenoArchTrigger
+  id: TriggerNarcotics
+  tip: xenoarch-trigger-tip-narcotics
+  components:
+  - type: XATReactive
+    reagents:
+    - Ephedrine
+    - Desoxyephedrine
+    - Stimulants
+
+- type: xenoArchTrigger
+  id: TriggerTropicalDrink
+  tip: xenoarch-trigger-tip-tropical-drink
+  components:
+  - type: XATReactive
+    reagents:
+    - BahamaMama
+    - BlueHawaiian
+    - ElectricShark
+    - JungleBird
+    - PinaColada
+    - PlantersPunch


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Changed xenoarchology nodes to have more vague and overlapping effect descriptions, as well as adding 5 new possible triggers!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Now that we've had ample time to playtest new xenoarcheology, one of the common complaints that I hear among hypothetical scientist players is simply, xenoarcheology provides the player too much information. Part of the enjoyment was the risk of not knowing exactly what each node did right from the get-go, and having to mentally puzzle and solve what specific reactions did, or prepare for what possible reactions could do. In xenoarcheology's current implementation, there is near-zero risk unless the scientist is intentionally being careless, as reading the console tells you everything you would ever need to know, let alone the amount of time you're given to flee from an artifact after triggering it.

Additionally, while there are plenty of nodes that ask for various gasses, there are only 2 nodes that strictly require a liquid - water and blood - so these additional triggers utilize this system in greater depth, particularly aimed at encouraging collaboration between xenoarcheologists and chemists, bartenders, and janitors.

## Technical details
<!-- Summary of code changes for easier review. -->

redefined the 'description' field for every actively used xenoarcheology effect, specifying 'replaceDescription: false' on nodes that would otherwise explicitly define their reaction product.

The descriptions used are as follows:

Biochemical disruption - For when the artifact produces chemical puddles or foams
Cerebral influence - For when the artifact gains or affects the minds of others
Electrical interference - For when the artifact disrupts local electronics
Energy consumption - For when the artifact absorbs nearby thermal or electrical energy
Energy release - For when the artifact emits thermal or nuclear energy
Entity translocation - For when plants, creatures, or people are brought to the artifact
Environmental disruption -haha, you know this one.
Internal chamber - For when the artifact gains capacity to hold chemicals
Magnetic waves - For when the artifact manipulates objects around it
Matter creation - For when the artifact creates inanimate objects
Metaphysical displacement - For when the artifact begins to move
Serrated rotator - For when the artifact becomes a weapon
Structural phasing - For when the artifact stops caring about walls
Temporal acceleration - For when the artifact speeds up those carrying it
Transmogrificational activity - For when the artifact physically alters those around it
Utility conglomerate - For when the artifact becomes a tool
Visual distortions - For when the artifact becomes invisible

Added 5 new 'XATReactive' triggers, defined within the _Moffstation namespace.

Cleaning solution - Space cleaner and bleach, which you can ask from a janitor.
Liquid euphoria - Laughter, Happiness, or Psicodine, which you can ask from a chemist.
Lubrication - Space Lube, Which you can get from a clown.
Illegal stimulants - Ephedrine, Desoxyephedrine, or Hyperzine, which you can ask from a chemist.
Tropical cocktail - Bahama Mama, Blue Hawaiian, Electric Shark, Jungle Bird, Pina Colada, or Planter's Punch, Which you can ask from a bartender.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="978" height="547" alt="image" src="https://github.com/user-attachments/assets/a0a4eec8-f4e2-4cce-8815-2f91ac7de9ca" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: New xenoarcheology reaction triggers.
- tweak: Made xenoarcheology effects more vague and dangerous.