### PR TITLE
Phenyl Healing Nerf

### DIFF
--- a/Resources/Prototypes/_Mono/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Mono/Reagents/narcotics.yml
@@ -21,6 +21,7 @@
           groups:
             Burn: -1.5 # 12.5 heat, shock, and caustic per 5u
             Brute: -3 # 25 blunt, slash, and pierce per 5u, its a painkiller
+          types:
             Poison: -0.5 # 12.5 poison per 5u
     Narcotic:
       metabolismRate: 0.2


### PR DESCRIPTION
## About the PR
Nerfed healing of phenylpiperidine from being "like 8x better than omni", it now heals around half as much and doesn't heal rads

## Why / Balance
It accidentally used to heal 138 brute per 5u. Oops.

## Technical details
only yaml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- tweak: Tweaked phenyl to have much more balanced healing
