### PR TITLE
[Tweak] Further antag objective maintenance

### DIFF
--- a/Resources/Locale/en-US/_Moffstation/objectives/conditions/open-objective.ftl
+++ b/Resources/Locale/en-US/_Moffstation/objectives/conditions/open-objective.ftl
@@ -13,7 +13,6 @@ objective-condition-incriminate = Incriminate {$targetName}, {CAPITALIZE($job)}
 objective-condition-steal-everything = Steal everything of value
 objective-condition-steal-money = Steal money
 objective-condition-rob-department = Steal from the {$targetName} department
-objective-condition-loud-rob-department = Rob the {$targetName} department
 objective-condition-leave-card = Leave a calling card
 objective-condition-leave-card-on-person = Leave a calling card on {$targetName}, {CAPITALIZE($job)}
 objective-condition-coexist = Coexist with your original self.

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -9,7 +9,6 @@
     TraitorObjectiveGroupSocial: 0.5 #Involves helping/harming others without killing them or stealing their stuff
     TraitorObjectiveGroupSabotage: 0.5
     TraitorObjectiveGroupOther: 0.5
-    TraitorObjectiveOpenEnded: 0.5
     # Moffstation - End
 
 - type: weightedRandom
@@ -60,12 +59,20 @@
   id: TraitorObjectiveGroupSabotage
   weights:
     SupercritAnomaliesObjective: 1
+    # Moffstation - Sabotage objectives
+    DisruptDepartmentObjective: 1
+    SabotageObjective: 0.5
+    # Moffstation - End
 
 #misc objectives that don't fall other another category
 - type: weightedRandom
   id: TraitorObjectiveGroupOther
   weights:
     HijackTradeStationObjective: 1
+    # Moffstation - Location based objectives
+    TrashRoomObjective: 1
+    ClaimLocationObjective: 1
+    # Moffstation - End
 
 
 #Thief groups

--- a/Resources/Prototypes/_Harmony/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Harmony/Objectives/objectiveGroups.yml
@@ -5,7 +5,9 @@
     BloodBrotherObjectiveGroupState: 0.25
     BloodBrotherObjectiveGroupSteal: 0.1
     BloodBrotherObjectiveGroupKill: 1
-    BloodBrotherObjectiveGroupOpenEnded: 0.5
+    BloodBrotherObjectiveGroupSocial: 0.5
+    BloodBrotherObjectiveGroupSabotage: 0.5
+    BloodBrotherObjectiveGroupOther: 0.5
     # Moffstation - End
 
 - type: weightedRandom
@@ -14,7 +16,7 @@
     # Blood brothers are expected to be usually trying to be stealthy, so low DAGD chance.
     # Moffstation - Start - Objective picker adjustments
     BloodBrotherEscapeShuttleObjective: 0.90
-    BloodBrotherDieObjective: 0.02
+    BloodBrotherDieObjective: 0.01
     #BloodBrotherSurviveObjective: 0.65
     # Moffstation - End
 
@@ -34,6 +36,10 @@
     BloodBrotherCaptainJetpackStealObjective: 0.5
     BloodBrotherHandTeleporterStealObjective: 0.5
     BloodBrotherEnergyMagnumStealObjective: 0.5
+    # Moffstation - Start - Steal objectives
+    BloodBrotherStealEverythingObjective: 0.2
+    BloodBrotherStealMoneyObjective: 1
+    # Moffstation - End
 
 - type: weightedRandom
   id: BloodBrotherObjectiveGroupKill
@@ -43,6 +49,7 @@
     # Moffstation - Start - Replace Harmony's Teach a lesson with our own
     #BloodBrotherTeachLessonRandomPersonObjective: 1
     BloodBrotherTeachLessonObjective: 1
+    BloodBrotherKillStationAiObjective: 0.25
     # Moffstation - End
 
 - type: weightedRandom

--- a/Resources/Prototypes/_Moffstation/Objectives/bloodbrother.yml
+++ b/Resources/Prototypes/_Moffstation/Objectives/bloodbrother.yml
@@ -24,13 +24,6 @@
   id: BloodBrotherRobDepartmentObjective
 
 - type: entity
-  parent: [BaseBloodBrotherObjective, RobDepartmentObjective]
-  id: BloodBrotherLoudRobDepartmentObjective
-  components:
-  - type: LocationObjective
-    title: objective-condition-loud-rob-department
-
-- type: entity
   parent: [BaseBloodBrotherObjective, SabotageObjective]
   id: BloodBrotherSabotageObjective
 
@@ -56,3 +49,11 @@
       sprite: Objects/Misc/bureaucracy.rsi
       state: paper_receipt_horizontal
     unique: true # only one person needs to really send a message.
+
+- type: entity
+  parent: [BaseBloodBrotherObjective, KillStationAiObjective]
+  id: BloodBrotherKillStationAiObjective
+
+- type: entity
+  parent: [BaseBloodBrotherObjective, SupercritAnomaliesObjective]
+  id: BloodBrotherSupercritAnomaliesObjective

--- a/Resources/Prototypes/_Moffstation/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Moffstation/Objectives/objectiveGroups.yml
@@ -1,12 +1,3 @@
-# Traitor open-ended objectives
-- type: weightedRandom
-  id: TraitorObjectiveOpenEnded
-  weights:
-    DisruptDepartmentObjective: 1
-    SabotageObjective: 0.5
-    TrashRoomObjective: 1
-    ClaimLocationObjective: 1
-
 # Thief open-ended objectives
 - type: weightedRandom
   id: ThiefObjectiveOpenEnded
@@ -18,15 +9,20 @@
 
 # Blood brother Moffstation objectives
 - type: weightedRandom
-  id: BloodBrotherObjectiveGroupOpenEnded
+  id: BloodBrotherObjectiveGroupSocial
   weights:
-    BloodBrotherDisruptDepartmentObjective: 1
     BloodBrotherJailbreakObjective: 0.5
+    BloodBrotherLeaveCallingCardObjective: 0.2
+
+- type: weightedRandom
+  id: BloodBrotherObjectiveGroupSabotage
+  weights:
+    BloodBrotherSupercritAnomaliesObjective: 1
+    BloodBrotherDisruptDepartmentObjective: 1
+    BloodBrotherSabotageObjective: 0.5
+
+- type: weightedRandom
+  id: BloodBrotherObjectiveGroupOther
+  weights:
     BloodBrotherTrashRoomObjective: 1
     BloodBrotherClaimLocationObjective: 1
-    BloodBrotherLeaveCallingCardObjective: 0.2
-    BloodBrotherRobDepartmentObjective: 1
-    BloodBrotherLoudRobDepartmentObjective: 1
-    BloodBrotherSabotageObjective: 0.5
-    BloodBrotherStealEverythingObjective: 0.2
-    BloodBrotherStealMoneyObjective: 1


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Added new 'Sabotage anomalies' and 'Destroy AI' to blood brother pool, and reordered our objective groups to better categorize our open-ended objectives based on action.

Additionally, removed the 'rob x department' duplicate objective from blood brothers, as it functionally acted the same as 'steal from x department' without much distinction. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Maintenance.

Blood brothers thematically sit in a spot between traitors and thieves, pulling from both pools for their objectives. This means that any time either pool gets new additions, we need to review and see if we can apply these changes to blood brothers as well.

While I would like to add the ATS hijack objective to blood brother as well - unfortunately this objective requires equipment unavailable to them.

As for our internal category changes, this should help us better tune our objectives; while these objective groups currently mirror traitors in terms of frequency, these groups will be reviewed soon for further adjustments - and this step is a preempt for said discussions.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
yml and ftl changes - nothing remarkable.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
N/A - adds new objectives and categorizes existing ones. 

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- add: Blood brothers may now be tasked with sabotaging anomalies or destroying the station AI.