### PR TITLE
use stage name in records

### DIFF
--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Access.Systems;
 using Content.Server._CD.Loadouts;
 using Content.Server.Forensics;
 using Content.Shared.Access.Components;
+using Content.Shared.Clothing;
 using Content.Shared.Forensics.Components;
 using Content.Shared.GameTicking;
 using Content.Shared.Inventory;
@@ -98,7 +99,10 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         TryComp<FingerprintComponent>(player, out var fingerprintComponent);
         TryComp<DnaComponent>(player, out var dnaComponent);
 
-        CreateGeneralRecord(station, idUid.Value, profile.Name, profile.Age, profile.Species, profile.Gender, jobId, fingerprintComponent?.Fingerprint, dnaComponent?.DNA, profile, records);
+        // Moffstation - Start - If the loadout specifies a name override, use that instead of the profile name for in the record.
+        var loadoutNameOrProfileName = profile.Loadouts.GetValueOrDefault(LoadoutSystem.GetJobPrototype(jobId))?.EntityName ?? profile.Name;
+        CreateGeneralRecord(station, idUid.Value, loadoutNameOrProfileName, profile.Age, profile.Species, profile.Gender, jobId, fingerprintComponent?.Fingerprint, dnaComponent?.DNA, profile, records);
+        // Moffstation - End
     }
 
 

--- a/Content.Server/_CD/Records/CharacterRecordsSystem.cs
+++ b/Content.Server/_CD/Records/CharacterRecordsSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.PDA;
 using Content.Shared.Roles;
 using Content.Shared.StationRecords;
 using Content.Shared._CD.Records;
+using Content.Shared.Clothing;
 using Content.Shared.Forensics.Components;
 using Robust.Shared.Prototypes;
 using Content.Shared.GameTicking;
@@ -73,7 +74,7 @@ public sealed class CharacterRecordsSystem : EntitySystem
         var records = new FullCharacterRecords(
             pRecords: new PlayerProvidedCharacterRecords(profile.CDCharacterRecords),
             stationRecordsKey: stationRecordsKey?.Id,
-            name: profile.Name,
+            name: profile.Loadouts.GetValueOrDefault(LoadoutSystem.GetJobPrototype(args.JobId))?.EntityName ?? profile.Name, // Moffstation - Name from job loadout if it overrides the proflie name.
             age: profile.Age,
             species: profile.Species,
             jobTitle: jobTitle,


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->

Stage names / names in loadouts are now what're displayed in station records.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Adds clarity as previously there'd be names that don't match what's on the manifest.
Additionally solves a bug where criminal status wouldn't properly apply due to name differences.

## Technical details
<!-- Summary of code changes for easier review. -->

Just had to rejigger some code where records are instantiated to look at the loadout name in addition to the profile name when first creating.
This shouldn't affect renaming after the fact by the HoP or anything.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="644" height="323" alt="image" src="https://github.com/user-attachments/assets/fe9500ce-8628-4e74-a65f-90e7086f995f" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Jobs which use loadout name overrides (stage names) should now properly display those names for station records.
- fix: Jobs which use loadout names now properly display criminal record icons on characters.