### PR TITLE
[Feature] Infectious Blood

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -98,6 +98,8 @@ namespace Content.Server.Zombies
             EnsureComp<PendingZombieComponent>(uid, out PendingZombieComponent pendingComp);
 
             pendingComp.GracePeriod = _random.Next(pendingComp.MinInitialInfectedGrace, pendingComp.MaxInitialInfectedGrace);
+
+            _bloodstream.ChangeBloodReagents(uid, component.InfectedBloodReagents); // Moffstation - Infectious blood
         }
 
         private void OnPendingMapInit(EntityUid uid, PendingZombieComponent component, MapInitEvent args)

--- a/Content.Shared/Zombies/IncurableZombieComponent.cs
+++ b/Content.Shared/Zombies/IncurableZombieComponent.cs
@@ -1,5 +1,8 @@
 ﻿using Robust.Shared.Prototypes;
-using Content.Shared.Chemistry.Components; // Moffstation - Infectious blood
+// Moffstation - Start - Infectious blood
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Reagent;
+// Moffstation - End
 
 namespace Content.Shared.Zombies;
 
@@ -17,7 +20,9 @@ public sealed partial class IncurableZombieComponent : Component
     public EntityUid? Action;
 
     // Moffstation - Start - Infectious blood
+    private static ProtoId<ReagentPrototype> _ZombieBlood = "ZombieBlood";
+
     [DataField]
-    public Solution InfectedBloodReagents = new([new("ZombieBlood", 1)]);
+    public Solution InfectedBloodReagents = new([new(_ZombieBlood, 1)]);
     // Moffstation - End
 }

--- a/Content.Shared/Zombies/IncurableZombieComponent.cs
+++ b/Content.Shared/Zombies/IncurableZombieComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Robust.Shared.Prototypes;
+using Content.Shared.Chemistry.Components;
 
 namespace Content.Shared.Zombies;
 
@@ -14,4 +15,9 @@ public sealed partial class IncurableZombieComponent : Component
 
     [DataField]
     public EntityUid? Action;
+
+    // Moffstation - Start - Infectious blood
+    [DataField]
+    public Solution InfectedBloodReagents = new([new("ZombieBlood", 1)]);
+    // Moffstation - End
 }

--- a/Content.Shared/Zombies/IncurableZombieComponent.cs
+++ b/Content.Shared/Zombies/IncurableZombieComponent.cs
@@ -1,5 +1,5 @@
 ﻿using Robust.Shared.Prototypes;
-using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Components; // Moffstation - Infectious blood
 
 namespace Content.Shared.Zombies;
 

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -163,6 +163,13 @@
       effects:
       - !type:SatiateThirst
         factor: -0.5
+      # Moffstation - Start - Infectious blood
+      - !type:CauseZombieInfection
+        conditions:
+        - !type:ReagentCondition
+          reagent: ZombieBlood
+          min: 2 # basically impossible to eat or drink to 5u of accumulation, so min is lower here
+      # Moffstation - End
     Bloodstream:
       effects:
       - !type:HealthChange
@@ -171,6 +178,14 @@
             Poison: 4
       - !type:Vomit
         probability: 0.25
+      # Moffstation - Start - Infectious blood
+      - !type:CauseZombieInfection
+        conditions:
+        - !type:ReagentCondition
+          reagent: ZombieBlood
+          min: 5
+      # Moffstation - End
+
 - type: reagent
   id: Ichor
   name: reagent-name-ichor


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Initial infected now possess zombie blood, and zombie blood is infectious.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This pull request is intended to resolve two resolve two issues - Thematic inconsistency and Initial Infected role disparity.

First - it has always struck me odd that, while Zeds themselves are a biological threat, there's very little concern regarding maintaining station cleanliness during these threats. Halls will be filled with blood and refuse, but as long as you're not bitten, there's no real care. By making zombie blood infectious, we maintain that station cleanliness is not only encouraged, but vital for station safety.

Second - Initial infected as a gamemode has suffers heavily from which roles are chosen for our patient zero. While some roles like engineer are capable of performing station-wide destruction by virtue of their position, other roles like bartender are more at the mercy of lucky breaks to really perform in the initial wave. By letting these service roles utilize their own blood to infect others, this provides greater opportunity for these service roles to succeed in their goal, while keeping thematic relative to being a biological threat.

Additionally, this also gives the station a means to potentially identify initial infected early, as you may be suspicious when you see john from accounting bleeding thick dark ichor instead of what you'd normally expect.

## Technical details
<!-- Summary of code changes for easier review. -->

C# and yml.

added line: ```_bloodstream.ChangeBloodReagents(uid, component.InfectedBloodReagents);``` to our OnPendingMapInit method, changing our incurable zeds (aka initial infected) to possess zombie blood instead of their normal blood.

Following this, we then added the ```!type:CauseZombieInfection``` to our ZombieBlood reagent, for both metabolism and bloodstream.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="529" height="342" alt="image" src="https://github.com/user-attachments/assets/4dfe85cf-008c-4553-bd32-71908a81b796" />

_Go, my poisoned burger!_

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- tweak: Initial infected now possess zombie blood.
- add: Zombie blood is now infectious.