### PR TITLE
Fixed Paradox Clone Targeting

### DIFF
--- a/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
@@ -61,7 +61,7 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
         else
         {
             // get possible targets
-            var allAliveHumanoids = _mind.GetAliveHumansOnMap(_transform.GetMap(spawner));
+            var allAliveHumanoids = _mind.GetAliveHumansOnMap(_transform.GetMap(spawner)); // Moffstation - Select Paradox Clones only from the same map.
 
             // we already checked when starting the gamerule, but someone might have died since then.
             if (allAliveHumanoids.Count == 0)

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -38,7 +38,8 @@ public abstract partial class SharedMindSystem : EntitySystem
     [Dependency] private readonly MetaDataSystem _metadata = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!; // Moffstation
+
     [ViewVariables]
     protected readonly Dictionary<NetUserId, EntityUid> UserMinds = new();
 
@@ -719,6 +720,7 @@ public abstract partial class SharedMindSystem : EntitySystem
         EnsureComp<ExaminerComponent>(uid);
     }
 
+    // Moffstation - Start - Helper for selecting Paradox Clone targets on the same map.
     /// <summary>
     /// Get all minds on the same Map as the Refrence
     /// </summary>>
@@ -737,6 +739,7 @@ public abstract partial class SharedMindSystem : EntitySystem
         }
         return outminds;
     }
+    // Moffstation - End
 }
 
 /// <summary>


### PR DESCRIPTION
## About the PR
Now only minds on the same map as the spawner are targets for the paradox clone gamerule.
## Why / Balance
This could accidantily clone adming characters such as Centcom Officals that are sitting at CC, or Nukies before they arive at the station.

## Technical details
Added a Loop through all active minds and remove those from the list that arent on the same grid.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl:
- fix: Paradox Clones now will only get made of Personal on the station

