### PR TITLE
[Tweak] Allow AI to be Ionstormed.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -407,7 +407,7 @@
 # The actual brain inside the core
 - type: entity
   id: StationAiBrain
-  parent: PositronicBrainNotIonStormable # One day
+  parent: PositronicBrain # Moffstation - let them be ion'd!
   categories: [ HideSpawnMenu, DoNotMap ]
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1687,10 +1687,17 @@
           components:
           - SiliconLawProvider
           - Item
+        disableEject: true # Moffstation - There must always be... a lawboard.
   - type: ContainerContainer
     containers:
       circuit_holder: !type:ContainerSlot
       board: !type:Container
+  # Moffstation - Start - Station AI law uploads start with a board
+  - type: ContainerFill
+    containers:
+      circuit_holder:
+      - AsimovCircuitBoard
+  # Moffstation - End
 
 - type: entity
   id: StationAiFixerComputer

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1687,17 +1687,10 @@
           components:
           - SiliconLawProvider
           - Item
-        disableEject: true # Moffstation - There must always be... a lawboard.
   - type: ContainerContainer
     containers:
       circuit_holder: !type:ContainerSlot
       board: !type:Container
-  # Moffstation - Start - Station AI law uploads start with a board
-  - type: ContainerFill
-    containers:
-      circuit_holder:
-      - AsimovCircuitBoard
-  # Moffstation - End
 
 - type: entity
   id: StationAiFixerComputer


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->

Enabled AI to be a target for Ionstorms.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Chaos reigns.

AI in its inception, as I understand, was not permitted to be Ionstormed, as in its earliest versions it lacked options for counterplay in regards to law resets, deconstruction, and recovery. However, we've come a decent distance from that, and with the inclusion of a few Moffstation unique systems like our law matrix imprinter, I believe we're at the point where we can enable the AI to be ionstormed.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
yml changes, currently.

Changed the AI's brain prototype to our ionstorm-compatable variant.

~~Additionally, changed our law upload console to spawn with a crewsimov board by default, along with disabling the ejection feature. this is in preparation for a few later updates, ensuring that the law upload console always has a board inserted by default, while still allowing you to swap the board by replacing it with a new board.~~ <<< _putting a pin on this, as it's causing failures._

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

N/A - we know what ionstorm laws look like.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: AI Ionstorm shielding is now 80% thinner!