### PR TITLE
Return of the borg tools - to service, janitor, and medical cyborgs.

### DIFF
--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -234,9 +234,7 @@
     - BorgModuleService
 
   defaultModules:
-  # Moffstation - Start - Return of the tool module
-  - BorgModuleTool
-  # Moffstation - End
+  - BorgModuleTool # Moffstation - Return of the tool module
   - BorgModuleMusique
   - BorgModuleService
   - BorgModuleClowning


### PR DESCRIPTION
## About the PR
Readded tool modules to janitor, service, and medical cyborgs as part of their default roundstart selection loadout.

## Why / Balance
The tool module is an essential piece of a cyborg's toolkit, and has a multitude of uses in every single role a cyborg might find themselves filling on station each round. Extensive discussion was had on discord regarding why the tool removal changes were detrimental to overall gameplay and anathema to our established design direction with cyborgs. The beginning of this conversation can be found at the following link:
https://discord.com/channels/1322447119252062260/1329504845924925503/1449954917510021182
This PR fixes the change made by upstream.

**To summarise the key points:**
1. Tools are useful and essential to role a cyborg might take on. The chassis type does not always define the role of the borg that round, and this change will cause the already popular engineer chassis to become even more so.
2. When doors lose power for whatever reason, cyborgs without tools cannot pry open the doors in any reasonable time like any other crew can with an emergency crowbar. This is a common use case across every borg, you can even arrive at a station that has lost power and be stuck from minute 1.
3. Tools have not been barred from the chassis, just been relegated to the chore of having them installed when you arrive by science. Inconveniencing them, and preventing you from getting to your job quicker. Sometimes on low pop shifts there isnt anyone to install this demonstrably _required_ module. This forces certain chassis to lose one of their open borg slots, limiting their future growth and progression throughout the round.
4. Moffstation has taken borgs in a design direction that diverges from upstream, creating a large number of research-able modules which allow for borgs to branch into other archetypes and customise/supplement their build in a unique way. The removal of tools from some chassis in the name of "making borgs more specialised" goes against this design philosophy and removes an available module slot that could otherwise be filled with Moff's custom module content.

## Technical details
Changed borg_types.yml and commented locations.

## Media
<img width="815" height="713" alt="image" src="https://github.com/user-attachments/assets/610c1f23-e6f7-4c76-9ec3-dbaf06379025" />

## Requirements
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- add: Readded borg tools to service, janitor, and medical cyborgs.

