### PR TITLE
Modular huds respect correct equip slots

### DIFF
--- a/Content.Client/_Moffstation/Clothing/ModularHud/Systems/ModularHudVisualizerSystem.cs
+++ b/Content.Client/_Moffstation/Clothing/ModularHud/Systems/ModularHudVisualizerSystem.cs
@@ -121,8 +121,6 @@ public sealed class ModularHudVisualizerSystem : VisualizerSystem<ModularHudVisu
         {
             return;
         }
-
-
         // Some species use different states, so make sure we consider those here.
         var speciesId = CompOrNull<InventoryComponent>(args.Equipee)?.SpeciesId;
         var excludedLayers = entity.Comp.EquippedExcludedLayers.GetExcludedLayersOrDefaultForSpecies(speciesId);

--- a/Content.Client/_Moffstation/Clothing/ModularHud/Systems/ModularHudVisualizerSystem.cs
+++ b/Content.Client/_Moffstation/Clothing/ModularHud/Systems/ModularHudVisualizerSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Content.Shared._Moffstation.Clothing.ModularHud.Components;
 using Content.Shared.Clothing;
+using Content.Shared.Clothing.Components;
 using Content.Shared.Foldable;
 using Content.Shared.Hands;
 using Content.Shared.Inventory;
@@ -113,6 +114,15 @@ public sealed class ModularHudVisualizerSystem : VisualizerSystem<ModularHudVisu
     /// Updates clothing sprites.
     private void OnGetClothingVisuals(Entity<ModularHudVisualsComponent> entity, ref GetEquipmentVisualsEvent args)
     {
+        // No layers if the clothing isn't in an "equipped" slot.
+        if (!TryComp<ClothingComponent>(entity, out var clothing) ||
+            clothing.InSlotFlag is not { } slotFlag ||
+            !clothing.Slots.HasFlag(slotFlag))
+        {
+            return;
+        }
+
+
         // Some species use different states, so make sure we consider those here.
         var speciesId = CompOrNull<InventoryComponent>(args.Equipee)?.SpeciesId;
         var excludedLayers = entity.Comp.EquippedExcludedLayers.GetExcludedLayersOrDefaultForSpecies(speciesId);


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
[Bugfix](https://discord.com/channels/1322447119252062260/1488959486172467260/1488959486172467260)

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Apparently the clothing system will ask for clothing layers to be applied even when the clothing isn't in a correct slot, so it was just a dumb bug.
Adds a guard to check if the clothing is truly equipped before applying its layers.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
Uhhhhhg I just closed my test server. Trust.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- fix: Modular HUDs will no longer partially render when in non-eye slots (ie. pockets)

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
