### PR TITLE
Re-Remove Nocturine Delay Except For Xenoborgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -309,3 +309,4 @@ Resources/MapImages
 
 # Direnv stuff
 .direnv/
+RobustToolbox

--- a/.gitignore
+++ b/.gitignore
@@ -309,4 +309,3 @@ Resources/MapImages
 
 # Direnv stuff
 .direnv/
-RobustToolbox

--- a/Resources/Locale/en-US/_Moffstation/reagents/meta/narcotics.ftl
+++ b/Resources/Locale/en-US/_Moffstation/reagents/meta/narcotics.ftl
@@ -1,0 +1,2 @@
+reagent-name-nanites = Neutralizing Nanites
+reagent-desc-nanites = A viscous liquid that inhibits a countless swarm of microscopic nanomachines. They have been shown to incapacitate anyone unlucky to have them in their bloodstream. Although their true origin is unknown, their use has been linked to Xenoborg operations in the system. 

--- a/Resources/Locale/en-US/_Moffstation/reagents/meta/narcotics.ftl
+++ b/Resources/Locale/en-US/_Moffstation/reagents/meta/narcotics.ftl
@@ -1,2 +1,2 @@
-reagent-name-nanites = Neutralizing Nanites
-reagent-desc-nanites = A viscous liquid in which inhabits a swarm of countless microscopic nanomachines. They have been shown to incapacitate anyone unlucky to have them in their bloodstream. Although their true origin is unknown, their use has been linked to Xenoborg operations in the system. 
+reagent-name-moff-xenoborg-nocturine = Neutralizing Nanites
+reagent-desc-moff-xenoborg-nocturine = A viscous liquid in which inhabits a swarm of countless microscopic nanomachines. They have been shown to incapacitate anyone unlucky to have them in their bloodstream. Although their true origin is unknown, their use has been linked to Xenoborg operations in the system. 

--- a/Resources/Locale/en-US/_Moffstation/reagents/meta/narcotics.ftl
+++ b/Resources/Locale/en-US/_Moffstation/reagents/meta/narcotics.ftl
@@ -1,2 +1,0 @@
-reagent-name-nanites = Neutralizing Nanites
-reagent-desc-nanites = A viscous liquid that inhibits a countless swarm of microscopic nanomachines. They have been shown to incapacitate anyone unlucky to have them in their bloodstream. Although their true origin is unknown, their use has been linked to Xenoborg operations in the system. 

--- a/Resources/Locale/en-US/_Moffstation/reagents/meta/narcotics.ftl
+++ b/Resources/Locale/en-US/_Moffstation/reagents/meta/narcotics.ftl
@@ -1,2 +1,2 @@
 reagent-name-nanites = Neutralizing Nanites
-reagent-desc-nanites = A viscous liquid that inhibits a countless swarm of microscopic nanomachines. They have been shown to incapacitate anyone unlucky to have them in their bloodstream. Although their true origin is unknown, their use has been linked to Xenoborg operations in the system. 
+reagent-desc-nanites = A viscous liquid in which inhabits a swarm of countless microscopic nanomachines. They have been shown to incapacitate anyone unlucky to have them in their bloodstream. Although their true origin is unknown, their use has been linked to Xenoborg operations in the system. 

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/nocturine_hypo.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/nocturine_hypo.yml
@@ -9,7 +9,7 @@
       hypospray:
         maxVol: 12
         reagents:
-        - ReagentId: Nocturine
+        - ReagentId: NocturineXenoborg #Moffstation - Xenoborgs get the nocturine w/ delay.
           Quantity: 12
   - type: SolutionRegeneration
     solution: hypospray

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/nocturine_hypo.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/nocturine_hypo.yml
@@ -15,5 +15,5 @@
     solution: hypospray
     generated:
       reagents:
-      - ReagentId: Nocturine
+      - ReagentId: NocturineXenoborg
         Quantity: 0.2

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/nocturine_hypo.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/nocturine_hypo.yml
@@ -15,5 +15,5 @@
     solution: hypospray
     generated:
       reagents:
-      - ReagentId: NocturineXenoborg
+      - ReagentId: NocturineXenoborg # Moffstation - Xenoborgs get the nocturine w/ delay.
         Quantity: 0.2

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/nocturine_hypo.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/nocturine_hypo.yml
@@ -9,7 +9,7 @@
       hypospray:
         maxVol: 12
         reagents:
-        - ReagentId: NocturineXenoborg #Moffstation - Xenoborgs get the nocturine w/ delay.
+        - ReagentId: NocturineXenoborg # Moffstation - Xenoborgs get the nocturine w/ delay.
           Quantity: 12
   - type: SolutionRegeneration
     solution: hypospray

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -328,7 +328,7 @@
           min: 8
         effectProto: StatusEffectForcedSleeping
         time: 9
-        delay: 5
+        #delay: 5 Moffstation - No more nocturine delay besides metabolization time
 
 - type: reagent
   id: MuteToxin

--- a/Resources/Prototypes/_Moffstation/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Moffstation/Reagents/narcotics.yml
@@ -1,0 +1,24 @@
+- type: reagent
+  id: NocturineXenoborg
+  name: reagent-name-nocturine
+  group: Narcotics
+  desc: reagent-desc-nocturine
+  physicalDesc: reagent-physical-desc-powdery
+  contrabandSeverity: Syndicate
+  color: "#128e80"
+  boilingPoint: 444.0
+  meltingPoint: 128.0
+  metabolisms:
+    Bloodstream:
+      effects: # It would be nice to have speech slurred or mumbly, but accents are a bit iffy atm. Same for distortion effects.
+      - !type:MovementSpeedModifier
+        walkSpeedModifier: 0.65
+        sprintSpeedModifier: 0.65
+      - !type:ModifyStatusEffect
+        conditions:
+        - !type:ReagentCondition
+          reagent: Nocturine
+          min: 8
+        effectProto: StatusEffectForcedSleeping
+        time: 9
+        delay: 5

--- a/Resources/Prototypes/_Moffstation/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Moffstation/Reagents/narcotics.yml
@@ -2,7 +2,7 @@
   id: NocturineXenoborg
   name: reagent-name-moff-xenoborg-nocturine
   group: Narcotics
-  desc: reagent-desc-nanites
+  desc: reagent-desc-moff-xenoborg-nocturine
   physicalDesc: reagent-physical-desc-powdery
   contrabandSeverity: Major
   color: "#128e80"

--- a/Resources/Prototypes/_Moffstation/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Moffstation/Reagents/narcotics.yml
@@ -1,10 +1,10 @@
-- type: reagent
+- type: reagent #This is just nocturine for xenoborgs w/ a delay.
   id: NocturineXenoborg
-  name: reagent-name-nocturine
+  name: reagent-name-nanites
   group: Narcotics
-  desc: reagent-desc-nocturine
+  desc: reagent-desc-nanites
   physicalDesc: reagent-physical-desc-powdery
-  contrabandSeverity: Syndicate
+  contrabandSeverity: Major
   color: "#128e80"
   boilingPoint: 444.0
   meltingPoint: 128.0

--- a/Resources/Prototypes/_Moffstation/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Moffstation/Reagents/narcotics.yml
@@ -17,7 +17,7 @@
       - !type:ModifyStatusEffect
         conditions:
         - !type:ReagentCondition
-          reagent: Nocturine
+          reagent: NocturineXenoborg
           min: 8
         effectProto: StatusEffectForcedSleeping
         time: 9

--- a/Resources/Prototypes/_Moffstation/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Moffstation/Reagents/narcotics.yml
@@ -1,6 +1,6 @@
 - type: reagent #This is just nocturine for xenoborgs w/ a delay.
   id: NocturineXenoborg
-  name: reagent-name-nanites
+  name: reagent-name-moff-xenoborg-nocturine
   group: Narcotics
   desc: reagent-desc-nanites
   physicalDesc: reagent-physical-desc-powdery


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
This concerns https://github.com/moff-station/moff-station-14/pull/597#issue-3462382199 and https://github.com/moff-station/moff-station-14/pull/815#issue-3687421278 .

Originally we reverted the Nocturine delay due to it being an unneeded nerf to stealth antags and disagreeing with the arguments regarding counterplay and effectiveness and generally just plummeting the chem into basically unusable tier. 

Xenoborgs were added and since the stealth variety has infinite nocturine, this Moffstation change was reverted (which could still be argued since they can only sleep people every 60 seconds with the regen rate but I digress).

That PR mentioned an "alternative solution could be giving xenoborgs their own version of Noct which works like upstream Noct". This is that exact solution. Xenoborgs get their version with delay, normal nocturine stays at no delay. I just hadn't noticed the change back until recently.

I believe adding back the delay recreates all the problems explained in #597 - I dont wanna rehash it all as you can just click the link but the tldr is that the delay makes the chem nigh unusable power-wise for normal traitors and already had counterplay.

## Why / Balance
See #597 . The reason for giving Xenoborgs their own version is because that was what prompted changing it back in the first place as an issue. I don't believe all other traitors had to take the fall as well.

## Technical details
Creates a narcotics YML file in moff namespace with Xenoborg Nocturine (with delay). Xenoborg's hypo is given that specific nocturine. Normal nocturine had the delay commented out.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Nocturine no longer has a delay to activate once metabolized. Xenoborgs now have their own version of nocturine with the previous delay.

