### PR TITLE
Fixed Zombies Not joining Their Hivemind

### DIFF
--- a/Content.Client/Zombies/ZombieSystem.cs
+++ b/Content.Client/Zombies/ZombieSystem.cs
@@ -41,7 +41,12 @@ public sealed class ZombieSystem : SharedZombieSystem
 
     private void OnStartup(EntityUid uid, ZombieComponent component, ComponentStartup args)
     {
-        if (TryComp<CollectiveMindComponent>(uid, out var collectiv)) { _collectiveMindUpdateSystem.UpdateCollectiveMind(uid, collectiv); }  // Moffstation - Zombies not getting added to their Hivemind
+        // Moffstation - Begin - Update to give zombies their collective mind communication
+        if (TryComp<CollectiveMindComponent>(uid, out var collective))
+        {
+            _collectiveMindUpdateSystem.UpdateCollectiveMind(uid, collective);
+        }
+        // Moffstation - End
         if (HasComp<HumanoidAppearanceComponent>(uid))
             return;
 


### PR DESCRIPTION
## About the PR
Zombies now get added to their Hivemind

## Why / Balance
Reqested by the Maintainer as this was a bug.

## Technical details
Inside the ZombieSystem.cs UpdateCollectiveMind is now called so that when something gets turned into a zombie its added


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


:cl:
- fix: Zombies Now Get Added to their Hivemind

