### PR TITLE
Integration test fix

### DIFF
--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -88,14 +88,9 @@ public sealed class GameMapManager : IGameMapManager
 
         var maps = AllVotableMaps().ToArray();
         _random.Shuffle(maps);
-        //Moffstation - Begin - Fixed the Integration test failing due to out Vote Rollover system
-        foreach (var map in maps)//ensures every map gets an Entry and is initzilized
-        {
-            _rollOverVotes[map] = 0;
-        }
-        //Moffstation - End
         foreach (var map in maps)
         {
+            _rollOverVotes[map] = 0; // Moffstation - Initialize rollover votes for all maps.
             if (_previousMaps.Count >= _mapQueueDepth)
                 break;
             _previousMaps.Enqueue(map.ID);


### PR DESCRIPTION
## About the PR
Fixed the Placment  of the Initilization of the Map Vote Rollover System causing the Integration test to fail

## Technical details
Gave the Rollover vote initzilation its own foreachloop so its always initzilaized.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->