### PR TITLE
Added dead states to moffstation AI sprites

### DIFF
--- a/Resources/Prototypes/_Moffstation/AppearanceCustomization/station_ai.yml
+++ b/Resources/Prototypes/_Moffstation/AppearanceCustomization/station_ai.yml
@@ -7,6 +7,10 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_alien
+    Dead: &defaultdead
+      sprite: Mobs/Silicon/station_ai.rsi
+      state: ai_dead
+
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -16,9 +20,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_angryface
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -28,9 +30,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_bloodylove
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -40,9 +40,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_boxfort
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -52,9 +50,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_cheerful
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -76,9 +72,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_fabulous
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -100,9 +94,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_hades
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -112,9 +104,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_helios
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -124,9 +114,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_honeycomb
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -136,9 +124,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_hourglass
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -148,9 +134,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_magma
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -160,9 +144,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_matrix
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -172,9 +154,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_mono
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -184,9 +164,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_nanotrasen
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -196,9 +174,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_president
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -208,9 +184,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_ravensdale
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -220,9 +194,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_royal
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -232,9 +204,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_sheltered
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -244,9 +214,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_terminal
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -256,9 +224,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_text
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -268,9 +234,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_thinking
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -280,9 +244,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_triumvirate
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -292,9 +254,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_u
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 - type: stationAiCustomization
   parent: StationAiIconBase
@@ -304,9 +264,7 @@
     Occupied:
       sprite: _Moffstation/Mobs/Silicon/station_ai.rsi
       state: ai_wasp
-    Dead:
-      sprite: Mobs/Silicon/station_ai.rsi
-      state: ai_dead
+    Dead: *defaultdead
 
 # Holograms
 - type: stationAiCustomization


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
Added the default bluescreen sprite as the dead state for most of the AI sprites unique to moffstation

## Why / Balance
If an AI using one of those sprites died, it would be really hard to tell as there would be no visual indication

## Technical details
Just some yaml changes, adding the dead layer to all the ai sprites missing it

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x ] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Moffstation ai sprites now properly show when they are dead

