### PR TITLE
Chemistry Gas Mask solution scanning respects the toggle

### DIFF
--- a/Content.Shared/Chemistry/Components/SolutionScannerComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionScannerComponent.cs
@@ -6,6 +6,11 @@ namespace Content.Shared.Chemistry.Components;
 /// Allows an entity to examine reagents inside of containers, puddles and similiar via the examine verb.
 /// Works when added either directly to an entity or to piece of clothing worn by that entity.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
-public sealed partial class SolutionScannerComponent : Component;
-
+// Moffstation - Begin - Solution scanners can be toggled
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class SolutionScannerComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool Enabled = true;
+}
+// Moffstation - End

--- a/Content.Shared/Chemistry/SolutionScannerSystem.cs
+++ b/Content.Shared/Chemistry/SolutionScannerSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Chemistry.Components;
+using Content.Shared.Clothing;
 using Content.Shared.Inventory;
 
 namespace Content.Shared.Chemistry;
@@ -9,12 +10,22 @@ public sealed class SolutionScannerSystem : EntitySystem
     {
         SubscribeLocalEvent<SolutionScannerComponent, SolutionScanEvent>(OnSolutionScanAttempt);
         SubscribeLocalEvent<SolutionScannerComponent, InventoryRelayedEvent<SolutionScanEvent>>((e, c, ev) => OnSolutionScanAttempt(e, c, ev.Args));
+
+        SubscribeLocalEvent<SolutionScannerComponent, ItemMaskToggledEvent>(OnItemMaskToggled); // Moffstation - Toggling masks toggles associated solution scanners
     }
 
     private void OnSolutionScanAttempt(EntityUid eid, SolutionScannerComponent component, SolutionScanEvent args)
     {
-        args.CanScan = true;
+        args.CanScan = component.Enabled; // Moffstation - Solution scanner can be enabled/disabled.
     }
+
+    // Moffstation - Begin - Toggling masks toggles associated solution scanners
+    private void OnItemMaskToggled(Entity<SolutionScannerComponent> entity, ref ItemMaskToggledEvent args)
+    {
+        entity.Comp.Enabled = !args.Mask.Comp.IsToggled;
+        Dirty(entity);
+    }
+    // Moffstation - End
 }
 
 public sealed class SolutionScanEvent : EntityEventArgs, IInventoryRelayEvent


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title
Resolves #907

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug; realism. You shouldn't be able to use a mask that's hanging off your neck.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Basically copied what masks do to block ingestion:
- add enablement boolean to solution scanner
- toggling the mask toggles the solution scanner boolean on the mask

This POTENTIALLY could cause issues if there's ever a solution scanner on a mask which shouldn't do this, but eh. I'll fix that if that happens.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
Smoll

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- fix: The chemistry gas mask no longer functions as a solution scanner while it's pulled down. Remember kids, if you're getting close enough to peer into the beaker, your mask should be up!


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
