### PR TITLE
unilaterally kill the review labeller because it just can't work

### DIFF
--- a/.github/workflows/labeler-review.yml
+++ b/.github/workflows/labeler-review.yml
@@ -1,62 +1,23 @@
-name: "Labels: Review" # Moffstation - Update workflow name to reflect additional responsibility
+name: "Labels: Approved"
 on:
   pull_request_review:
     types: [submitted]
 jobs:
   add_label:
     # Change the repository name after you've made sure the team name is correct for your fork!
-    if: ${{ (github.repository == 'moff-station/moff-station-14') && ((github.event.review.state == 'APPROVED') || (github.event.review.state == 'CHANGES_REQUESTED')) }} # Moffstation - Change org and repo names + handle both APPROVED and CHANGES_REQUESTED
+    if: ${{ (github.repository == 'space-wizards/space-station-14') && (github.event.review.state == 'APPROVED') }}
     permissions:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    # Moffstation - Begin - We don't use teams, so don't check teams.
-#    - uses: tspascoal/get-user-teams-membership@v3
-#      id: checkUserMember
-#      with:
-#        username: ${{ github.actor }}
-#        team: "content-maintainers,junior-maintainers"
-#        GITHUB_TOKEN: ${{ secrets.LABELER_PAT }}
-    # Instead, check for org membership.
-    - id: checkMember
-      uses: actions/github-script@v7
+    - uses: tspascoal/get-user-teams-membership@v3
+      id: checkUserMember
       with:
-        script: |
-          const org = context.repo.owner;
-          const username = context.payload.review.user.login;
-
-          try {
-            const { status } = await github.rest.orgs.checkMembershipForUser({
-              org: org,
-              username: username,
-            });
-            // status will be 204 if they are a member
-            return status === 204;
-          } catch (error) {
-            // If user is not a member, GitHub returns 404
-            return false;
-          }
-    # Moffstation - End
-    - if: ${{ github.event.review.state == 'APPROVED' && steps.checkMember.outputs.result == 'true' }} # Moffstation - Handle just approved
+        username: ${{ github.actor }}
+        team: "content-maintainers,junior-maintainers"
+        GITHUB_TOKEN: ${{ secrets.LABELER_PAT }}
+    - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
       uses: actions-ecosystem/action-add-labels@v1
       with:
         labels: "S: Approved"
-    - if: ${{ github.event.review.state == 'APPROVED' && steps.checkMember.outputs.result == 'true' }}
-      uses: actions-ecosystem/action-remove-labels@v1
-      with:
-        labels: "S: Awaiting Changes"
-    # Moffstation - Begin - Handle both APPROVED and CHANGES_REQUESTED
-    - if: ${{ github.event.review.state == 'CHANGES_REQUESTED' && steps.checkMember.outputs.result == 'true' }}
-      uses: actions-ecosystem/action-add-labels@v1
-      with:
-        labels: "S: Awaiting Changes"
-    - if: ${{ github.event.review.state == 'CHANGES_REQUESTED' && steps.checkMember.outputs.result == 'true' }}
-      uses: actions-ecosystem/action-remove-labels@v1
-      with:
-        labels: "S: Approved"
-    - if: ${{ steps.checkMember.outputs.result == 'true' }}
-      uses: actions-ecosystem/action-remove-labels@v1
-      with:
-        labels: "S: Needs Review"
-    # Moffstation - End


### PR DESCRIPTION
Title.
The triggering action from Github doesn't provide access to repo secrets, so we can never get the tokens needed to interact with labels and all that.
So, this just reverts to upstream's version of the file, "turning off" the workflow.