### PR TITLE
Catwalk Durability Adjustement

### DIFF
--- a/Resources/Prototypes/Entities/Structures/catwalk.yml
+++ b/Resources/Prototypes/Entities/Structures/catwalk.yml
@@ -40,13 +40,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100 #Moffstation - Catwalk change
+        damage: 100 #Moffstation - Catwalk adjustement
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 25 #Moffstation - Catwalk change
+        damage: 25 #Moffstation - Catwalk adjustement
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:

--- a/Resources/Prototypes/Entities/Structures/catwalk.yml
+++ b/Resources/Prototypes/Entities/Structures/catwalk.yml
@@ -40,13 +40,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 500
+        damage: 100
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 200
+        damage: 25
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:

--- a/Resources/Prototypes/Entities/Structures/catwalk.yml
+++ b/Resources/Prototypes/Entities/Structures/catwalk.yml
@@ -40,13 +40,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 100 #Moffstation - Catwalk change
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 25
+        damage: 25 #Moffstation - Catwalk change
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->
<img width="356" height="272" alt="CatwalkBreak" src="https://github.com/user-attachments/assets/9cb5896c-6a62-4abd-9bd6-11079ac3936f" />


## About the PR
<!-- What did you change? -->
Catwalks were incredibly durable, boasting twice the durability of a machine frame.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Catwalks were unreasonably durable for the usage of two metal rods, if you as an antagonist of any sort wanted to break them to for example destroy the wiring underneath or grab a redspace drop but you didn't have a wirecutter then you'd spend a ridiculous amount of time trying to break it as it took
41 hits with a toolbox, (Now 6)
14 with a baseball,  (Now 2)
10 with a pickaxe,  (Now 2)
8 with an e-sword and  (Now 1)
12 with the diamond drill.  (Now 2)


## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- tweak: Catwalks are no longer incredibly durable.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

