### PR TITLE
picking up cards from hands while your hands are full doesn't crash

### DIFF
--- a/Content.Shared/_Moffstation/Cards/Components/PlayingCardHandComponent.cs
+++ b/Content.Shared/_Moffstation/Cards/Components/PlayingCardHandComponent.cs
@@ -42,6 +42,7 @@ public sealed partial class PlayingCardHandComponent : PlayingCardStackComponent
     public static readonly LocId CardsAddedText = "playing-cards-hand-card-count-changed-added";
     public static readonly LocId CardsRemovedText = "playing-cards-hand-card-count-changed-removed";
     public static readonly LocId CardsChangedText = "playing-cards-hand-card-count-changed-unknown";
+    public static readonly LocId CantPickupNoFreeHands = "playing-cards-hand-cant-pickup-no-free-hands";
 
     public new static class Verbs
     {

--- a/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Deck.cs
+++ b/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Deck.cs
@@ -201,8 +201,9 @@ public abstract partial class SharedPlayingCardsSystem
             () =>
             {
                 VerbAudioAndPopup(PlayingCardDeckComponent.Verbs.CutDeck, entity, user);
-                var newDeckContents = Take(entity, ^(entity.Comp.NumCards / 2).., Transform(entity).Coordinates, user);
-                return CreateDeckPredicted(newDeckContents, user, entity.Comp.Prototype);
+                var degenerateDeck = CreateDeckPredicted([], user, entity.Comp.Prototype);
+                Transfer(entity, degenerateDeck, ^(entity.Comp.NumCards / 2).., user);
+                return degenerateDeck;
             }
         );
     }

--- a/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Hand.cs
+++ b/Content.Shared/_Moffstation/Cards/Systems/SharedPlayingCardsSystem.Hand.cs
@@ -103,13 +103,20 @@ public abstract partial class SharedPlayingCardsSystem
     /// Takes and tries to pick up the card specified by <paramref name="args"/>.
     private void OnPlayingCardPicked(Entity<HandsComponent> entity, ref PlayingCardPickedEvent args)
     {
-        if (args.Handled)
+        if (args.Handled || !_gameTiming.IsFirstTimePredicted)
             return;
 
-        // Dumb special case for when somebody hits "E" on the hand in their active hand.
+        if (!_hands.CanPickupAnyHand(entity, args.SourceHand))
+        {
+            _popup.PopupPredictedCursor(Loc.GetString(PlayingCardHandComponent.CantPickupNoFreeHands), entity);
+            return;
+        }
+
+        bool pickedUp;
         if (_hands.TryGetActiveItem(entity.AsNullable(), out var activeItem) && activeItem == args.SourceHand)
         {
-            _hands.TryPickupAnyHand(
+            // Dumb special case for when somebody hits "E" on the hand in their active hand.
+            pickedUp = _hands.TryPickupAnyHand(
                 entity,
                 TakePickedCard(args, Transform(entity).Coordinates),
                 animate: false,
@@ -118,17 +125,18 @@ public abstract partial class SharedPlayingCardsSystem
         }
         else
         {
-            var pickedUp = _hands.TryPickup(
+            pickedUp = _hands.TryPickupAnyHand(
                 entity,
                 TakePickedCard(args, Transform(entity).Coordinates),
-                handId: null,
                 animate: false,
                 handsComp: entity
             );
-            if (!pickedUp)
-            {
-                this.AssertOrLogError("Failed to pick up picked card");
-            }
+        }
+
+        if (!pickedUp)
+        {
+            this.AssertOrLogError("Failed to pick up picked card");
+            return;
         }
 
         args.Handled = true;

--- a/Resources/Locale/en-US/_Moffstation/cards/cards.ftl
+++ b/Resources/Locale/en-US/_Moffstation/cards/cards.ftl
@@ -27,6 +27,7 @@ playing-card-deck-flip-entire-popup = Flipped the deck
 playing-cards-hand-card-count-changed-added = Card was added (Total of cards: {$quantity})
 playing-cards-hand-card-count-changed-removed = Card was removed (Total of cards: {$quantity})
 playing-cards-hand-card-count-changed-unknown = Unknown
+playing-cards-hand-cant-pickup-no-free-hands = Your hands are full!
 
 playing-card-hand-card-pickup-verb-text = Pick card into hand
 playing-card-hand-stack-pickup-verb-text = Pick card

--- a/Resources/Locale/en-US/_Moffstation/cards/cards.ftl
+++ b/Resources/Locale/en-US/_Moffstation/cards/cards.ftl
@@ -20,8 +20,11 @@ playing-card-deck-card-pickup-verb-text = Draw into hand
 playing-card-deck-stack-pickup-verb-text = Draw
 playing-card-deck-draw-verb-text = Draw
 playing-card-deck-cut-verb-text = Split
+playing-card-deck-cut-popup = You split the {$target}.
+playing-card-deck-cut-popup-other = {$user} split the {$target}.
 playing-card-deck-flip-entire-verb-text = Flip entire deck
-playing-card-deck-flip-entire-popup = Flipped the deck
+playing-card-deck-flip-entire-popup = You flipped the {$target}.
+playing-card-deck-flip-entire-popup-other = {$user} flipped the {$target}.
 
 # Hand
 playing-cards-hand-card-count-changed-added = Card was added (Total of cards: {$quantity})


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
title. @Huaqas found it

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfix

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Basically, I had a debug assert in a spot that was accessible from normal gameplay because I missed an edge case.
Before this, if you were holding your roobbeer and used `E` to pick a card out of a hand on the ground -- crash.
NO LONGER, SET MY ROOBBEER HAND FREE

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
Too smoll to warrant

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
