### PR TITLE
Rename 'antag' tab to 'special roles' and stowaway changes

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -355,7 +355,7 @@ namespace Content.Client.Lobby.UI
 
             #endregion Jobs
 
-            TabContainer.SetTabTitle(2, Loc.GetString("humanoid-profile-editor-antags-tab"));
+            TabContainer.SetTabTitle(2, Loc.GetString("humanoid-profile-editor-special-roles-tab")); // Moffstation - Expanded non-crew roles
 
             RefreshTraits();
 

--- a/Resources/Locale/en-US/_Moffstation/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/_Moffstation/preferences/ui/humanoid-profile-editor.ftl
@@ -2,3 +2,6 @@
 humanoid-profile-editor-height-label = Height:
 humanoid-profile-editor-reset-height-button = Reset
 humanoid-profile-editor-department-jobs-label-moffstation = [font="DefaultBold" size=16][color=white]{$departmentName} jobs[/color][/font]
+
+# Moffstation Tabs
+humanoid-profile-editor-special-roles-tab = Special roles

--- a/Resources/Prototypes/_Moffstation/GameRules/stowaways.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/stowaways.yml
@@ -19,6 +19,7 @@
       playerRatio: 20
       startingGear: StowawayGear
       roleLoadout:
+      - JobStowaway
       - RoleSurvivalVoxTank # give vox something to breath in case they don't get a copy
       briefing:
         text: roles-antag-stowaway-greeting

--- a/Resources/Prototypes/_Moffstation/GameRules/stowaways.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/stowaways.yml
@@ -3,7 +3,7 @@
   id: Stowaways
   components:
   - type: GameRule
-    minPlayers: 30
+    #minPlayers: 30
     cancelPresetOnTooFewPlayers: false
   - type: AntagRandomSpawn
   - type: AntagLoadProfileRule
@@ -20,7 +20,8 @@
       startingGear: StowawayGear
       roleLoadout:
       - JobStowaway
-      - RoleSurvivalVoxTank # give vox something to breath in case they don't get a copy
       briefing:
         text: roles-antag-stowaway-greeting
         color: Salmon
+      mindRoles:
+      - MindRoleGhostRoleFreeAgent

--- a/Resources/Prototypes/_Moffstation/GameRules/stowaways.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/stowaways.yml
@@ -3,7 +3,7 @@
   id: Stowaways
   components:
   - type: GameRule
-    #minPlayers: 30
+    minPlayers: 30
     cancelPresetOnTooFewPlayers: false
   - type: AntagRandomSpawn
   - type: AntagLoadProfileRule

--- a/Resources/Prototypes/_Moffstation/Loadouts/LoadoutGroups/free_agents.yml
+++ b/Resources/Prototypes/_Moffstation/Loadouts/LoadoutGroups/free_agents.yml
@@ -1,0 +1,11 @@
+﻿# Stowaway
+- type: loadoutGroup
+  id: StowawaySurvival
+  name: loadout-group-survival-basic
+  minLimit: 3
+  hidden: true
+  loadouts:
+  - EmergencyNitrogenStowaway
+  - EmergencyOxygenStowaway
+  - EmergencyAmmoniaStowaway
+  - LoadoutSpeciesVoxNitrogen

--- a/Resources/Prototypes/_Moffstation/Loadouts/LoadoutGroups/free_agents.yml
+++ b/Resources/Prototypes/_Moffstation/Loadouts/LoadoutGroups/free_agents.yml
@@ -5,7 +5,7 @@
   minLimit: 3
   hidden: true
   loadouts:
+  - EmergencyAmmoniaStowaway
   - EmergencyNitrogenStowaway
   - EmergencyOxygenStowaway
-  - EmergencyAmmoniaStowaway
   - LoadoutSpeciesVoxNitrogen

--- a/Resources/Prototypes/_Moffstation/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/_Moffstation/Loadouts/Miscellaneous/survival.yml
@@ -73,6 +73,49 @@
     back:
     - BoxSurvivalSecurityAmmonia
 
+# Stowaway
+- type: loadout
+  id: EmergencyAmmoniaStowaway
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: EffectSpeciesAvali
+  storage:
+    back:
+    - DrinkAmmoniaBottleFull
+    - EmergencyOxygenTankFilled
+    - Multitool
+    - Crowbar
+    - Screwdriver
+    - FoodSnackNutribrick
+
+- type: loadout
+  id: EmergencyNitrogenStowaway
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: NitrogenBreather
+  storage:
+    back:
+    - DrinkWaterBottleFull
+    - EmergencyNitrogenTankFilled
+    - Multitool
+    - Crowbar
+    - Screwdriver
+    - FoodSnackNutribrick
+
+- type: loadout
+  id: EmergencyOxygenStowaway
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: OxygenBreather
+  storage:
+    back:
+    - DrinkWaterBottleFull
+    - EmergencyOxygenTankFilled
+    - Multitool
+    - Crowbar
+    - Screwdriver
+    - FoodSnackNutribrick
+
 # Syndicate
 - type: loadout
   id: EmergencyOxygenSyndicateAmmonia

--- a/Resources/Prototypes/_Moffstation/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/_Moffstation/Loadouts/Miscellaneous/survival.yml
@@ -81,12 +81,12 @@
     proto: EffectSpeciesAvali
   storage:
     back:
+    - Crowbar
     - DrinkAmmoniaBottleFull
     - EmergencyOxygenTankFilled
-    - Multitool
-    - Crowbar
-    - Screwdriver
     - FoodSnackNutribrick
+    - Multitool
+    - Screwdriver
 
 - type: loadout
   id: EmergencyNitrogenStowaway
@@ -95,12 +95,12 @@
     proto: NitrogenBreather
   storage:
     back:
+    - Crowbar
     - DrinkWaterBottleFull
     - EmergencyNitrogenTankFilled
-    - Multitool
-    - Crowbar
-    - Screwdriver
     - FoodSnackNutribrick
+    - Multitool
+    - Screwdriver
 
 - type: loadout
   id: EmergencyOxygenStowaway
@@ -109,12 +109,12 @@
     proto: OxygenBreather
   storage:
     back:
+    - Crowbar
     - DrinkWaterBottleFull
     - EmergencyOxygenTankFilled
-    - Multitool
-    - Crowbar
-    - Screwdriver
     - FoodSnackNutribrick
+    - Multitool
+    - Screwdriver
 
 # Syndicate
 - type: loadout

--- a/Resources/Prototypes/_Moffstation/Loadouts/RoleLoadouts/antag_role_loadouts.yml
+++ b/Resources/Prototypes/_Moffstation/Loadouts/RoleLoadouts/antag_role_loadouts.yml
@@ -55,15 +55,6 @@
     head: ClothingHeadBandBlack
     outerClothing: ClothingOuterCoatPirate
 
-# Stowaway
-- type: roleLoadout
-  id: JobStowaway
-  canCustomizeName: true
-  groups:
-  - NukieJumpsuit
-  - NukieBackpackEmpty
-  - PersonalItemsJobAgnostic
-
 # Syndicate
 - type: roleLoadout
   id: JobSyndicateSpy

--- a/Resources/Prototypes/_Moffstation/Loadouts/RoleLoadouts/free_agent_role_loadouts.yml
+++ b/Resources/Prototypes/_Moffstation/Loadouts/RoleLoadouts/free_agent_role_loadouts.yml
@@ -1,0 +1,11 @@
+﻿# Stowaway
+- type: roleLoadout
+  id: JobStowaway
+  canCustomizeName: true
+  groups:
+  - CommonBackpack
+  - Glasses
+  - Trinkets
+  - GroupTankHarness
+  - StowawaySurvival
+  - PersonalItemsJobAgnostic

--- a/Resources/Prototypes/_Moffstation/Loadouts/RoleLoadouts/special_role_loadouts.yml
+++ b/Resources/Prototypes/_Moffstation/Loadouts/RoleLoadouts/special_role_loadouts.yml
@@ -26,17 +26,6 @@
   - NukieGloves
   - PersonalItemsJobAgnostic
 
-# Wizard
-- type: roleLoadout
-  id: JobWizard
-  canCustomizeName: true
-  groups:
-    - WizardJumpsuit
-    - WizardRobes
-    - WizardHat
-    - CommonBackpack
-    - PersonalItemsJobAgnostic
-
 # Pirates
 - type: roleLoadout
   id: JobPirateCrew
@@ -66,6 +55,15 @@
     head: ClothingHeadBandBlack
     outerClothing: ClothingOuterCoatPirate
 
+# Stowaway
+- type: roleLoadout
+  id: JobStowaway
+  canCustomizeName: true
+  groups:
+  - NukieJumpsuit
+  - NukieBackpackEmpty
+  - PersonalItemsJobAgnostic
+
 # Syndicate
 - type: roleLoadout
   id: JobSyndicateSpy
@@ -75,7 +73,18 @@
   - NukieBackpackEmpty
   - PersonalItemsJobAgnostic
 
-# Xenoborg
+# Wizard
+- type: roleLoadout
+  id: JobWizard
+  canCustomizeName: true
+  groups:
+  - WizardJumpsuit
+  - WizardRobes
+  - WizardHat
+  - CommonBackpack
+  - PersonalItemsJobAgnostic
+
+# Xenoborgs
 - type: roleLoadout
   id: JobXenoborg
   canCustomizeName: true

--- a/Resources/Prototypes/_Moffstation/Roles/Antags/stowaway.yml
+++ b/Resources/Prototypes/_Moffstation/Roles/Antags/stowaway.yml
@@ -9,14 +9,10 @@
   id: StowawayGear
   equipment:
     jumpsuit: ClothingUniformRandomStandard
-    back: ClothingBackpack
     shoes: ClothingShoesColorBlack
     mask: ClothingMaskGas
+    gloves: ClothingHandsGlovesColorYellow
     id: CardboardIDCard
-  storage:
-    back:
-    - FoodSnackMREBrownie
-    - DrinkWaterBottleFull
 
 - type: entity
   categories: [ HideSpawnMenu, Spawner ]
@@ -28,6 +24,9 @@
   - type: GhostRole
     name: roles-antag-stowaway-name
     description: roles-antag-stowaway-desc
+    rules: ghost-role-information-freeagent-rules
+    mindRoles:
+    - MindRoleGhostRoleFreeAgent
     raffle:
       settings: default
   - type: Sprite


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
This pull request makes the following changes:
- Renames the ```antag``` tab within character customization to ```special roles```.
- Changes stowaway from ```Crew Aligned``` to ```Free Agent```.
- Adds loadout customization for stowaways.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
There has been a recent discussion brought up among moffstation players with the introduction of the stowaway regarding the potential and expansion of non-crew, non-antagonistic roles; There is a clear desire to flesh out the potential inclusion of these roles both for narrative (roleplay) and mechanical (anti-gamemode metagaming) reasons, however our current UI elements don't quite reflect this support. Changing the name from ```antag``` to ```special roles``` is a first step to help address that, making it clear that these roles aren't seen every shift, and importantly, won't always be anti-crew either, instead obeying their own unique rules.

Furthermore, stowaways now have the option to have custom names for their stowaway shift, to give the player to separate their crew persona from their stowaway persona a la LPO, and have a limited selection of customization options. Additionally, each stowaway also comes with a few tools to help them hack open doors - both giving them a possible explanation for how they got onto the station and a means to navigate outside of whatever segment they find themselves starting in, while also leaving criminal evidence for security to pursue. 

## Technical details
<!-- Summary of code changes for easier review. -->
mostly yml and ftl work.

added "MindRoleGhostRoleFreeAgent" mindrole to the ```Stowaways``` gamerule, and ghostrole variant. Additionally created new loadout groups for stowaways under ==free_agent.yml== and ==free_agent_loadout_groups.yml==, preempting for additional future free agent roles.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="787" height="848" alt="image" src="https://github.com/user-attachments/assets/33137aed-4d8e-4169-93e1-4aefd6e5d420" />

_Tab name change._

<img width="806" height="806" alt="image" src="https://github.com/user-attachments/assets/810f16a7-5001-45ce-a175-93bad9787e80" />

_Loadout customization._

<img width="401" height="338" alt="image" src="https://github.com/user-attachments/assets/1c48d8db-bc79-48f5-ac12-359c7fb75554" />

_Stowaways are free agents as they're not under NT, but aren't intended to cause chaos beyond their own self-preservation._

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- tweak: Antag tab has been renamed to special roles
- tweak: Stowaways are now considered free agents
- tweak: Stowaways now have customization options