### PR TITLE
Stop foolbox fill test fails

### DIFF
--- a/Content.Shared/Containers/ContainerFillSystem.cs
+++ b/Content.Shared/Containers/ContainerFillSystem.cs
@@ -74,6 +74,14 @@ public sealed class ContainerFillSystem : EntitySystem
                 var spawn = Spawn(proto, coords);
                 if (!_containerSystem.Insert(spawn, container, containerXform: xform))
                 {
+                    // Moffstation - Begin - Allow container fills to just fail to insert stuff, deleting the entity they attempted to add.
+                    if (ent.Comp.SkipFillsWhichDontFit)
+                    {
+                        QueueDel(spawn);
+                        continue;
+                    }
+                    // Moffstation - End
+
                     var alreadyContained = container.ContainedEntities.Count > 0 ? string.Join("\n", container.ContainedEntities.Select(e => $"\t - {ToPrettyString(e)}")) : "< empty >";
                     Log.Error($"Entity {ToPrettyString(ent)} with a {nameof(EntityTableContainerFillComponent)} failed to insert an entity: {ToPrettyString(spawn)}.\nCurrent contents:\n{alreadyContained}");
                     _transform.AttachToGridOrMap(spawn);

--- a/Content.Shared/Containers/EntityTableContainerFillComponent.cs
+++ b/Content.Shared/Containers/EntityTableContainerFillComponent.cs
@@ -13,6 +13,8 @@ public sealed partial class EntityTableContainerFillComponent : Component
 
     // Moffstation - Begin - Allow EntityTableContainerFillComponent to fail gracefully
     /// If false, trying to overfill a container fill will emit an error.
+    /// Ideally this'd be a flag per container in <see cref="Containers"/>, but that is a much larger blast radius that
+    /// I don't want to deal with when making a kinda hackfix to upstream code.
     [DataField]
     public bool SkipFillsWhichDontFit = false;
     // Moffstation - End

--- a/Content.Shared/Containers/EntityTableContainerFillComponent.cs
+++ b/Content.Shared/Containers/EntityTableContainerFillComponent.cs
@@ -10,4 +10,10 @@ public sealed partial class EntityTableContainerFillComponent : Component
 {
     [DataField]
     public Dictionary<string, EntityTableSelector> Containers = new();
+
+    // Moffstation - Begin - Allow EntityTableContainerFillComponent to fail gracefully
+    /// If false, trying to overfill a container fill will emit an error.
+    [DataField]
+    public bool SkipFillsWhichDontFit = false;
+    // Moffstation - End
 }

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -164,6 +164,7 @@
   suffix: Filled
   components:
   - type: EntityTableContainerFill
+    skipFillsWhichDontFit: true # Moffstation - If the table rolls too much or too big of things, just delete those rolls. I am so tired of the foolbox failing tests because we have so much garbage in it.
     containers:
       storagebase: !type:NestedSelector
         tableId: FoolboxTable


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title. Adds a flag to `EntityTableContainerFillComponent` which tells the system to not freak out if something in the fill doesn't fit in the container.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The foolbox has a big table of options for things which can go into it and on Moff, we have a bunch of things in there that are kinda big, so it's not uncommon to see "ZOMG THE FOOLBOX COULDN'T FIT THIS" in test failures.
You could say "well just modify the tables so that failures just can't happen", to which I respond "no that sounds like a lot of work and the tables are shared and AHHHHH".

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Flag is off by default for everything, this should only affect the foolbox.
If the foolbox rolls contents which don't fit, it fills as much as it can and deletes anything that doesn't fit.
This is a slight change from before where if you rolled stuff that didn't fit on `Release`, it'd drop it somewhere (reading the code I really am not sure _where_ it'd show up so 🤷 )

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
smol

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
n/a, code only, really


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
