### PR TITLE
Accentless trait changed to 0 point cost

### DIFF
--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -7,7 +7,7 @@
   name: trait-accentless-name
   description: trait-accentless-desc
   category: SpeechTraits
-cost: 0 # Moffstation - change cost to 0 for point balancing
+  cost: 0 # Moffstation - change cost to 0 for point balancing
   components:
   - type: Accentless
     removes:


### PR DESCRIPTION
## About the PR
The accentless trait now costs one point.

## Why / Balance
The price of this trait makes it so no character can have a proper accent that isn't accompanied by their species accent. I do not see the need for this and I believe it allows for more customization options. Some accents already get very complicated when paired with species accents, and having to pick between that or just having the plain SS14 accent isn't optimal.

## Technical details
Edits upstream code.

## Media
<img width="259" height="498" alt="image" src="https://github.com/user-attachments/assets/3050ee5f-3dfb-4d29-9455-3ae080ac2986" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Lady Death's Head
- tweak: Accentless trait changed to 0 point cost instead of 2. Now you can be a stuttering lizard!
