### PR TITLE
Rollover vote getting/setting is infallible

### DIFF
--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -93,7 +93,6 @@ public sealed class GameMapManager : IGameMapManager
             if (_previousMaps.Count >= _mapQueueDepth)
                 break;
             _previousMaps.Enqueue(map.ID);
-            _rollOverVotes[map] = 0; // Moffstation - initialize rollover votes
         }
     }
 
@@ -248,15 +247,10 @@ public sealed class GameMapManager : IGameMapManager
     }
 
     // Moffstation - Start - setters and getters for the rollover votes
-    public int GetRollOverVotes(GameMapPrototype map)
-    {
-        Debug.Assert(_rollOverVotes.ContainsKey(map), $"Attempted to get rollover votes for unknown map \"{map.MapName}\". Existing keys={string.Join(", ", _rollOverVotes.Keys)}");
-        return _rollOverVotes.GetValueOrDefault(map);
-    }
+    public int GetRollOverVotes(GameMapPrototype map) => _rollOverVotes.GetOrNew(map);
 
     public void SetRollOverVotes(GameMapPrototype map, int votes)
     {
-        Debug.Assert(_rollOverVotes.ContainsKey(map), $"Attempted to set rollover votes for unknown map \"{map.MapName}\". Existing keys={string.Join(", ", _rollOverVotes.Keys)}");
         _rollOverVotes[map] = votes;
     }
     // Moffstation - End


### PR DESCRIPTION
No more initializing.
No more inability to get values.

If we try to get a rollover vote value that doesn't exist, it's initialized to 0 in the dictionary and returned immediately.
Setting should already be infallible.