### PR TITLE
[Adjustment] Prevent traitors from getting steal objectives relative to their department.

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -27,7 +27,6 @@
     HandTeleporterStealObjective: 0.5
     EnergyMagnumStealObjective: 0.5 # Moffstation - Objective picker adjustments
     ValkyrieHudStealObjective : 1 # Moffstation - Valkyrie Hud is now a Steal Objective
-    #BigIronStealObjective : 0.5 # Moffstation - Big Iron is now a Steal Objective - not in use atm
 
 - type: weightedRandom
   id: TraitorObjectiveGroupKill

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -426,7 +426,7 @@
   id: BoozeDispenserStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ Bartender, ServiceWorker ]
+    jobs: [ Bartender, ServiceWorker , Scientist ] # Moffstation - More drama, less cheese (Scientists can currently make these)
   - type: StealCondition
     stealGroup: BoozeDispenser
   - type: Objective

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -426,7 +426,7 @@
   id: BoozeDispenserStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ Bartender, ServiceWorker , Scientist ] # Moffstation - More drama, less cheese (Scientists can currently make these)
+    jobs: [ Bartender, ServiceWorker, Scientist ] # Moffstation - More drama, less cheese (Scientists can currently make these)
   - type: StealCondition
     stealGroup: BoozeDispenser
   - type: Objective

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -194,7 +194,7 @@
   id: BaseCMOStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ ChiefMedicalOfficer ]
+    jobs: [ ChiefMedicalOfficer , Paramedic , Chemist , MedicalDoctor , Psychologist ] # Moffstation - More drama, less cheese
   - type: StealCondition
     owner: job-name-cmo
 
@@ -220,7 +220,7 @@
   id: BaseRDStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ ResearchDirector ]
+    jobs: [ ResearchDirector , Scientist ] # Moffstation - More drama, less cheese
   - type: StealCondition
     owner: job-name-rd
 
@@ -251,7 +251,7 @@
     # HoS will have this on them a lot of the time so..
     difficulty: 3
   - type: NotJobRequirement
-    jobs: [ HeadOfSecurity ]
+    jobs: [ HeadOfSecurity , Warden , Detective , SecurityOfficer , Lawyer ] # Moffstation - More drama, less cheese
   - type: StealCondition
     stealGroup: WeaponEnergyMagnum
     owner: job-name-hos
@@ -263,7 +263,7 @@
   id: MagbootsStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ ChiefEngineer ]
+    jobs: [ ChiefEngineer , AtmosphericTechnician , StationEngineer ] # Moffstation - More drama, less cheese
   - type: StealCondition
     stealGroup: ClothingShoesBootsMagAdv
     owner: job-name-ce
@@ -275,7 +275,7 @@
   id: ClipboardStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ Quartermaster ]
+    jobs: [ Quartermaster , CargoTechnician , SalvageSpecialist ] # Moffstation - More drama, less cheese
   - type: StealCondition
     stealGroup: BoxFolderQmClipboard
     owner: job-name-qm
@@ -285,7 +285,7 @@
   id: KnuckleDustersStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ Quartermaster ]
+    jobs: [ Quartermaster , CargoTechnician , SalvageSpecialist ] # Moffstation - More drama, less cheese
   - type: StealCondition
     stealGroup: ClothingHandsKnuckleDustersQM
     owner: job-name-qm

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -194,7 +194,7 @@
   id: BaseCMOStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ ChiefMedicalOfficer , Paramedic , Chemist , MedicalDoctor , Psychologist ] # Moffstation - More drama, less cheese
+    jobs: [ ChiefMedicalOfficer, Paramedic, Chemist, MedicalDoctor, Psychologist ] # Moffstation - More drama, less cheese
   - type: StealCondition
     owner: job-name-cmo
 
@@ -220,7 +220,7 @@
   id: BaseRDStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ ResearchDirector , Scientist ] # Moffstation - More drama, less cheese
+    jobs: [ ResearchDirector, Scientist ] # Moffstation - More drama, less cheese
   - type: StealCondition
     owner: job-name-rd
 
@@ -251,7 +251,7 @@
     # HoS will have this on them a lot of the time so..
     difficulty: 3
   - type: NotJobRequirement
-    jobs: [ HeadOfSecurity , Warden , Detective , SecurityOfficer , Lawyer ] # Moffstation - More drama, less cheese
+    jobs: [ HeadOfSecurity, Warden, Detective, SecurityOfficer, Lawyer ] # Moffstation - More drama, less cheese
   - type: StealCondition
     stealGroup: WeaponEnergyMagnum
     owner: job-name-hos
@@ -263,7 +263,7 @@
   id: MagbootsStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ ChiefEngineer , AtmosphericTechnician , StationEngineer ] # Moffstation - More drama, less cheese
+    jobs: [ ChiefEngineer, AtmosphericTechnician, StationEngineer ] # Moffstation - More drama, less cheese
   - type: StealCondition
     stealGroup: ClothingShoesBootsMagAdv
     owner: job-name-ce
@@ -275,7 +275,7 @@
   id: ClipboardStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ Quartermaster , CargoTechnician , SalvageSpecialist ] # Moffstation - More drama, less cheese
+    jobs: [ Quartermaster, CargoTechnician, SalvageSpecialist ] # Moffstation - More drama, less cheese
   - type: StealCondition
     stealGroup: BoxFolderQmClipboard
     owner: job-name-qm
@@ -285,7 +285,7 @@
   id: KnuckleDustersStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ Quartermaster , CargoTechnician , SalvageSpecialist ] # Moffstation - More drama, less cheese
+    jobs: [ Quartermaster, CargoTechnician, SalvageSpecialist ] # Moffstation - More drama, less cheese
   - type: StealCondition
     stealGroup: ClothingHandsKnuckleDustersQM
     owner: job-name-qm

--- a/Resources/Prototypes/_Moffstation/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Moffstation/Objectives/traitor.yml
@@ -163,13 +163,8 @@
       - SimpleObjective
 
 - type: entity
-  parent: BaseTraitorStealObjective
+  parent: BaseCMOStealObjective
   id: ValkyrieHudStealObjective
   components:
-  - type: Objective
-    difficulty: 1
-  - type: NotJobRequirement
-    jobs: [ ChiefMedicalOfficer ]
   - type: StealCondition
     stealGroup: ClothingEyesGlassesMedChem
-    owner: job-name-cmo


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Syndicate agents will no longer be given objectives for items within their department.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With the addition of the objective picker, syndicates now have a greater degree of control to select which tasks they'd like to perform. While this mechanical support for task curation is an excellent addition to our space and supports the identity we founded with the removal of greentext and introduction of pinktext, it suffers one major flaw - task cheesing.

An issue especially seen frequently, especially in lower pop shifts without command, there have been a notable number of shifts where traitors will solely select steal objectives relevant to their department - knowing there isn't a head of staff currently in round - and just take the items round start with zero engagement. While this /could/ occur with the old system, it was rare that your only objectives would be to rob explicitly your own missing department head, and was often combined with some other external task that would risk you blowing your cover. With our current system, this objective cheese ultimately leads to less chaos, which I do not see to be our intended direction for Moffstation.

So how do we fix this?

Simple - we expand the steal objective denylist to cover the department. If you want to rob a missing department head, you're more likely to be caught robbing a different department, as that involves interaction with said department, leading to risk of exposure. Additionally, with less steal objectives in the pool, this should ideally offer other objectives in these missing places, providing more vectors of chaos. This practice already is seen with thief objectives as well, such as scientists, engineers, medical staff, and the chef being unable to have a freezer as a theft objective, as each of those roles have freezers as a part of their role to begin with.

In summary, our goal is to give syndicate agents the priority to tell the story how they would prefer to tell their story - but there's still a story being expected to told. Enabling agents to rob their head of staff lockers shift-start does not offer any engagement for the rest of the station, and does not reflect our principles in this regard. As a result, we should remove these objectives from the pool to give agents other alternatives to build around, encouraging interaction with the rest of the station, and reducing dead-air in shifts.

## Technical details
<!-- Summary of code changes for easier review. -->
yml changes.

Modified ```NotJobRequirement``` for multiple steal objectives within /Objectives/traitor.yml.

Removed old commented out Prototype from ```TraitorObjectiveGroupSteal``` for the Big Iron, as this firearm no longer exists within the game. (still within the files, but we may want to later reevaluate what we want to do with it and perform cleanup)

Also cleaned up the yml on ```ValkyrieHudStealObjective``` to match other CMO theft objectives.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

How do you get media of something -not- existing?

<img width="794" height="504" alt="image" src="https://github.com/user-attachments/assets/89ac9dad-cf82-4136-a4ad-9acea519b65b" />

_Look ma, no experimental hardsuit or hand teleporter!_

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- tweak: Syndicate objectives will no longer provide you with steal objectives relative to your own department.