### PR TITLE
More intermitten test failuires Fixes

### DIFF
--- a/Content.IntegrationTests/Tests/Minds/MindTest.DeleteAllThenGhost.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTest.DeleteAllThenGhost.cs
@@ -26,7 +26,7 @@ public sealed partial class MindTests
         // Delete **everything**
         var conHost = pair.Server.ResolveDependency<IConsoleHost>();
         await pair.Server.WaitPost(() => conHost.ExecuteCommand("entities delete"));
-        // Moffstation - Begin - Ensure Clenup Succeds
+        // Moffstation - Begin - Ensure Cleanup Succeeds
         for (var i = 0; i < 60; i++)
         {
             await pair.RunTicksSync(1);


### PR DESCRIPTION
## About the PR
Gives the Mind test more time to delete everything

## Why / Balance
Testfailuires are Meanies and should be outlawed

## Technical details
Before the Mindtest only had 5 simulation ticks to delete everything wich doesnt garuntee anything, now it has up to 60 ticks and checks after everytick if on the ClientSide everything is delete, The normal check on the Server side still runs so if even after 60 ticks it still fails it will be caught.

## Media
Nu uh

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
I would never break anything...