### PR TITLE
Contraband status fix: Toy box, ERT chest rig, Webvests

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -201,7 +201,7 @@
     sprite: Clothing/Belt/militarywebbingmed.rsi
 
 - type: entity
-  parent: ClothingBeltMilitaryWebbing
+  parent: [ BaseCentcommContraband , ClothingBeltMilitaryWebbing ] # Moffstation - Fix contra status
   id: ClothingBeltMilitaryWebbingERT
   name: ERT chest rig
   description: A set of tactical webbing worn by Emergency Response Team operatives.

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -201,7 +201,7 @@
     sprite: Clothing/Belt/militarywebbingmed.rsi
 
 - type: entity
-  parent: [ BaseCentcommContraband , ClothingBeltMilitaryWebbing ] # Moffstation - Fix contra status
+  parent: [ BaseCentcommContraband, ClothingBeltMilitaryWebbing ] # Moffstation - Fix contra status
   id: ClothingBeltMilitaryWebbingERT
   name: ERT chest rig
   description: A set of tactical webbing worn by Emergency Response Team operatives.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -147,7 +147,7 @@
 
 #Web vest
 - type: entity
-  parent: [ClothingOuterArmorBase, ClothingOuterStorageBase, BaseSyndicateContraband]
+  parent: [ BaseSyndicateContraband, ClothingOuterArmorBase, ClothingOuterStorageBase ] # Moffstation - Fix contra status
   id: ClothingOuterVestWeb
   name: web vest
   description: A synthetic armor vest. This one has added webbing and ballistic plates.
@@ -168,7 +168,7 @@
 
 #Elite web vest
 - type: entity
-  parent: [ClothingOuterArmorBase, AllowSuitStorageClothing, BaseSyndicateContraband]
+  parent: [ BaseSyndicateContraband, ClothingOuterArmorBase, AllowSuitStorageClothing ] # Moffstation - Fix contra status
   id: ClothingOuterVestWebElite
   name: elite web vest
   description: A synthetic armor vest. This one has added webbing and heat resistant fibers.

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -684,7 +684,7 @@
     stateDoorClosed: crate_door
 
 - type: entity
-  parent: CratePirate
+  parent: CrateGeneric # Moffstation - break parenting off of Pirate Chest
   id: CrateToyBox
   name: toy box
   suffix: Empty
@@ -705,6 +705,12 @@
   - type: Icon
     sprite: Structures/Storage/Crates/toybox.rsi
     state: crate_icon
+  # Moffstation - Start - break parenting off of Pirate Chest
+  - type: Appearance
+  - type: EntityStorageVisuals
+    stateDoorOpen: crate_open
+    stateDoorClosed: crate_door
+  # Moffstation - End
 
 - type: entity
   parent: CrateGeneric


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Corrected the following contra statuses:
- Toy box
- ERT chest rig
- Web vest
- Elite web vest

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
General maintenance and fixes. 👍 

## Technical details
<!-- Summary of code changes for easier review. -->
- Reparented "CrateToyBox" from ```CratePirate``` to ```CrateGeneric```, as Pirates are a thing on Moff and the Pirate chest is illegal.
- Added ```BaseCentcomContraband``` as initial parent for "ClothingBeltMilitaryWebbingERT", so it defaults to central command contraband instead of syndicate contraband.
- Reordered parenting on "ClothingOuterVestWeb" and "ClothingOuterVestWebElite" to initialize with ```BaseSyndicateContraband``` first, so it defaults to syndicate contraband instead of security contraband.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="360" height="159" alt="image" src="https://github.com/user-attachments/assets/9542c586-f686-48d4-a1b1-81d310701c00" />

_Not contraband._

<img width="673" height="207" alt="image" src="https://github.com/user-attachments/assets/7522d9b6-bdbf-4cd0-8052-1065b8304eab" />

_Centcom contraband, for ERT._

<img width="651" height="193" alt="image" src="https://github.com/user-attachments/assets/0d0c76b4-e264-401f-b209-af8a373de751" />

<img width="643" height="198" alt="image" src="https://github.com/user-attachments/assets/39cb8f54-f70a-4771-bd84-7861b4246474" />

_Webvests are Syndicate contraband, as intended._

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- fix: Corrected contraband status for Toy box, ERT chest rig, and Webvests.