### PR TITLE
Fixed green nuno skip card having regular card reverse side sprite.

### DIFF
--- a/Resources/Prototypes/_EstacaoPirata/Entities/Objects/Misc/Cards/Individual Cards/nuno_cards.yml
+++ b/Resources/Prototypes/_EstacaoPirata/Entities/Objects/Misc/Cards/Individual Cards/nuno_cards.yml
@@ -861,3 +861,6 @@
       state: background_green
     - sprite: _EstacaoPirata/Objects/Misc/Cards/card_nuno.rsi
       state: skip
+    reverseSprite:
+    - sprite: _EstacaoPirata/Objects/Misc/Cards/card_nuno.rsi
+      state: singlecard_down_nuno


### PR DESCRIPTION
Because Github is very cool, this PR exists literally just so that I can make #1011 but with merged-in master.
So, see that PR.

Closes #1011

:cl: KaylaSolace
- fix: The green nuno skip card now uses the correct card backing sprite.