### PR TITLE
Add wrecks to space traffic events

### DIFF
--- a/Resources/Locale/en-US/_Moffstation/station-events/wrecks.ftl
+++ b/Resources/Locale/en-US/_Moffstation/station-events/wrecks.ftl
@@ -1,0 +1,1 @@
+﻿station-event-wreck-incoming = Attention! A large mass of debris has been detected drifting into your sector.

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -499,6 +499,8 @@
         tableId: UnknownShuttlesFreelanceTable
       - !type:NestedSelector
         tableId: UnknownShuttlesHostileTable
+      - !type:NestedSelector
+        tableId: WreckEventTable # Moffstation - Wrecks as space traffic events
 
 - type: entity
   id: BasicStationEventScheduler

--- a/Resources/Prototypes/_Moffstation/GameRules/wrecks.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/wrecks.yml
@@ -27,6 +27,7 @@
   parent: BaseGameRule
   id: BasewreckRule
   components:
+  - type: DummyRule
   - type: StationEvent
     startAnnouncement: station-event-wreck-incoming
     startAudio:

--- a/Resources/Prototypes/_Moffstation/GameRules/wrecks.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/wrecks.yml
@@ -1,0 +1,170 @@
+﻿- type: entityTable
+  id: WreckEventTable
+  table: !type:AllSelector
+    children:
+    - id: WreckAbandonedOutpost
+    - id: WreckAtmosInterchange
+    - id: WreckChunkedTComms
+    - id: WreckBiodomeSatellite
+    - id: WreckDerelict
+    - id: WreckDJStation
+    - id: WreckEmptyFlagship
+    - id: WreckHydroOutpost
+    - id: WreckOldAISat
+    - id: WreckRuinedPrisonShip
+    - id: WreckSyndicateDropship
+    - id: WreckWhiteshipAncient
+    - id: WreckWhiteshipBluespaceJumper
+    - id: WreckWrecklaimer
+    - id: WreckDisplacedTelescience
+
+
+
+- type: entity
+  abstract: true
+  parent: BaseGameRule
+  id: BasewreckRule
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-wreck-incoming
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    weight: 10 # 10 default
+    reoccurrenceDelay: 30
+    duration: 1
+    maxOccurrences: 1
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckAbandonedOutpost
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/abandoned_outpost.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckAtmosInterchange
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/atmos_interchange.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckChunkedTComms
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/chunked_tcomms.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckBiodomeSatellite
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/biodome_satellite.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckDerelict
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/derelict.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckDJStation
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/djstation.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckEmptyFlagship
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/empty_flagship.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckHydroOutpost
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/hydro_outpost.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckOldAISat
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/old_ai_sat.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckRuinedPrisonShip
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/ruined_prison_ship.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckSyndicateDropship
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/syndicate_dropship.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckWhiteshipAncient
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/whiteship_ancient.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckWhiteshipBluespaceJumper
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/whiteship_bluespacejumper.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckWrecklaimer
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/wrecklaimer.yml
+    minimumDistance: 250
+    maximumDistance: 750
+
+- type: entity
+  parent: BasewreckRule
+  id: WreckDisplacedTelescience
+  components:
+  - type: LoadGridRule
+    gridPath: /Maps/Ruins/displaced_telescience.yml
+    minimumDistance: 250
+    maximumDistance: 750

--- a/Resources/Prototypes/_Moffstation/GameRules/wrecks.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/wrecks.yml
@@ -1,4 +1,6 @@
-﻿- type: entityTable
+﻿# Wreck game rule table
+
+- type: entityTable
   id: WreckEventTable
   table: !type:AllSelector
     children:
@@ -18,7 +20,7 @@
     - id: WreckWrecklaimer
     - id: WreckDisplacedTelescience
 
-
+# Wreck game rule base
 
 - type: entity
   abstract: true
@@ -33,6 +35,8 @@
     reoccurrenceDelay: 30
     duration: 1
     maxOccurrences: 1
+
+# Wreck game rules
 
 - type: entity
   parent: BasewreckRule


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Adds static wrecks to space traffic events.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Honestly a bit surprising this doesn't already happen - having new debris wander into the local 'airspace' feels thematic, and provides salvage with another midgame activity they can selectively choose to participate in.

## Technical details
<!-- Summary of code changes for easier review. -->
Created new BaseGameRule table utilizing the 'loadgrid' component from LPO to load wreck grids in when triggered.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="650" height="650" alt="image" src="https://github.com/user-attachments/assets/453f4d10-2547-4a00-a1a5-d2a36122f62a" />

_'WreckDerelict', out in space._

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: New event where wrecks drift into nearby sector space.