### PR TITLE
Fix two subtle card deck bugs

### DIFF
--- a/Content.Shared/_Moffstation/Cards/Components/PlayingCardDeckComponent.cs
+++ b/Content.Shared/_Moffstation/Cards/Components/PlayingCardDeckComponent.cs
@@ -126,7 +126,17 @@ public sealed partial class PlayingCardInDeckUnspawnedData : PlayingCardInDeck
         ProtoId<PlayingCardSuitPrototype>? suit
     )
     {
-        Card = card;
+        // Copy the card data so that we don't modify the prototype when messing with this individual deck.
+        Card = new PlayingCardDeckPrototypeElementCard
+        {
+            Id = card.Id,
+            NameLoc = card.NameLoc,
+            ObverseLayers = card.ObverseLayers,
+            UseDeckLayers = card.UseDeckLayers,
+            UseSuitLayers = card.UseSuitLayers,
+            FaceDown = card.FaceDown,
+            Count = card.Count,
+        };
         Deck = deck;
         Suit = suit;
     }

--- a/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Card.cs
+++ b/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Card.cs
@@ -253,7 +253,7 @@ public abstract partial class SharedPlayingCardsSystem
 
     /// Like <see cref="Flip"/>, but for a <see cref="PlayingCardInDeck"/>, which may be an unspawned card in a
     /// deck.
-    private bool FlipCardInDeck(PlayingCardInDeck card, bool? faceDown = null) => card switch
+    private bool FlipCardInDeck(PlayingCardInDeck card, bool? faceDown) => card switch
     {
         PlayingCardInDeckNetEnt(var cardNetEnt) =>
             NetEntToCard(cardNetEnt) is { } cardEnt && SetFacingOrFlip(cardEnt, faceDown),

--- a/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Card.cs
+++ b/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Card.cs
@@ -256,7 +256,7 @@ public abstract partial class SharedPlayingCardsSystem
     private bool FlipCardInDeck(PlayingCardInDeck card, bool? faceDown = null) => card switch
     {
         PlayingCardInDeckNetEnt(var cardNetEnt) =>
-            NetEntToCard(cardNetEnt) is { } cardEnt && SetFacingOrFlip(cardEnt, null),
+            NetEntToCard(cardNetEnt) is { } cardEnt && SetFacingOrFlip(cardEnt, faceDown),
         PlayingCardInDeckUnspawnedData(var data, _, _) => SetOrInvert(ref data.FaceDown, faceDown),
         PlayingCardInDeckUnspawnedRef(_, var fd) => SetOrInvert(ref fd, faceDown),
         _ => card.ThrowUnknownInheritor<PlayingCardInDeck, bool>(),

--- a/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Deck.cs
+++ b/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Deck.cs
@@ -218,18 +218,22 @@ public abstract partial class SharedPlayingCardsSystem
         return deck.Cards.SelectMany(deckEl => deckEl switch
         {
             PlayingCardDeckPrototypeElementCard card =>
-                Enumerable.Repeat(new PlayingCardInDeckUnspawnedData(card, deck, suit: null), card.Count),
+                Repeat(card.Count, () => new PlayingCardInDeckUnspawnedData(card, deck, suit: null)),
             PlayingCardDeckPrototypeElementPrototypeReference protoRef =>
-                Enumerable.Repeat(
-                    new PlayingCardInDeckUnspawnedRef(protoRef.Prototype, protoRef.FaceDown),
-                    protoRef.Count
+                Repeat(
+                    protoRef.Count,
+                    () => new PlayingCardInDeckUnspawnedRef(protoRef.Prototype, protoRef.FaceDown)
                 ),
             PlayingCardDeckPrototypeElementSuit s => _proto.Resolve(s.Suit, out var suit)
                 ? suit.Cards.SelectMany(suitEl =>
-                    Enumerable.Repeat(new PlayingCardInDeckUnspawnedData(suitEl, deck, suit), suitEl.Count)
+                    Repeat(suitEl.Count, () => new PlayingCardInDeckUnspawnedData(suitEl, deck, suit))
                 )
                 : [],
             _ => deckEl.ThrowUnknownInheritor<PlayingCardDeckPrototype.Element, IEnumerable<PlayingCardInDeck>>(),
         });
     }
+
+    /// Like <see cref="Repeat"/>, but unlike that function, this invokes <paramref name="func"/> once per repetition
+    /// rather than just yielding the same value multiple times.
+    private static IEnumerable<T> Repeat<T>(int count, Func<T> func) => Enumerable.Repeat(0, count).Select(_ => func());
 }

--- a/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Deck.cs
+++ b/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Deck.cs
@@ -178,7 +178,7 @@ public abstract partial class SharedPlayingCardsSystem
 
         foreach (var card in deck.Comp.Cards)
         {
-            FlipCardInDeck(card);
+            FlipCardInDeck(card, faceDown: null);
         }
 
         VerbAudioAndPopup(PlayingCardDeckComponent.Verbs.FlipEntire, deck, user);

--- a/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Stack.cs
+++ b/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Stack.cs
@@ -134,6 +134,7 @@ public abstract partial class SharedPlayingCardsSystem
 
         if (didAnyFlip)
         {
+            Dirty(entity);
             entity.Comp.DirtyVisuals = true;
         }
 

--- a/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Stack.cs
+++ b/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Stack.cs
@@ -126,7 +126,7 @@ public abstract partial class SharedPlayingCardsSystem
         var didAnyFlip = entity.Comp switch
         {
             PlayingCardDeckComponent deck => deck.Cards.Aggregate(false,
-                (current, card) => current | FlipCardInDeck(card)),
+                (current, card) => current | FlipCardInDeck(card, faceDown)),
             PlayingCardHandComponent hand => hand.Cards.Aggregate(false,
                 (current, card) => current | (NetEntToCard(card) is { } cardEnt && SetFacingOrFlip(cardEnt, faceDown))),
             _ => entity.Comp.ThrowUnknownInheritor<PlayingCardStackComponent, bool>(),

--- a/Resources/Locale/en-US/_Moffstation/cards/cards.ftl
+++ b/Resources/Locale/en-US/_Moffstation/cards/cards.ftl
@@ -21,6 +21,7 @@ playing-card-deck-stack-pickup-verb-text = Draw
 playing-card-deck-draw-verb-text = Draw
 playing-card-deck-cut-verb-text = Split
 playing-card-deck-flip-entire-verb-text = Flip entire deck
+playing-card-deck-flip-entire-popup = Flipped the deck
 
 # Hand
 playing-cards-hand-card-count-changed-added = Card was added (Total of cards: {$quantity})

--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Misc/Cards/card_bases.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Misc/Cards/card_bases.yml
@@ -30,8 +30,8 @@
   components:
   - type: Sprite
     layers:
-    - state: joker # Dummy layer because the actual visuals are composed dynamically.
-      sprite: _Moffstation/Objects/Misc/Cards/card_black.rsi
+    - state: error # Dummy layer because the actual visuals are composed dynamically.
+      sprite: error.rsi
       visible: False
   - type: Item
     size: Normal


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
See @neomoth 's comments on #833 post-merge.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfixes good

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Basically there were three bugs:
- one place where I wasn't passing a flip parameter (oopers)
- putting direct prototype-owned data definitions into cards and then modifying the card data means OH SHIT YOU'RE MODIFYING YOUR COPY OF THE PROTOTYPES :D YAY
  - so now we make copies of the prototype data. I wish that this could be done more cleanly, and I wish `[Access]` could protect against this
- a similar issue to the above, when filling out a deck with cards, if you ever used the "there are two of these", like with jokers in the default playing cards, OOPS THEY'RE THE SAME CARD!
  - so when the deck said "flip all the cards", it flipped the joker on the top of the card... and then immediately flipped it back over when it flipped the second-from-the-top card (because it's the same card in memory)
  - fixed by replacing `Enumerable.Repeat` with something that works like like Kotlin's `List(numRepeats) { your element initializer here }` which actually gets invoked once per repitition instead of yielding the literal same value multiple times.

The second and third could've been avoided by making the data inside of the prototypes structs (because then instead of ever, EVER AT ALL, holding onto references to them, we'd just implicitly get copies) and for fucking once that'd've been useful. BUUUUUT instead, they're classes because trying to get Robust to play nice with structs and implicit polymorphic deserialization and data definitions and everything else made me actually go insane, so here we are.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
maybe somebody can teach me to record gifs someday lmao it's midnight and I'm more than a little punchy.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- fix: Fix a few subtle bugs with cards causing visual issues and various mispredicts.
- fix: Fix missing localization on one card deck verb.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
