### PR TITLE
Give roundstart and latejoin Captains their station's nukecodes.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -49,7 +49,7 @@
   storage:
     back:
     - Flash
-    - BoxFolderStationNuclearCodes
+    - BoxFolderStationNuclearCodes # Moffstation - Station nuke codes
     # - StationCharter
 
 - type: chameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -49,6 +49,7 @@
   storage:
     back:
     - Flash
+    - BoxFolderStationNuclearCodes
     # - StationCharter
 
 - type: chameleonOutfit

--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Misc/folders.yml
@@ -1,8 +1,8 @@
 ﻿- type: entity
-  parent: [ BaseItem , BaseCentcommCommandContraband ]
+  parent: [ BoxFolderNuclearCodes , BaseCentcommCommandContraband ]
   id: BoxFolderStationNuclearCodes
   name: nuclear code folder
-  description: A standard Nanotrasen brand folder, marked "For Captain's eyes only."
+  description: A standard Nanotrasen brand folder with a small warning stamp - "open only in case of irreversible station loss."
   components:
   - type: Sprite
     sprite: Objects/Misc/folders.rsi
@@ -12,12 +12,8 @@
     - state: folder-base
     - state: folder-stamp-inverse
       color: "#ffce5b"
-  - type: PhysicalComposition
-    materialComposition:
-      Paper: 50
   - type: SpawnItemsOnUse
     items:
     - id: NukeCodePaperStation
     sound:
       path: /Audio/Effects/packetrip.ogg
-  - type: Appearance

--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Misc/folders.yml
@@ -1,0 +1,23 @@
+﻿- type: entity
+  parent: [ BaseItem , BaseCentcommCommandContraband ]
+  id: BoxFolderStationNuclearCodes
+  name: nuclear code folder
+  description: A standard Nanotrasen brand folder, marked "For Captain's eyes only."
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/folders.rsi
+    layers:
+    - state: folder-colormap
+      color: "#2a365e"
+    - state: folder-base
+    - state: folder-stamp-inverse
+      color: "#ffce5b"
+  - type: PhysicalComposition
+    materialComposition:
+      Paper: 50
+  - type: SpawnItemsOnUse
+    items:
+    - id: NukeCodePaperStation
+    sound:
+      path: /Audio/Effects/packetrip.ogg
+  - type: Appearance


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Gives non-acting Captains codes to their station nuclear device.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This change is meant to address a few setting continuity issues while also create new opportunities for antagonistic roleplay.

First, thematically, while Nanotrasen has the capacity to remotely detonate the nuke without disk as a failsafe, it is odd that the captain has the nuke disk used to arm the device but not the codes themselves, while they are meant to act as a physical on-the-site failsafe if Nanotrasen's remote detonation fails. You would imagine that the captain, if not command, would have this information, as they should have access to all faucets of the station. And while yes, a captain /could/ request for these codes - it's rare that the captain has the time to file for a request at the time they may need them, and wait for Nanotrasen to respond back. By giving them the codes shift start, they will have this information available - leading to opportunities of interrogation and roleplay - even if they do not need it in 99% of cases.

As it currently stands, the station nuclear fission device is a heavily guarded McGuffin, with very little use outside of NukeOps and technically thieves. While not every shift needs to involve the nuclear device, there is a missed opportunity for its involvement in non-militant scenarios, where other antagonistic factions may attempt to discover the codes for their use - or reverse, the station arms the nuke in a 'all hope is lost' scenario.

One concern I have heard regarding this is bad captains just nuking their own station "for the funny". While it is a valid concern, I do not expect this will be an issue within Moffstation specifically, as we are a whitelist MRP community and have furthermore reenabled role timers for command roles. I do think from a meta perspective this may encourage more folks to play command - for the opportunity to partake in scenarios that evolve from this change - and as a whole I believe this to be a positive to pursue.

Ultimately, in 99% of shifts, I do not expect this change to make much of a difference - but for the opportunities of roleplay it opens within this disaster roleplay game, I believe this is a change worth experimenting with.

## Technical details
<!-- Summary of code changes for easier review. -->

Created a NT folder with the station nuke codes, and added it to the Captain's role loadout.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="689" height="457" alt="image" src="https://github.com/user-attachments/assets/3a22a15d-3aae-4c29-a8b0-e95e4533ea3c" />

_Nuke code folder._

<img width="625" height="142" alt="image" src="https://github.com/user-attachments/assets/2ac3c49e-6266-4b5f-b1d1-cdfe72780696" />

_Station nuke codes._

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: Captains now start with their station's nuclear codes.