### PR TITLE
Phenyl update #2 (Price nerf, fixed Infinite Dylo Hack No Mods 2025, Drunkness adjustment, Haloperidol functionality)

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1504,6 +1504,11 @@
       - !type:AdjustReagent
         reagent: MindbreakerToxin
         amount: -3.0
+      # Moffstation Start - Phenylpiperidine (Fentanyl)
+      - !type:AdjustReagent
+        reagent: Phenylpiperidine
+        amount: -3.0
+      # Moffstation End
 
 - type: reagent
   id: Warfarin

--- a/Resources/Prototypes/_Mono/Entities/Objects/Misc/solids.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Misc/solids.yml
@@ -10,7 +10,7 @@
   - type: Item
     size: Tiny
   - type: StaticPrice
-    price: 1250 # Tweak later once we figure out a good balance
+    price: 900 # Reduced from the 1250 it is in monolith
   - type: Edible
   - type: FlavorProfile
     flavors:
@@ -20,10 +20,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 5
+        maxVol: 4 
         reagents:
         - ReagentId: Phenylpiperidine
-          Quantity: 5
+          Quantity: 4 # Contains 4u but costs 5u to make - No more infinite dylo with 5u of phenyl
   - type: DamageOnLand
     damage:
       types:

--- a/Resources/Prototypes/_Mono/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Mono/Reagents/narcotics.yml
@@ -50,7 +50,7 @@
           reagent: Phenylpiperidine
           max: 20
       - !type:Drunk
-        boozePower: 75
+        boozePower: 35
         # OD effects
       - !type:Vomit
         probability: 0.05


### PR DESCRIPTION
## About the PR
Nerfed the price of phenyl crystals, reduces the amount of chemical contained within the crystals from 5u to 4u. Reduced the chemical's booze power and made haloperidol remove it from your system.

## Why / Balance
Phenyl made just a bit too much money that people were talking about it, and grinding a crystal to get back all the reagent used to make it theoretically allow anyone with a chemmaster, reagent grinder, a single phenyl crystal and a tric pill to make infinite amounts of the dylovene byproduct. Also the sheer amount of time it would make you have the drunk accent was extremely annoying. Halo change to make it consistent with the other narcotics.

## Technical details
Only yml, haloperidol changes are outside our namespace

## Media

## Requirements
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Reduced price of Phenylpiperidine crystals. Phenyl crystals now contain 4u of reagent instead of 5u.
- tweak: Adjusted Phenylpiperidine drunkness values,
- add: Added functionality to Haloperidol to purge Phenylpiperidine from the system
