### PR TITLE
Expanded ninja summons

### DIFF
--- a/Resources/Locale/en-US/_Moffstation/communications/terror.ftl
+++ b/Resources/Locale/en-US/_Moffstation/communications/terror.ftl
@@ -1,0 +1,7 @@
+﻿# Ninja threats
+terror-clown = Attention crew, it appears that someone on your station has made an unexpected communication with a bombastic trio of honkies in nearby space.
+terror-eeep = Attention crew, it appears that someone on your station has made an unexpected communication with an adorable sentient tesla in nearby space.
+terror-lone-op = Attention crew, it appears that someone on your station has made an unexpected communication with a blood-red marauder in nearby space.
+terror-ninja = Attention crew, it appears that someone on your station has made an unexpected communication with the spider clan in nearby space.
+terror-rod = Attention crew, it appears that someone on your station has made an unexpected communication with an unstoppable force in nearby space.
+terror-wizard = Attention crew, it appears that someone on your station has made an unexpected communication with a wizard federation representative in nearby space.

--- a/Resources/Prototypes/_Moffstation/ninja_threats.yml
+++ b/Resources/Prototypes/_Moffstation/ninja_threats.yml
@@ -1,0 +1,29 @@
+﻿- type: ninjaHackingThreat
+  id: Clown
+  announcement: terror-clown
+  rule: UnknownShuttleHonki
+
+- type: ninjaHackingThreat
+  id: Eeeplet
+  announcement: terror-eeep
+  rule: EeepEvent
+
+- type: ninjaHackingThreat
+  id: LoneOp
+  announcement: terror-lone-op
+  rule: LoneOpsSpawn
+
+- type: ninjaHackingThreat
+  id: NinjaBackup
+  announcement: terror-ninja
+  rule: NinjaSpawn
+
+- type: ninjaHackingThreat
+  id: Rod
+  announcement: terror-rod
+  rule: ImmovableRodSpawn
+
+- type: ninjaHackingThreat
+  id: Wizard
+  announcement: terror-wizard
+  rule: WizardSpawn

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -10,7 +10,7 @@
     LoneOp: 0.75
     NinjaBackup: 0.1
     Rod: 0.75
-    Wizard: 0.75
+    Wizard: 0.1
   # Moffstation - End
 
 - type: ninjaHackingThreat

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -4,6 +4,14 @@
   weights:
     Dragon: 1
     Revenant: 1
+  # Moffstation - Start - Expanded ninja summons
+    Clown: 1
+    Eeeplet: 1
+    LoneOp: 0.75
+    NinjaBackup: 0.1
+    Rod: 0.75
+    Wizard: 0.75
+  # Moffstation - End
 
 - type: ninjaHackingThreat
   id: Dragon


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Adds new events for the ninja communication console objective, thematic to the idea of calling in a station threat.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As it currently stands, the ninja communication console event is very hit-or-miss; you have the space dragon which performs well in its role of acting as a station threat, drawing away from the attention of the ninja, while revenant on the other hand is more of a mild inconvenience for the station.

The goal of this PR is to expand on this, allowing for more varied and thematic summons, so the overall experience of the ninja event is less binary in it's reception.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds six new events, weighted:
Clowns - a higher weight, low chaos option - where up to 3 clowns and 3 honkbots are brought to interact with the station and cause trouble.
Eeeplet - a higher weight, medium chaos option - another space fauna, similar to the dragon, though likely less destructive overall.
LoneOp - a medium weight, high chaos option - at least the crew will be aware of the impending nuclear threat.
Ninja Backup - a low weight, high chaos option - what's worse than one ninja? two ninjas.
Rod - a medium weight, medium chaos option - I just think the idea of the ninja calling up a rod to cut the station in half is novel.
Wizard - a low weight, high chaos option - similar to loneOp, this is for sure to draw attention of security.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="443" height="116" alt="image" src="https://github.com/user-attachments/assets/39b3225a-d7a8-447d-867d-eece32d49972" />

_oh fuck._

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: Ninjas can now summon a greater variety of station threats.