### PR TITLE
Fix chat with open radial menu

### DIFF
--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -237,22 +237,22 @@ public abstract class RadialMenuButtonBase : BaseButton
         EnableAllKeybinds = true;
     }
 
-    // MoffStation Start
     /// <inheritdoc />
     protected override void KeyBindUp(GUIBoundKeyEventArgs args)
     {
-        if (args.Function.IsClickOrAltClick())
+        if (args.Function.IsClickOrAltClick()) // MoffStation
             base.KeyBindUp(args);
     }
 
+    // MoffStation - Begin
     /// <inheritdoc />
     protected override void KeyBindDown(GUIBoundKeyEventArgs args)
     {
         if (args.Function.IsClickOrAltClick())
             base.KeyBindDown(args);
     }
+    //MoffStation - End
 }
-// MoffStation End
 
 /// <summary>
 /// Special button for closing radial menu or going back between radial menu levels.
@@ -289,22 +289,22 @@ public sealed class RadialMenuContextualCentralTextureButton : TextureButton
         return distSquared < innerRadiusSquared;
     }
 
-    //MoffStation Start
     /// <inheritdoc />
     protected override void KeyBindUp(GUIBoundKeyEventArgs args)
     {
-        if (args.Function.IsClickOrAltClick())
+        if (args.Function.IsClickOrAltClick()) // MoffStation
             base.KeyBindUp(args);
     }
 
+    // MoffStation - Begin
     /// <inheritdoc />
     protected override void KeyBindDown(GUIBoundKeyEventArgs args)
     {
         if (args.Function.IsClickOrAltClick())
             base.KeyBindDown(args);
     }
+    // MoffStation - End
 }
-//MoffStation End
 
 /// <summary>
 /// Menu button for outer area of radial menu (covers everything 'outside').
@@ -698,7 +698,7 @@ public class RadialMenuButtonWithSector : RadialMenuButton, IRadialMenuItemWithS
     }
 }
 
-//MoffStation Start
+//MoffStation - Begin
 static file class RadialMenuButtonsHelpers
 {
     public static bool IsClickOrAltClick(this BoundKeyFunction function)
@@ -707,4 +707,4 @@ static file class RadialMenuButtonsHelpers
                || function == ContentKeyFunctions.AltActivateItemInWorld;
     }
 }
-//MoffStation End
+//MoffStation - End


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
Ports https://github.com/space-wizards/space-station-14/pull/40929 to Moff. Fixes the radial menu blocking chat interactions.

All praise great Pok27.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds an override for KeyBindDown that prevents it from blocking other interactions while the Radial is open.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/c0b62d38-5c85-40ce-9905-7f7267b3477d


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Pok27
- fix: Radial menus no longer prevent sending to chat, or deleting text from the chat input box.
