### PR TITLE
Hotfix: Revert IFF changes for the pirate cove.

### DIFF
--- a/Content.Client/Shuttles/BUI/IFFConsoleBoundUserInterface.cs
+++ b/Content.Client/Shuttles/BUI/IFFConsoleBoundUserInterface.cs
@@ -23,7 +23,7 @@ public sealed class IFFConsoleBoundUserInterface : BoundUserInterface
 
         _window = this.CreateWindowCenteredLeft<IFFConsoleWindow>();
         _window.ShowIFF += SendIFFMessage;
-        _window.ShowVessel += SendVesselMessage;
+        _window.ShowVessel += SendVesselMessage; // Moffstation - Revert IFF changes
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)
@@ -44,6 +44,7 @@ public sealed class IFFConsoleBoundUserInterface : BoundUserInterface
         });
     }
 
+    // Moffstation - Start - Revert IFF changes
     private void SendVesselMessage(bool obj)
     {
         SendMessage(new IFFShowVesselMessage()
@@ -51,6 +52,7 @@ public sealed class IFFConsoleBoundUserInterface : BoundUserInterface
             Show = obj,
         });
     }
+    // Moffstation - End
 
     protected override void Dispose(bool disposing)
     {

--- a/Content.Client/Shuttles/BUI/IFFConsoleBoundUserInterface.cs
+++ b/Content.Client/Shuttles/BUI/IFFConsoleBoundUserInterface.cs
@@ -23,6 +23,7 @@ public sealed class IFFConsoleBoundUserInterface : BoundUserInterface
 
         _window = this.CreateWindowCenteredLeft<IFFConsoleWindow>();
         _window.ShowIFF += SendIFFMessage;
+        _window.ShowVessel += SendVesselMessage;
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)
@@ -38,6 +39,14 @@ public sealed class IFFConsoleBoundUserInterface : BoundUserInterface
     private void SendIFFMessage(bool obj)
     {
         SendMessage(new IFFShowIFFMessage()
+        {
+            Show = obj,
+        });
+    }
+
+    private void SendVesselMessage(bool obj)
+    {
+        SendMessage(new IFFShowVesselMessage()
         {
             Show = obj,
         });

--- a/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml
@@ -9,12 +9,13 @@
                 <Button Name="ShowIFFOnButton" Text="{Loc 'iff-console-on'}" StyleClasses="OpenRight" />
                 <Button Name="ShowIFFOffButton" Text="{Loc 'iff-console-off'}" StyleClasses="OpenLeft" />
             </BoxContainer>
-
+<!-- Moffstation - Start - Revert IFF changes -->
             <Label Name="ShowVesselLabel" Text="{Loc 'iff-console-show-vessel-label'}" HorizontalExpand="True" StyleClasses="highlight" />
             <BoxContainer Orientation="Horizontal" MinWidth="120">
                 <Button Name="ShowVesselOnButton" Text="{Loc 'iff-console-on'}" StyleClasses="OpenRight" />
                 <Button Name="ShowVesselOffButton" Text="{Loc 'iff-console-off'}" StyleClasses="OpenLeft" />
             </BoxContainer>
+<!-- Moffstation - End -->
         </GridContainer>
     </BoxContainer>
 </controls:FancyWindow>

--- a/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml
@@ -9,6 +9,12 @@
                 <Button Name="ShowIFFOnButton" Text="{Loc 'iff-console-on'}" StyleClasses="OpenRight" />
                 <Button Name="ShowIFFOffButton" Text="{Loc 'iff-console-off'}" StyleClasses="OpenLeft" />
             </BoxContainer>
+
+            <Label Name="ShowVesselLabel" Text="{Loc 'iff-console-show-vessel-label'}" HorizontalExpand="True" StyleClasses="highlight" />
+            <BoxContainer Orientation="Horizontal" MinWidth="120">
+                <Button Name="ShowVesselOnButton" Text="{Loc 'iff-console-on'}" StyleClasses="OpenRight" />
+                <Button Name="ShowVesselOffButton" Text="{Loc 'iff-console-off'}" StyleClasses="OpenLeft" />
+            </BoxContainer>
         </GridContainer>
     </BoxContainer>
 </controls:FancyWindow>

--- a/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml.cs
+++ b/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml.cs
@@ -13,7 +13,9 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
     IComputerWindow<IFFConsoleBoundUserInterfaceState>
 {
     private readonly ButtonGroup _showIFFButtonGroup = new();
+    private readonly ButtonGroup _showVesselButtonGroup = new();
     public event Action<bool>? ShowIFF;
+    public event Action<bool>? ShowVessel;
 
     public IFFConsoleWindow()
     {
@@ -22,6 +24,11 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
         ShowIFFOnButton.Group = _showIFFButtonGroup;
         ShowIFFOnButton.OnPressed += args => ShowIFFPressed(true);
         ShowIFFOffButton.OnPressed += args => ShowIFFPressed(false);
+
+        ShowVesselOffButton.Group = _showVesselButtonGroup;
+        ShowVesselOnButton.Group = _showVesselButtonGroup;
+        ShowVesselOnButton.OnPressed += args => ShowVesselPressed(true);
+        ShowVesselOffButton.OnPressed += args => ShowVesselPressed(false);
     }
 
     private void ShowIFFPressed(bool pressed)
@@ -29,14 +36,19 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
         ShowIFF?.Invoke(pressed);
     }
 
+    private void ShowVesselPressed(bool pressed)
+    {
+        ShowVessel?.Invoke(pressed);
+    }
+
     public void UpdateState(IFFConsoleBoundUserInterfaceState state)
     {
-        if ((state.AllowedFlags & IFFFlags.HideLabel) != 0x0 || (state.AllowedFlags & IFFFlags.Hide) != 0x0)
+        if ((state.AllowedFlags & IFFFlags.HideLabel) != 0x0)
         {
             ShowIFFOffButton.Disabled = false;
             ShowIFFOnButton.Disabled = false;
 
-            if ((state.Flags & IFFFlags.HideLabel) != 0x0 || (state.Flags & IFFFlags.Hide) != 0x0)
+            if ((state.Flags & IFFFlags.HideLabel) != 0x0)
             {
                 ShowIFFOffButton.Pressed = true;
             }
@@ -49,6 +61,26 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
         {
             ShowIFFOffButton.Disabled = true;
             ShowIFFOnButton.Disabled = true;
+        }
+
+        if ((state.AllowedFlags & IFFFlags.Hide) != 0x0)
+        {
+            ShowVesselOffButton.Disabled = false;
+            ShowVesselOnButton.Disabled = false;
+
+            if ((state.Flags & IFFFlags.Hide) != 0x0)
+            {
+                ShowVesselOffButton.Pressed = true;
+            }
+            else
+            {
+                ShowVesselOnButton.Pressed = true;
+            }
+        }
+        else
+        {
+            ShowVesselOffButton.Disabled = true;
+            ShowVesselOnButton.Disabled = true;
         }
     }
 }

--- a/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml.cs
+++ b/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml.cs
@@ -13,9 +13,9 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
     IComputerWindow<IFFConsoleBoundUserInterfaceState>
 {
     private readonly ButtonGroup _showIFFButtonGroup = new();
-    private readonly ButtonGroup _showVesselButtonGroup = new();
+    private readonly ButtonGroup _showVesselButtonGroup = new(); // Moffstation - Revert IFF changes
     public event Action<bool>? ShowIFF;
-    public event Action<bool>? ShowVessel;
+    public event Action<bool>? ShowVessel; // Moffstation - Revert IFF changes
 
     public IFFConsoleWindow()
     {
@@ -25,10 +25,12 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
         ShowIFFOnButton.OnPressed += args => ShowIFFPressed(true);
         ShowIFFOffButton.OnPressed += args => ShowIFFPressed(false);
 
+        // Moffstation - Start - Revert IFF changes
         ShowVesselOffButton.Group = _showVesselButtonGroup;
         ShowVesselOnButton.Group = _showVesselButtonGroup;
         ShowVesselOnButton.OnPressed += args => ShowVesselPressed(true);
         ShowVesselOffButton.OnPressed += args => ShowVesselPressed(false);
+        // Moffstation - End
     }
 
     private void ShowIFFPressed(bool pressed)
@@ -36,19 +38,21 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
         ShowIFF?.Invoke(pressed);
     }
 
+    // Moffstation - Start - Revert IFF changes
     private void ShowVesselPressed(bool pressed)
     {
         ShowVessel?.Invoke(pressed);
     }
+    // Moffstation - End - Revert IFF changes
 
     public void UpdateState(IFFConsoleBoundUserInterfaceState state)
     {
-        if ((state.AllowedFlags & IFFFlags.HideLabel) != 0x0)
+        if ((state.AllowedFlags & IFFFlags.HideLabel) != 0x0) // Moffstation - Revert IFF changes
         {
             ShowIFFOffButton.Disabled = false;
             ShowIFFOnButton.Disabled = false;
 
-            if ((state.Flags & IFFFlags.HideLabel) != 0x0)
+            if ((state.Flags & IFFFlags.HideLabel) != 0x0) // Moffstation - Revert IFF changes
             {
                 ShowIFFOffButton.Pressed = true;
             }
@@ -63,6 +67,7 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
             ShowIFFOnButton.Disabled = true;
         }
 
+        // Moffstation - Start - Revert IFF changes
         if ((state.AllowedFlags & IFFFlags.Hide) != 0x0)
         {
             ShowVesselOffButton.Disabled = false;
@@ -82,5 +87,6 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
             ShowVesselOffButton.Disabled = true;
             ShowVesselOnButton.Disabled = true;
         }
+        // Moffstation - End
     }
 }

--- a/Content.Server/Shuttles/Components/IFFConsoleComponent.cs
+++ b/Content.Server/Shuttles/Components/IFFConsoleComponent.cs
@@ -12,11 +12,11 @@ public sealed partial class IFFConsoleComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("allowedFlags")]
     public IFFFlags AllowedFlags = IFFFlags.HideLabel;
 
-    //// Moffstation - Start - Revert IFF changes
+    /* // Moffstation - Start - Revert IFF changes
     /// <summary>
     /// If true, automatically applies all supported IFF flags to the console's grid on MapInitEvent.
     /// </summary>
-    //[DataField]
-    //public bool HideOnInit = false;
-    //// Moffstation - End
+    [DataField]
+    public bool HideOnInit = false;
+    */ // Moffstation - End
 }

--- a/Content.Server/Shuttles/Components/IFFConsoleComponent.cs
+++ b/Content.Server/Shuttles/Components/IFFConsoleComponent.cs
@@ -12,9 +12,6 @@ public sealed partial class IFFConsoleComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("allowedFlags")]
     public IFFFlags AllowedFlags = IFFFlags.HideLabel;
 
-    /// <summary>
-    /// If true, automatically applies all supported IFF flags to the console's grid on MapInitEvent.
-    /// </summary>
     [DataField]
     public bool HideOnInit = false;
 }

--- a/Content.Server/Shuttles/Components/IFFConsoleComponent.cs
+++ b/Content.Server/Shuttles/Components/IFFConsoleComponent.cs
@@ -11,7 +11,4 @@ public sealed partial class IFFConsoleComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("allowedFlags")]
     public IFFFlags AllowedFlags = IFFFlags.HideLabel;
-
-    [DataField]
-    public bool HideOnInit = false;
 }

--- a/Content.Server/Shuttles/Components/IFFConsoleComponent.cs
+++ b/Content.Server/Shuttles/Components/IFFConsoleComponent.cs
@@ -11,4 +11,12 @@ public sealed partial class IFFConsoleComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("allowedFlags")]
     public IFFFlags AllowedFlags = IFFFlags.HideLabel;
+
+    //// Moffstation - Start - Revert IFF changes
+    /// <summary>
+    /// If true, automatically applies all supported IFF flags to the console's grid on MapInitEvent.
+    /// </summary>
+    //[DataField]
+    //public bool HideOnInit = false;
+    //// Moffstation - End
 }

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
@@ -42,14 +42,28 @@ public sealed partial class ShuttleSystem
             return;
         }
 
+        // Merged toggle controls both HideLabel and Hide flags
         if (!args.Show)
         {
-            AddAllSupportedIFFFlags(xform, component);
+            if ((component.AllowedFlags & IFFFlags.HideLabel) != 0x0)
+            {
+                AddIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
+            }
+            if ((component.AllowedFlags & IFFFlags.Hide) != 0x0)
+            {
+                AddIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
+            }
         }
         else
         {
-            RemoveIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
-            RemoveIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
+            if ((component.AllowedFlags & IFFFlags.HideLabel) != 0x0)
+            {
+                RemoveIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
+            }
+            if ((component.AllowedFlags & IFFFlags.Hide) != 0x0)
+            {
+                RemoveIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
+            }
         }
     }
 
@@ -62,7 +76,8 @@ public sealed partial class ShuttleSystem
 
         if (component.HideOnInit)
         {
-            AddAllSupportedIFFFlags(xform, component);
+            AddIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
+            AddIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
         }
     }
 
@@ -104,27 +119,6 @@ public sealed partial class ShuttleSystem
                 AllowedFlags = comp.AllowedFlags,
                 Flags = component.Flags,
             });
-        }
-    }
-
-    // Made this method to avoid copy and pasting.
-    /// <summary>
-    /// Adds all IFF flags that are allowed by AllowedFlags to the grid.
-    /// </summary>
-    private void AddAllSupportedIFFFlags(TransformComponent xform, IFFConsoleComponent component)
-    {
-        if (xform.GridUid == null)
-        {
-            return;
-        }
-
-        if ((component.AllowedFlags & IFFFlags.HideLabel) != 0x0)
-        {
-            AddIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
-        }
-        if ((component.AllowedFlags & IFFFlags.Hide) != 0x0)
-        {
-            AddIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
         }
     }
 }

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
@@ -117,26 +117,26 @@ public sealed partial class ShuttleSystem
         }
     }
 
-    //// Moffstation - Start - Revert IFF changes
+    /* // Moffstation - Start - Revert IFF changes
     // Made this method to avoid copy and pasting.
     /// <summary>
     /// Adds all IFF flags that are allowed by AllowedFlags to the grid.
     /// </summary>
-    //private void AddAllSupportedIFFFlags(TransformComponent xform, IFFConsoleComponent component)
-    //{
-    //    if (xform.GridUid == null)
-    //    {
-    //        return;
-    //    }
-    //
-    //    if ((component.AllowedFlags & IFFFlags.HideLabel) != 0x0)
-    //    {
-    //        AddIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
-    //    }
-    //    if ((component.AllowedFlags & IFFFlags.Hide) != 0x0)
-    //    {
-    //        AddIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
-    //    }
-    // }
-    //// Moffstation - End
+    private void AddAllSupportedIFFFlags(TransformComponent xform, IFFConsoleComponent component)
+    {
+        if (xform.GridUid == null)
+        {
+            return;
+        }
+
+        if ((component.AllowedFlags & IFFFlags.HideLabel) != 0x0)
+        {
+            AddIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
+        }
+        if ((component.AllowedFlags & IFFFlags.Hide) != 0x0)
+        {
+            AddIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
+        }
+     }
+    */ // Moffstation - End
 }

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
@@ -12,7 +12,7 @@ public sealed partial class ShuttleSystem
     {
         SubscribeLocalEvent<IFFConsoleComponent, AnchorStateChangedEvent>(OnIFFConsoleAnchor);
         SubscribeLocalEvent<IFFConsoleComponent, IFFShowIFFMessage>(OnIFFShow);
-        SubscribeLocalEvent<IFFConsoleComponent, MapInitEvent>(OnInitIFFConsole);
+        SubscribeLocalEvent<IFFConsoleComponent, IFFShowVesselMessage>(OnIFFShowVessel);
         SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
     }
 
@@ -37,47 +37,37 @@ public sealed partial class ShuttleSystem
 
     private void OnIFFShow(EntityUid uid, IFFConsoleComponent component, IFFShowIFFMessage args)
     {
-        if (!TryComp(uid, out TransformComponent? xform) || xform.GridUid == null)
+        if (!TryComp(uid, out TransformComponent? xform) || xform.GridUid == null ||
+            (component.AllowedFlags & IFFFlags.HideLabel) == 0x0)
         {
             return;
         }
 
-        // Merged toggle controls both HideLabel and Hide flags
         if (!args.Show)
         {
-            if ((component.AllowedFlags & IFFFlags.HideLabel) != 0x0)
-            {
-                AddIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
-            }
-            if ((component.AllowedFlags & IFFFlags.Hide) != 0x0)
-            {
-                AddIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
-            }
+            AddIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
         }
         else
         {
-            if ((component.AllowedFlags & IFFFlags.HideLabel) != 0x0)
-            {
-                RemoveIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
-            }
-            if ((component.AllowedFlags & IFFFlags.Hide) != 0x0)
-            {
-                RemoveIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
-            }
+            RemoveIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
         }
     }
 
-    private void OnInitIFFConsole(EntityUid uid, IFFConsoleComponent component, MapInitEvent args)
+    private void OnIFFShowVessel(EntityUid uid, IFFConsoleComponent component, IFFShowVesselMessage args)
     {
-        if (!TryComp(uid, out TransformComponent? xform) || xform.GridUid == null)
+        if (!TryComp(uid, out TransformComponent? xform) || xform.GridUid == null ||
+            (component.AllowedFlags & IFFFlags.Hide) == 0x0)
         {
             return;
         }
 
-        if (component.HideOnInit)
+        if (!args.Show)
         {
-            AddIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
             AddIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
+        }
+        else
+        {
+            RemoveIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
         }
     }
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
@@ -12,7 +12,7 @@ public sealed partial class ShuttleSystem
     {
         SubscribeLocalEvent<IFFConsoleComponent, AnchorStateChangedEvent>(OnIFFConsoleAnchor);
         SubscribeLocalEvent<IFFConsoleComponent, IFFShowIFFMessage>(OnIFFShow);
-        SubscribeLocalEvent<IFFConsoleComponent, IFFShowVesselMessage>(OnIFFShowVessel);
+        SubscribeLocalEvent<IFFConsoleComponent, IFFShowVesselMessage>(OnIFFShowVessel); // Moffstation - Revert IFF changes
         SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
     }
 
@@ -37,22 +37,26 @@ public sealed partial class ShuttleSystem
 
     private void OnIFFShow(EntityUid uid, IFFConsoleComponent component, IFFShowIFFMessage args)
     {
+        // Moffstation - Start - Revert IFF changes
         if (!TryComp(uid, out TransformComponent? xform) || xform.GridUid == null ||
             (component.AllowedFlags & IFFFlags.HideLabel) == 0x0)
+        // Moffstation - End
         {
             return;
         }
 
         if (!args.Show)
         {
-            AddIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
+            AddIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel); // Moffstation - Revert IFF changes
         }
         else
         {
             RemoveIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
+            // RemoveIFFFlag(xform.GridUid.Value, IFFFlags.Hide); // Moffstation - Revert IFF changes
         }
     }
 
+    // Moffstation - Start - Revert IFF changes
     private void OnIFFShowVessel(EntityUid uid, IFFConsoleComponent component, IFFShowVesselMessage args)
     {
         if (!TryComp(uid, out TransformComponent? xform) || xform.GridUid == null ||
@@ -70,6 +74,7 @@ public sealed partial class ShuttleSystem
             RemoveIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
         }
     }
+    // Moffstation - End
 
     private void OnIFFConsoleAnchor(EntityUid uid, IFFConsoleComponent component, ref AnchorStateChangedEvent args)
     {
@@ -111,4 +116,27 @@ public sealed partial class ShuttleSystem
             });
         }
     }
+
+    //// Moffstation - Start - Revert IFF changes
+    // Made this method to avoid copy and pasting.
+    /// <summary>
+    /// Adds all IFF flags that are allowed by AllowedFlags to the grid.
+    /// </summary>
+    //private void AddAllSupportedIFFFlags(TransformComponent xform, IFFConsoleComponent component)
+    //{
+    //    if (xform.GridUid == null)
+    //    {
+    //        return;
+    //    }
+    //
+    //    if ((component.AllowedFlags & IFFFlags.HideLabel) != 0x0)
+    //    {
+    //        AddIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
+    //    }
+    //    if ((component.AllowedFlags & IFFFlags.Hide) != 0x0)
+    //    {
+    //        AddIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
+    //    }
+    // }
+    //// Moffstation - End
 }

--- a/Content.Shared/Shuttles/Events/IFFShowVesselMessage.cs
+++ b/Content.Shared/Shuttles/Events/IFFShowVesselMessage.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Shuttles.Events;
+
+[Serializable, NetSerializable]
+public sealed class IFFShowVesselMessage : BoundUserInterfaceMessage
+{
+    public bool Show;
+}

--- a/Content.Shared/Shuttles/Events/IFFShowVesselMessage.cs
+++ b/Content.Shared/Shuttles/Events/IFFShowVesselMessage.cs
@@ -1,3 +1,4 @@
+// Moffstation - Start - Revert IFF changes
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Shuttles.Events;
@@ -7,3 +8,4 @@ public sealed class IFFShowVesselMessage : BoundUserInterfaceMessage
 {
     public bool Show;
 }
+// Moffstation - End

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -283,6 +283,7 @@
     allowedFlags:
       - Hide
       - HideLabel
+    # hideOnInit: true # Moffstation - Revert IFF changes
   - type: ActivatableUI
     key: enum.IFFConsoleUiKey.Key
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -283,7 +283,6 @@
     allowedFlags:
       - Hide
       - HideLabel
-    hideOnInit: true
   - type: ActivatableUI
     key: enum.IFFConsoleUiKey.Key
   - type: UserInterface

--- a/Resources/Prototypes/_Moffstation/GameRules/pirates.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/pirates.yml
@@ -6,8 +6,8 @@
   - type: PiratesRule
   - type: LoadGridRule
     gridPath: /Maps/_Moffstation/Nonstations/pirate-cove.yml
-    minimumDistance: 1000
-    maximumDistance: 2000
+    minimumDistance: 750
+    maximumDistance: 1000
   - type: RuleGrids
   - type: AntagSelection
   - type: AntagLoadProfileRule


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Reverts the following Wizden PRs:
https://github.com/space-wizards/space-station-14/pull/42104
https://github.com/space-wizards/space-station-14/pull/42122

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
right around the same time we pushed the pirate cove to Moffstation, wizden changed IFF computers, combining the 'hide label' and 'hide grid' features into a single point. While this change may make sense for Wizden, as they do not have roles like LPO and Pirates, this loss of feature ended up causing problems for Moffstation. This pull requests reverts these two pull requests are this simplification is not needed here, and only serves to hinder player control.

## Technical details
<!-- Summary of code changes for easier review. -->
git reverts.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="969" height="775" alt="image" src="https://github.com/user-attachments/assets/54a9c473-bee7-4f45-9618-73a172d2ff74" />
_an unlabeled, but visible grid._

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- fix: IFFs now have full player control over names and grids again.