### PR TITLE
Fix very smoll dwarves getting HUD icons getting ignored for no reason

### DIFF
--- a/Content.Client/StatusIcon/StatusIconOverlay.cs
+++ b/Content.Client/StatusIcon/StatusIconOverlay.cs
@@ -88,10 +88,14 @@ public sealed class StatusIconOverlay : Overlay
                 if (proto.LocationPreference == StatusIconLocationPreference.Left ||
                     proto.LocationPreference == StatusIconLocationPreference.None && countL <= countR)
                 {
-                    if (accOffsetL + texture.Height > _sprite.GetLocalBounds((uid, sprite)).Height * EyeManager.PixelsPerMeter)
-                        break;
+                    // Moffstation - Move icon cutoff check into `if` so that `Mod` layer icons don't get dropped when they could fit.
                     if (proto.Layer == StatusIconLayer.Base)
                     {
+                        // Moffstation - Begin
+                        if (accOffsetL + texture.Height > _sprite.GetLocalBounds((uid, sprite)).Height * EyeManager.PixelsPerMeter)
+                            break;
+                        // Moffstation - End
+
                         accOffsetL += texture.Height;
                         countL++;
                     }
@@ -101,10 +105,14 @@ public sealed class StatusIconOverlay : Overlay
                 }
                 else
                 {
-                    if (accOffsetR + texture.Height > _sprite.GetLocalBounds((uid, sprite)).Height * EyeManager.PixelsPerMeter)
-                        break;
+                    // Moffstation - Move icon cutoff check into `if` so that `Mod` layer icons don't get dropped when they could fit.
                     if (proto.Layer == StatusIconLayer.Base)
                     {
+                        // Moffstation - Begin
+                        if (accOffsetR + texture.Height > _sprite.GetLocalBounds((uid, sprite)).Height * EyeManager.PixelsPerMeter)
+                            break;
+                        // Moffstation - End
+
                         accOffsetR += texture.Height;
                         countR++;
                     }


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Fix a bug in HUD icon rendering code which treated `Mod` (ie. overlay icons) as though they would be placed in the next spot of a main icon, and thus would be dropped.

This should also affect the mindshield icon.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix

## Technical details
<!-- Summary of code changes for easier review. -->
Just moved some checks into an `if` branch.
The bug seems to originate from dwarves already being scaled down, so when the height slider scaling is applied on top of that, the rendering code was just like "this sprite is just too small to put more icons onto" -- which, yes, true, but modifier HUD icons aren't _more_ icons, they're modifiers that sit on top of other ones, so it's fine.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="328" height="364" alt="image" src="https://github.com/user-attachments/assets/09d64051-a683-42f9-a029-e4117e906409" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: Dwarves at the smallest height slider value will not get HUD icons describing them dropped for no reason. (For example, the "Is Crew?" silicon HUD icon shows now.)