### PR TITLE
Intermitten test failuire caused by Nightvision fix

### DIFF
--- a/Content.Client/_Moffstation/Overlay/Systems/NightVisionSystem.cs
+++ b/Content.Client/_Moffstation/Overlay/Systems/NightVisionSystem.cs
@@ -52,7 +52,7 @@ public sealed class NightVisionSystem : EntitySystem
 
     private void OnPlayerDetached(Entity<NightVisionComponent> ent, ref LocalPlayerDetachedEvent args)
     {
-        RemoveEffect(ent, true);
+        RemoveEffect(ent);
     }
 
     private void OnVisionInit(Entity<NightVisionComponent> ent, ref ComponentInit args)
@@ -78,20 +78,9 @@ public sealed class NightVisionSystem : EntitySystem
         entity.Comp.Effect = effect;
     }
 
-    // `force` is needed because we need to remove the overlay AFTER the player is detached.
-    private void RemoveEffect(Entity<NightVisionComponent> entity, bool force = false)
+    private void RemoveEffect(Entity<NightVisionComponent> entity)
     {
-        if (!force &&
-            _player.LocalSession?.AttachedEntity != entity)
-            return;
-
-        if (!_flash.IsFlashImmune(entity))
-            return;
-
-        if (!_overlayMan.TryGetOverlay(out NightVisionOverlay? overlay))
-            return;
-
-        _overlayMan.RemoveOverlay(overlay);
+        _overlayMan.RemoveOverlay<NightVisionOverlay>();
         PredictedQueueDel(entity.Comp.Effect);
         entity.Comp.Effect = null;
     }


### PR DESCRIPTION
## About the PR
Rip 90% of the function out so it stops complaining

## Why / Balance
caused test failuires

## Technical details
Nolonger only removes the Overlay when the entity has flash immunity...

## Media
Nu uh

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->