### PR TITLE
Adjust ATS hijack to be more fair

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -526,4 +526,5 @@ uplink-energycrossbow-desc = The go-to sidearm of any operative who prefers thei
 
 #Objective items
 uplink-hijack-beacon-name = Hijack Beacon
-uplink-hijack-beacon-desc = A syndicate-brand hijack beacon designed to get around the firewalls of Nanotrasen-brand Automated Trade Stations. They take 200 seconds to work and Trade Stations will announce they are being hacked, so prepare accordingly.
+# Moffstation - Changed timer to say 300
+uplink-hijack-beacon-desc = A syndicate-brand hijack beacon designed to get around the firewalls of Nanotrasen-brand Automated Trade Stations. They take 300 seconds to work and Trade Stations will announce they are being hacked, so prepare accordingly.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -526,5 +526,4 @@ uplink-energycrossbow-desc = The go-to sidearm of any operative who prefers thei
 
 #Objective items
 uplink-hijack-beacon-name = Hijack Beacon
-# Moffstation - Changed timer to say 300
-uplink-hijack-beacon-desc = A syndicate-brand hijack beacon designed to get around the firewalls of Nanotrasen-brand Automated Trade Stations. They take 300 seconds to work and Trade Stations will announce they are being hacked, so prepare accordingly.
+uplink-hijack-beacon-desc = A syndicate-brand hijack beacon designed to get around the firewalls of Nanotrasen-brand Automated Trade Stations. They take 300 seconds to work and Trade Stations will announce they are being hacked, so prepare accordingly. # Moffstation - Changed timer to say 300

--- a/Resources/Prototypes/Entities/Objects/Tools/hijack_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hijack_beacon.yml
@@ -13,6 +13,7 @@
   - type: Item
     size: Normal
   - type: HijackBeacon
+    remainingTime: 300 # Moffstation - Timer line added to increase the time from the hardcoded
   - type: Fixtures
     fixtures:
       fix1:
@@ -32,3 +33,4 @@
     noRot: true
     layers:
     - state: extraction_point
+

--- a/Resources/Prototypes/Entities/Objects/Tools/hijack_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hijack_beacon.yml
@@ -33,4 +33,3 @@
     noRot: true
     layers:
     - state: extraction_point
-

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -413,3 +413,5 @@
   - type: ObjectiveLimit
     # There is only one trade station so there should never be more than one of these objectives.
     limit: 1
+  - type: NotJobRequirement
+    jobs: [ Quartermaster, CargoTechnician, SalvageSpecialist ] # Moffstation - It's too easy for cargo people


### PR DESCRIPTION
## About the PR
Increases ATS hijack time from 3:20 to 5 minutes to give security more time to respond. This also blacklist cargo members from from getting the hijack the ATS objective.

## Why / Balance
It's generally agreed on that the current 200 seconds isn't long enough for any meaningful response to the ATS hijacking announcement. It's also way too easy to cheese the objective as cargo so this is being removed from the cargo objectives pool.

## Technical details
N/A

## Media
N/A

## Requirements
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: The hijack the ATS now takes longer to complete
- tweak: Cargo members can no longer roll hijack ATS