### PR TITLE
Give parameds externals

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -32,6 +32,7 @@
   - ChiefMedicalOfficer
   - Brig
   - Cryogenics
+  - External # Moffstation - Give paramedics externals (CMO to match)
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -15,6 +15,7 @@
   access:
   - Medical
   - Maintenance
+  - External # Moffstation - Give paramedics externals
   extendedAccess:
   - Chemistry
 


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Gives paramedics externals access by default.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The role of the paramedic is to help recover any station crew who is unable to get themselves to medical in order to save lives. This includes station engineers, who occasionally go outside to repair the station hull or maintain solars arrays, and salvagers, who will leave the station to recover materials. In the current implementation of accesses however, paramedics are unable to actually /leave/ the station, rendering it impossible to save these external-facing roles. To correct this, this PR gives paramedics externals access by default, enabling them to perform their duty of recovery.

## Technical details
<!-- Summary of code changes for easier review. -->
single line yml change.

adds "External" under ```access``` for the paramedic job.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="705" height="497" alt="image" src="https://github.com/user-attachments/assets/b96cf724-7ed0-4d43-9a3c-d25165c76bc4" />

_ignore the chemistry access - that's from skeleton crew rules._

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- tweak: Paramedics now start with externals in addition to their previous accesses.