### PR TITLE
[Feature] Jukebox volume buttons!

### DIFF
--- a/Content.Client/Audio/Jukebox/JukeboxBoundUserInterface.cs
+++ b/Content.Client/Audio/Jukebox/JukeboxBoundUserInterface.cs
@@ -41,6 +41,18 @@ public sealed class JukeboxBoundUserInterface : BoundUserInterface
             SendMessage(new JukeboxStopMessage());
         };
 
+        // Moffstation - Start - Jukebox volume control
+        _menu.OnVolumeDownPressed += () =>
+        {
+            SendMessage(new JukeboxVolumeDownMessage());
+        };
+
+        _menu.OnVolumeUpPressed += () =>
+        {
+            SendMessage(new JukeboxVolumeUpMessage());
+        };
+        // Moffstation - End
+
         _menu.OnSongSelected += SelectSong;
 
         _menu.SetTime += SetTime;

--- a/Content.Client/Audio/Jukebox/JukeboxBoundUserInterface.cs
+++ b/Content.Client/Audio/Jukebox/JukeboxBoundUserInterface.cs
@@ -85,13 +85,16 @@ public sealed class JukeboxBoundUserInterface : BoundUserInterface
         UpdateVolumeDisplay();
     }
 
+    // Moffstation - Start - Jukebox volume control
     public void UpdateVolumeDisplay()
     {
         if (_menu == null || !EntMan.TryGetComponent(Owner, out JukeboxComponent? jukebox))
             return;
 
-        _menu.SetVolumeDisplay(jukebox.JukeboxVolume);
+        _menu.SetVolumeDisplay(jukebox.JukeboxVolume, jukebox.JukeboxVolumeMin);
     }
+    // Moffstation - End
+
     public void PopulateMusic()
     {
         _menu?.Populate(_protoManager.EnumeratePrototypes<JukeboxPrototype>());

--- a/Content.Client/Audio/Jukebox/JukeboxBoundUserInterface.cs
+++ b/Content.Client/Audio/Jukebox/JukeboxBoundUserInterface.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Audio.Jukebox;
 using Robust.Client.Audio;
+using Robust.Client.Console;
 using Robust.Client.UserInterface;
 using Robust.Shared.Audio.Components;
 using Robust.Shared.Prototypes;
@@ -45,11 +46,13 @@ public sealed class JukeboxBoundUserInterface : BoundUserInterface
         _menu.OnVolumeDownPressed += () =>
         {
             SendMessage(new JukeboxVolumeDownMessage());
+            UpdateVolumeDisplay();
         };
 
         _menu.OnVolumeUpPressed += () =>
         {
             SendMessage(new JukeboxVolumeUpMessage());
+            UpdateVolumeDisplay();
         };
         // Moffstation - End
 
@@ -79,8 +82,16 @@ public sealed class JukeboxBoundUserInterface : BoundUserInterface
         {
             _menu.SetSelectedSong(string.Empty, 0f);
         }
+        UpdateVolumeDisplay();
     }
 
+    public void UpdateVolumeDisplay()
+    {
+        if (_menu == null || !EntMan.TryGetComponent(Owner, out JukeboxComponent? jukebox))
+            return;
+
+        _menu.SetVolumeDisplay(jukebox.JukeboxVolume);
+    }
     public void PopulateMusic()
     {
         _menu?.Populate(_protoManager.EnumeratePrototypes<JukeboxPrototype>());

--- a/Content.Client/Audio/Jukebox/JukeboxBoundUserInterface.cs
+++ b/Content.Client/Audio/Jukebox/JukeboxBoundUserInterface.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Audio.Jukebox;
 using Robust.Client.Audio;
-using Robust.Client.Console;
 using Robust.Client.UserInterface;
 using Robust.Shared.Audio.Components;
 using Robust.Shared.Prototypes;
@@ -82,7 +81,7 @@ public sealed class JukeboxBoundUserInterface : BoundUserInterface
         {
             _menu.SetSelectedSong(string.Empty, 0f);
         }
-        UpdateVolumeDisplay();
+        UpdateVolumeDisplay(); // Moffstation - Start
     }
 
     // Moffstation - Start - Jukebox volume control

--- a/Content.Client/Audio/Jukebox/JukeboxMenu.xaml
+++ b/Content.Client/Audio/Jukebox/JukeboxMenu.xaml
@@ -15,8 +15,8 @@
             <!--Moffstation - Start - Jukebox volume control -->
             <Label Name="VolumeDividerLeft" Text="|" />
             <Button Name="VolumeDown" Text="{Loc 'jukebox-menu-volume-down'}" />
-            <Button Name="VolumeUp" Text="{Loc 'jukebox-menu-volume-up'}" />
             <Label Name="VolumeDisplay" Text="---" />
+            <Button Name="VolumeUp" Text="{Loc 'jukebox-menu-volume-up'}" />
             <Label Name="VolumeDividerRight" Text="|" />
             <!--Moffstation - End -->
             <Label Name="DurationLabel" Text="00:00 / 00:00" HorizontalAlignment="Right" HorizontalExpand="True"/>

--- a/Content.Client/Audio/Jukebox/JukeboxMenu.xaml
+++ b/Content.Client/Audio/Jukebox/JukeboxMenu.xaml
@@ -16,6 +16,7 @@
             <Label Name="VolumeDividerLeft" Text="|" />
             <Button Name="VolumeDown" Text="{Loc 'jukebox-menu-volume-down'}" />
             <Button Name="VolumeUp" Text="{Loc 'jukebox-menu-volume-up'}" />
+            <Label Name="VolumeDisplay" Text="---" />
             <Label Name="VolumeDividerRight" Text="|" />
             <!--Moffstation - End -->
             <Label Name="DurationLabel" Text="00:00 / 00:00" HorizontalAlignment="Right" HorizontalExpand="True"/>

--- a/Content.Client/Audio/Jukebox/JukeboxMenu.xaml
+++ b/Content.Client/Audio/Jukebox/JukeboxMenu.xaml
@@ -12,6 +12,12 @@
         VerticalExpand="False" SizeFlagsStretchRatio="1">
             <Button Name="PlayButton" Text="{Loc 'jukebox-menu-buttonplay'}" />
             <Button Name="StopButton" Text="{Loc 'jukebox-menu-buttonstop'}" />
+            <!--Moffstation - Start - Jukebox volume control -->
+            <Label Name="VolumeDividerLeft" Text="|" />
+            <Button Name="VolumeDown" Text="{Loc 'jukebox-menu-volume-down'}" />
+            <Button Name="VolumeUp" Text="{Loc 'jukebox-menu-volume-up'}" />
+            <Label Name="VolumeDividerRight" Text="|" />
+            <!--Moffstation - End -->
             <Label Name="DurationLabel" Text="00:00 / 00:00" HorizontalAlignment="Right" HorizontalExpand="True"/>
         </BoxContainer>
     </BoxContainer>

--- a/Content.Client/Audio/Jukebox/JukeboxMenu.xaml
+++ b/Content.Client/Audio/Jukebox/JukeboxMenu.xaml
@@ -10,14 +10,12 @@
         </BoxContainer>
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True"
         VerticalExpand="False" SizeFlagsStretchRatio="1">
-            <Button Name="PlayButton" Text="{Loc 'jukebox-menu-buttonplay'}" />
-            <Button Name="StopButton" Text="{Loc 'jukebox-menu-buttonstop'}" />
             <!--Moffstation - Start - Jukebox volume control -->
-            <Label Name="VolumeDividerLeft" Text="|" />
-            <Button Name="VolumeDown" Text="{Loc 'jukebox-menu-volume-down'}" />
-            <Label Name="VolumeDisplay" Text="---" />
-            <Button Name="VolumeUp" Text="{Loc 'jukebox-menu-volume-up'}" />
-            <Label Name="VolumeDividerRight" Text="|" />
+            <Button Name="PlayButton" Text="{Loc 'jukebox-menu-buttonplay'}" Margin="1 0"/>
+            <Button Name="StopButton" Text="{Loc 'jukebox-menu-buttonstop'}" Margin="1 0"/>
+            <Button Name="VolumeDown" Text="{Loc 'jukebox-menu-volume-down'}" StyleClasses="OpenRight" Margin="1 0 0 0"/>
+            <Button Name="VolumeDisplay" Text="---" StyleClasses="OpenBoth" MinWidth="50"/>
+            <Button Name="VolumeUp" Text="{Loc 'jukebox-menu-volume-up'}" StyleClasses="OpenLeft" Margin="0 0 1 0"/>
             <!--Moffstation - End -->
             <Label Name="DurationLabel" Text="00:00 / 00:00" HorizontalAlignment="Right" HorizontalExpand="True"/>
         </BoxContainer>

--- a/Content.Client/Audio/Jukebox/JukeboxMenu.xaml.cs
+++ b/Content.Client/Audio/Jukebox/JukeboxMenu.xaml.cs
@@ -183,7 +183,7 @@ public sealed partial class JukeboxMenu : FancyWindow
     // Moffstation - Start - Jukebox volume control
     public void SetVolumeDisplay(int volume, int volumeMin)
     {
-        VolumeDisplay.Text = "[ " + (volume-volumeMin+1) + " ]"; // +1 so our lowest display value starts at '1', rather than '0'
+        VolumeDisplay.Text = (volume-volumeMin+1).ToString(); // +1 so our lowest display value starts at '1', rather than '0'
     }
     // Moffstation - End
 }

--- a/Content.Client/Audio/Jukebox/JukeboxMenu.xaml.cs
+++ b/Content.Client/Audio/Jukebox/JukeboxMenu.xaml.cs
@@ -91,11 +91,6 @@ public sealed partial class JukeboxMenu : FancyWindow
         _audio = audio;
     }
 
-    public void SetVolumeDisplay(int volume, int volumeMin)
-    {
-        VolumeDisplay.Text = "[ " + (volume-volumeMin+1).ToString() + " ]"; // +1 so our lowest display value starts at '1', rather than '0'
-    }
-
     private void PlaybackSliderKeyUp(Slider args)
     {
         SetTime?.Invoke(PlaybackSlider.Value);
@@ -184,4 +179,11 @@ public sealed partial class JukeboxMenu : FancyWindow
             SongName.Text = "---";
         }
     }
+
+    // Moffstation - Start - Jukebox volume control
+    public void SetVolumeDisplay(int volume, int volumeMin)
+    {
+        VolumeDisplay.Text = "[ " + (volume-volumeMin+1) + " ]"; // +1 so our lowest display value starts at '1', rather than '0'
+    }
+    // Moffstation - End
 }

--- a/Content.Client/Audio/Jukebox/JukeboxMenu.xaml.cs
+++ b/Content.Client/Audio/Jukebox/JukeboxMenu.xaml.cs
@@ -30,6 +30,10 @@ public sealed partial class JukeboxMenu : FancyWindow
     public event Action? OnStopPressed;
     public event Action<ProtoId<JukeboxPrototype>>? OnSongSelected;
     public event Action<float>? SetTime;
+    // Moffstation - Start - Jukebox volume control
+    public event Action? OnVolumeDownPressed;
+    public event Action? OnVolumeUpPressed;
+    // Moffstation - End
 
     private EntityUid? _audio;
 
@@ -63,6 +67,18 @@ public sealed partial class JukeboxMenu : FancyWindow
         PlaybackSlider.OnReleased += PlaybackSliderKeyUp;
 
         SetPlayPauseButton(_audioSystem.IsPlaying(_audio), force: true);
+
+        // Moffstation - Start - Jukebox volume control
+        VolumeDown.OnPressed += args =>
+        {
+            OnVolumeDownPressed?.Invoke();
+        };
+
+        VolumeUp.OnPressed += args =>
+        {
+            OnVolumeUpPressed?.Invoke();
+        };
+        // Moffstation - End
     }
 
     public JukeboxMenu(AudioSystem audioSystem)

--- a/Content.Client/Audio/Jukebox/JukeboxMenu.xaml.cs
+++ b/Content.Client/Audio/Jukebox/JukeboxMenu.xaml.cs
@@ -91,6 +91,11 @@ public sealed partial class JukeboxMenu : FancyWindow
         _audio = audio;
     }
 
+    public void SetVolumeDisplay(int volume)
+    {
+        VolumeDisplay.Text = volume.ToString();
+    }
+
     private void PlaybackSliderKeyUp(Slider args)
     {
         SetTime?.Invoke(PlaybackSlider.Value);

--- a/Content.Client/Audio/Jukebox/JukeboxMenu.xaml.cs
+++ b/Content.Client/Audio/Jukebox/JukeboxMenu.xaml.cs
@@ -91,9 +91,9 @@ public sealed partial class JukeboxMenu : FancyWindow
         _audio = audio;
     }
 
-    public void SetVolumeDisplay(int volume)
+    public void SetVolumeDisplay(int volume, int volumeMin)
     {
-        VolumeDisplay.Text = volume.ToString();
+        VolumeDisplay.Text = "[ " + (volume-volumeMin+1).ToString() + " ]"; // +1 so our lowest display value starts at '1', rather than '0'
     }
 
     private void PlaybackSliderKeyUp(Slider args)

--- a/Content.Server/Audio/Jukebox/JukeboxSystem.cs
+++ b/Content.Server/Audio/Jukebox/JukeboxSystem.cs
@@ -214,7 +214,7 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
         if (entity.Comp.JukeboxVolume > entity.Comp.JukeboxVolumeMin)
         {
             entity.Comp.JukeboxVolume--;
-            Dirty(entity);
+            Dirty(entity); //
             Audio.SetVolume(entity.Comp.AudioStream, entity.Comp.JukeboxVolume);
         }
     }

--- a/Content.Server/Audio/Jukebox/JukeboxSystem.cs
+++ b/Content.Server/Audio/Jukebox/JukeboxSystem.cs
@@ -211,18 +211,20 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
     // Moffstation - Start - Jukebox volume control
     private void OnJukeboxVolumeDown(Entity<JukeboxComponent> entity, ref JukeboxVolumeDownMessage args)
     {
-        if (entity.Comp.JukeboxVolume > -10)
+        if (entity.Comp.JukeboxVolume > entity.Comp.JukeboxVolumeMin)
         {
             entity.Comp.JukeboxVolume--;
+            Dirty(entity);
             Audio.SetVolume(entity.Comp.AudioStream, entity.Comp.JukeboxVolume);
         }
     }
 
     private void OnJukeboxVolumeUp(Entity<JukeboxComponent> entity, ref JukeboxVolumeUpMessage args)
     {
-        if (entity.Comp.JukeboxVolume < 0)
+        if (entity.Comp.JukeboxVolume < entity.Comp.JukeboxVolumeMax)
         {
             entity.Comp.JukeboxVolume++;
+            Dirty(entity);
             Audio.SetVolume(entity.Comp.AudioStream, entity.Comp.JukeboxVolume);
         }
     }

--- a/Content.Server/Audio/Jukebox/JukeboxSystem.cs
+++ b/Content.Server/Audio/Jukebox/JukeboxSystem.cs
@@ -25,6 +25,10 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
         SubscribeLocalEvent<JukeboxComponent, JukeboxSetTimeMessage>(OnJukeboxSetTime);
         SubscribeLocalEvent<JukeboxComponent, ComponentInit>(OnComponentInit);
         SubscribeLocalEvent<JukeboxComponent, ComponentShutdown>(OnComponentShutdown);
+        // Moffstation - Start - Jukebox volume control
+        SubscribeLocalEvent<JukeboxComponent, JukeboxVolumeDownMessage>(OnJukeboxVolumeDown);
+        SubscribeLocalEvent<JukeboxComponent, JukeboxVolumeUpMessage>(OnJukeboxVolumeUp);
+        // Moffstation - End
 
         SubscribeLocalEvent<JukeboxComponent, PowerChangedEvent>(OnPowerChanged);
     }
@@ -162,6 +166,7 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
             }
 
             ent.Comp.AudioStream = Audio.PlayPvs(jukeboxProto.Path, ent, AudioParams.Default.WithMaxDistance(10f))?.Entity;
+            Audio.SetVolume(ent.Comp.AudioStream, ent.Comp.JukeboxVolume); // Moffstation - Jukebox volume control
             Dirty(ent);
         }
         return true;
@@ -202,4 +207,24 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
 
         Audio.SetPlaybackPosition(entity.Comp.AudioStream, songTime);
     }
+
+    // Moffstation - Start - Jukebox volume control
+    private void OnJukeboxVolumeDown(Entity<JukeboxComponent> entity, ref JukeboxVolumeDownMessage args)
+    {
+        if (entity.Comp.JukeboxVolume > -10)
+        {
+            entity.Comp.JukeboxVolume--;
+            Audio.SetVolume(entity.Comp.AudioStream, entity.Comp.JukeboxVolume);
+        }
+    }
+
+    private void OnJukeboxVolumeUp(Entity<JukeboxComponent> entity, ref JukeboxVolumeUpMessage args)
+    {
+        if (entity.Comp.JukeboxVolume < 0)
+        {
+            entity.Comp.JukeboxVolume++;
+            Audio.SetVolume(entity.Comp.AudioStream, entity.Comp.JukeboxVolume);
+        }
+    }
+    // Moffstation - End
 }

--- a/Content.Server/Audio/Jukebox/JukeboxSystem.cs
+++ b/Content.Server/Audio/Jukebox/JukeboxSystem.cs
@@ -214,7 +214,7 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
         if (entity.Comp.JukeboxVolume > entity.Comp.JukeboxVolumeMin)
         {
             entity.Comp.JukeboxVolume--;
-            Dirty(entity); //
+            Dirty(entity);
             Audio.SetVolume(entity.Comp.AudioStream, entity.Comp.JukeboxVolume);
         }
     }

--- a/Content.Shared/Audio/Jukebox/JukeboxComponent.cs
+++ b/Content.Shared/Audio/Jukebox/JukeboxComponent.cs
@@ -38,8 +38,10 @@ public sealed partial class JukeboxComponent : Component
     [ViewVariables]
     public float SelectAccumulator;
 
+    // Moffstation - Start - Jukebox volume control
     [ViewVariables]
     public int JukeboxVolume = -5;
+    // Moffstation - End
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Audio/Jukebox/JukeboxComponent.cs
+++ b/Content.Shared/Audio/Jukebox/JukeboxComponent.cs
@@ -39,10 +39,10 @@ public sealed partial class JukeboxComponent : Component
     public float SelectAccumulator;
 
     // Moffstation - Start - Jukebox volume control
-    [DataField]
-    public int JukeboxVolumeMax = 0;
+    [ViewVariables]
+    public int JukeboxVolumeMax;
 
-    [DataField]
+    [ViewVariables]
     public int JukeboxVolumeMin = -10;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Audio/Jukebox/JukeboxComponent.cs
+++ b/Content.Shared/Audio/Jukebox/JukeboxComponent.cs
@@ -37,6 +37,9 @@ public sealed partial class JukeboxComponent : Component
 
     [ViewVariables]
     public float SelectAccumulator;
+
+    [ViewVariables]
+    public int JukeboxVolume = -5;
 }
 
 [Serializable, NetSerializable]
@@ -78,3 +81,11 @@ public enum JukeboxVisualLayers : byte
 {
     Base
 }
+
+// Moffstation - Start - Jukebox volume control
+[Serializable, NetSerializable]
+public sealed class JukeboxVolumeDownMessage : BoundUserInterfaceMessage;
+
+[Serializable, NetSerializable]
+public sealed class JukeboxVolumeUpMessage : BoundUserInterfaceMessage;
+// Moffstation - End

--- a/Content.Shared/Audio/Jukebox/JukeboxComponent.cs
+++ b/Content.Shared/Audio/Jukebox/JukeboxComponent.cs
@@ -39,7 +39,13 @@ public sealed partial class JukeboxComponent : Component
     public float SelectAccumulator;
 
     // Moffstation - Start - Jukebox volume control
-    [ViewVariables]
+    [DataField]
+    public int JukeboxVolumeMax = 0;
+
+    [DataField]
+    public int JukeboxVolumeMin = -10;
+
+    [DataField, AutoNetworkedField]
     public int JukeboxVolume = -5;
     // Moffstation - End
 }

--- a/Resources/Locale/en-US/_Moffstation/jukebox/jukebox-menu.ftl
+++ b/Resources/Locale/en-US/_Moffstation/jukebox/jukebox-menu.ftl
@@ -1,0 +1,2 @@
+﻿jukebox-menu-volume-up = ▲
+jukebox-menu-volume-down = ▼


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Adds volume buttons to the jukebox!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's fun.

There are light discussions going on for adding new features to jukebox and jukebox-adjacent entities, and one of the features requested before proceeding was to add IC volume control. Could also be used for some roleplay elements too, where someone may either lower the volume while onlooking others in a dramatic moment, or another may bump up the volume to in a moment of defiance. Giving players the ability to interact with their environment dynamically is just fun.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
C# and Xaml.

Created two buttons and networked them to a new int component, which in turn is referenced by our audio SetVolume method. The jukebox starts off with a default value of '-5', which then can be increased back up to '0' (for max volume), or lowered down to '-10' for our quietest setting.

The reason '0' is our highest value is to prevent audio gain issues; we can always take volume away, but adding volume adds noise and causes problems.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->


https://github.com/user-attachments/assets/49b7f909-0d6c-4664-8a39-200cecd6f0b9

_Volume buttons, in function!_

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- add: Jukebox now have volume controls!