### PR TITLE
Prescription huds work

### DIFF
--- a/Content.Shared/Eye/Blinding/Systems/BlurryVisionSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlurryVisionSystem.cs
@@ -12,7 +12,7 @@ public sealed class BlurryVisionSystem : EntitySystem
 
         SubscribeLocalEvent<VisionCorrectionComponent, GotEquippedEvent>(OnGlassesEquipped);
         SubscribeLocalEvent<VisionCorrectionComponent, GotUnequippedEvent>(OnGlassesUnequipped);
-        Subs.SubscribeWithRelay<VisionCorrectionComponent, GetBlurEvent>(OnGetBlur, held: false); // Moffstation - Modular HUDs need this to be base + relayed
+        Subs.SubscribeWithRelay<VisionCorrectionComponent, GetBlurEvent>(OnGetBlur, held: false); // Moffstation - Modular HUDs need to handle both the basic event and the inventory relayed one
     }
 
     // Moffstation - Begin - Modular HUDs need this to be base + relayed

--- a/Content.Shared/Eye/Blinding/Systems/BlurryVisionSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlurryVisionSystem.cs
@@ -12,14 +12,16 @@ public sealed class BlurryVisionSystem : EntitySystem
 
         SubscribeLocalEvent<VisionCorrectionComponent, GotEquippedEvent>(OnGlassesEquipped);
         SubscribeLocalEvent<VisionCorrectionComponent, GotUnequippedEvent>(OnGlassesUnequipped);
-        SubscribeLocalEvent<VisionCorrectionComponent, InventoryRelayedEvent<GetBlurEvent>>(OnGetBlur);
+        Subs.SubscribeWithRelay<VisionCorrectionComponent, GetBlurEvent>(OnGetBlur, held: false); // Moffstation - Modular HUDs need this to be base + relayed
     }
 
-    private void OnGetBlur(Entity<VisionCorrectionComponent> glasses, ref InventoryRelayedEvent<GetBlurEvent> args)
+    // Moffstation - Begin - Modular HUDs need this to be base + relayed
+    private void OnGetBlur(Entity<VisionCorrectionComponent> glasses, ref GetBlurEvent args)
     {
-        args.Args.Blur += glasses.Comp.VisionBonus;
-        args.Args.CorrectionPower *= glasses.Comp.CorrectionPower;
+        args.Blur += glasses.Comp.VisionBonus;
+        args.CorrectionPower *= glasses.Comp.CorrectionPower;
     }
+    // Moffstation - End
 
     public void UpdateBlurMagnitude(Entity<BlindableComponent?> ent)
     {

--- a/Content.Shared/_Moffstation/Clothing/ModularHud/Components/ModularHudComponent.cs
+++ b/Content.Shared/_Moffstation/Clothing/ModularHud/Components/ModularHudComponent.cs
@@ -61,6 +61,7 @@ public sealed partial class ModularHudComponent : Component
     [DataField] public LocId MissingToolQualityErrorText = "modularhud-verb-remove-modules-error-missing-tool-quality";
     [DataField] public LocId NoModulesToRemovePopupText = "modularhud-verb-remove-modules-error-no-modules-to-remove";
 
+    [DataField] public LocId CapacityExamineText = "modularhud-examine-capacity";
     [DataField] public LocId NoModulesExamineText = "modularhud-examine-no-modules";
     [DataField] public LocId HeaderExamineText = "modularhud-examine-modules-header";
     [DataField] public LocId ModuleItemExamineText = "modularhud-examine-module-item";

--- a/Content.Shared/_Moffstation/Clothing/ModularHud/Systems/SharedModularHudSystem.cs
+++ b/Content.Shared/_Moffstation/Clothing/ModularHud/Systems/SharedModularHudSystem.cs
@@ -329,14 +329,18 @@ public abstract partial class SharedModularHudSystem : EntitySystem
             if (!modules.MoveNext())
             {
                 args.PushMarkup(Loc.GetString(entity.Comp.NoModulesExamineText));
-                return;
+            }
+            else
+            {
+                args.PushMarkup(Loc.GetString(entity.Comp.HeaderExamineText));
+                do
+                {
+                    args.PushMarkup(Loc.GetString(entity.Comp.ModuleItemExamineText, ("module", modules.Current)));
+                } while (modules.MoveNext());
             }
 
-            args.PushMarkup(Loc.GetString(entity.Comp.HeaderExamineText));
-            do
-            {
-                args.PushMarkup(Loc.GetString(entity.Comp.ModuleItemExamineText, ("module", modules.Current)));
-            } while (modules.MoveNext());
+            args.PushMarkup(Loc.GetString(entity.Comp.CapacityExamineText,
+                ("capacity", entity.Comp.MaximumContainedModules)));
         }
     }
 
@@ -389,7 +393,7 @@ public abstract partial class SharedModularHudSystem : EntitySystem
     /// the disparate HUD effects to be updated when the modular HUD is un/equipped.
     private void RefreshVisualsAndEffects(Entity<ModularHudComponent> entity, EntityUid? equippee)
     {
-        if (equippee is {} e)
+        if (equippee is { } e)
         {
             _blurryVision.UpdateBlurMagnitude(e);
             var flashEv = new FlashImmunityChangedEvent(_flash.IsFlashImmune(e));

--- a/Content.Shared/_Moffstation/Clothing/ModularHud/Systems/SharedModularHudSystem.cs
+++ b/Content.Shared/_Moffstation/Clothing/ModularHud/Systems/SharedModularHudSystem.cs
@@ -360,30 +360,41 @@ public abstract partial class SharedModularHudSystem : EntitySystem
     ) where TArgs : ContainerModifiedMessage
     {
         if (args.Container.ID != entity.Comp.ModuleContainerId ||
-            !TryComp<ModularHudModuleComponent>(args.Entity, out var moduleComp))
+            !HasComp<ModularHudModuleComponent>(args.Entity))
             return;
 
-        RefreshEffectsForModules([(args.Entity, moduleComp)]);
-        SyncVisuals(entity);
+        var parentUid = Transform(entity).ParentUid;
+        if (HasComp<InventoryComponent>(parentUid) &&
+            _inventory.InSlotWithAnyFlags(entity.Owner, entity.Comp.ActiveSlots))
+        {
+            RefreshVisualsAndEffects(entity, parentUid);
+        }
+        else
+        {
+            RefreshVisualsAndEffects(entity, null);
+        }
     }
 
     private void OnGotEquipped(Entity<ModularHudComponent> entity, ref GotEquippedEvent args)
     {
-        RefreshEffectsForWearerForContainedModules(entity, args.Equipee);
+        RefreshVisualsAndEffects(entity, args.Equipee);
     }
 
     private void OnGotUneqipped(Entity<ModularHudComponent> entity, ref GotUnequippedEvent args)
     {
-        RefreshEffectsForWearerForContainedModules(entity, args.Equipee);
+        RefreshVisualsAndEffects(entity, args.Equipee);
     }
 
     /// This function contains a functional grab-bag of whatever function calls / event raisings need to happen to cause
     /// the disparate HUD effects to be updated when the modular HUD is un/equipped.
-    private void RefreshEffectsForWearerForContainedModules(Entity<ModularHudComponent> entity, EntityUid equippee)
+    private void RefreshVisualsAndEffects(Entity<ModularHudComponent> entity, EntityUid? equippee)
     {
-        _blurryVision.UpdateBlurMagnitude(equippee);
-        var flashEv = new FlashImmunityChangedEvent(_flash.IsFlashImmune(equippee));
-        RaiseLocalEvent(equippee, ref flashEv);
+        if (equippee is {} e)
+        {
+            _blurryVision.UpdateBlurMagnitude(e);
+            var flashEv = new FlashImmunityChangedEvent(_flash.IsFlashImmune(e));
+            RaiseLocalEvent(e, ref flashEv);
+        }
 
         RefreshEffectsForModules(GetModules(entity));
         SyncVisuals(entity);

--- a/Resources/Locale/en-US/_Moffstation/overlay/modular-hud.ftl
+++ b/Resources/Locale/en-US/_Moffstation/overlay/modular-hud.ftl
@@ -1,15 +1,19 @@
 # Verbs
 modularhud-verb-insert-module = Insert module
-modularhud-verb-insert-module-message = Inserts the { $module } into the { $hud }.
-modularhud-verb-insert-module-error-fails-requirements = This { $module } is incompatible with the { $hud }.
-modularhud-verb-insert-module-error-slots-full = the { $hud } is full.
+modularhud-verb-insert-module-message = Inserts { THE($module) } into { THE($hud) }.
+modularhud-verb-insert-module-error-fails-requirements = This { $module } {CONJUGATE-BE(module)} incompatible with { THE($hud) }.
+modularhud-verb-insert-module-error-slots-full = { CAPITALIZE(THE($hud)) } {CONJUGATE-BE(hud)} full.
 modularhud-verb-remove-modules = Remove modules
-modularhud-verb-remove-modules-message = Removes the modules from the { $hud }.
+modularhud-verb-remove-modules-message = Removes the modules from { THE($hud) }.
 modularhud-verb-remove-modules-error-missing-tool-quality = You need something capable of {$quality} to do that.
-modularhud-verb-remove-modules-error-no-modules-to-remove = The { $hud } is already empty.
+modularhud-verb-remove-modules-error-no-modules-to-remove = { CAPITALIZE(THE($hud)) } {CONJUGATE-BE(hud)} already empty.
 
 # Examine
-modularhud-examine-no-modules = It contains no modules
+modularhud-examine-capacity = It has room for { $capacity ->
+  [1] [bold]one[/bold] module
+  *[other] [bold]{ $capacity }[/bold] modules
+} in total.
+modularhud-examine-no-modules = It contains no modules.
 modularhud-examine-modules-header = It contains:
 modularhud-examine-module-item = - [bold]{$module}[/bold]
 


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
title + bugfix for immediately updating on module insertion

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfix

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Was missing a handler to make it so that the VisionCorrectionComponent handles the "yo can you unblur vision" event without being relayed by the inventory (which modular HUDs don't).
Fix was just changing the subscription, basically.

Insertion bugfix was making it so the entire "refresh effects" was called when a module was inserted.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- fix: The Prescription HUD Module actually corrects blurry vision now.
- fix: Modular HUDs should immediately update effects on insertion/removal of modules for all modules now.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
