### PR TITLE
Set examine appears last in the actions bar

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -383,6 +383,7 @@
     itemIconStyle: NoItem
     useDelay: 1 # emote spam
     checkCanInteract: false
+    priority: 1000 # Moffstation - RP actions go last in the bar
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/_Umbra/Actions/roleplay.yml
+++ b/Resources/Prototypes/_Umbra/Actions/roleplay.yml
@@ -12,5 +12,6 @@
       sprite: _Umbra/Interface/Actions/set-pose.rsi
       state: eyeopen
     itemIconStyle: NoItem
+    priority: 100000 # Will be added first, making it show up last
   - type: InstantAction
     event: !type:SetExamineActionEvent

--- a/Resources/Prototypes/_Umbra/Actions/roleplay.yml
+++ b/Resources/Prototypes/_Umbra/Actions/roleplay.yml
@@ -12,6 +12,6 @@
       sprite: _Umbra/Interface/Actions/set-pose.rsi
       state: eyeopen
     itemIconStyle: NoItem
-    priority: 100000 # Will be added first, making it show up last
+    priority: 10000 # Will be added first, making it show up last
   - type: InstantAction
     event: !type:SetExamineActionEvent


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
See Title
Not giving it a priority made it get mixed with harm mode, screaming, and the PDA, which most people have muscle memory of.

Does the same thing for tail wagging

2 will always be scream
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
QoL
## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="349" height="90" alt="image" src="https://github.com/user-attachments/assets/aeb3544a-d6f3-4cfe-ae21-3749823f6459" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- tweak: The set examine button now appears past the default action bar buttons
- tweak: The tail wagging button now appears past the default action bar buttons

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
