### PR TITLE
Potato APC permatrips and cooks into space fries

### DIFF
--- a/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
@@ -75,6 +75,14 @@ namespace Content.Client.Power.APC.UI
                 var chargePercentage = (castState.Charge / ChargeBar.MaxValue);
                 ChargePercentage.Text = Loc.GetString("apc-menu-charge-label",("percent",  chargePercentage.ToString("P0")));
             }
+            // Moffstation - Start - potato APC cooking
+            if (castState.PermaTripped)
+            {
+                BreakerButton.Disabled = true;
+                BreakerButton.ToolTip = Loc.GetString("apc-component-permatripped-tooltip");
+                PowerLabel?.Text = Loc.GetString("apc-menu-power-state-label-dead");
+            }
+            // Moffstation - End
         }
 
         public void SetAccessEnabled(bool hasAccess)

--- a/Content.Server/Power/Components/ApcComponent.cs
+++ b/Content.Server/Power/Components/ApcComponent.cs
@@ -1,6 +1,7 @@
 using Content.Server.Power.NodeGroups;
 using Content.Shared.APC;
 using Robust.Shared.Audio;
+using Robust.Shared.Prototypes; // Moffstation - potato APC cooking
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Power.Components;
@@ -59,6 +60,20 @@ public sealed partial class ApcComponent : BaseApcNetComponent
     /// </summary>
     [DataField]
     public bool TripFlag;
+
+    // Moffstation - Start - potato APC cooking
+    /// <summary>
+    /// If true, APC cannot be turned back on ever again.
+    /// </summary>
+    [DataField]
+    public bool PermaTripped;
+
+    /// <summary>
+    /// If not null, will spawn the entity and set <see cref="PermaTripped"/> to true.
+    /// </summary>
+    [DataField]
+    public EntProtoId? SpawnedEntityOnTrip;
+    // Moffstation - End
 
     // TODO ECS power a little better!
     // End the suffering

--- a/Content.Server/Power/Components/ApcComponent.cs
+++ b/Content.Server/Power/Components/ApcComponent.cs
@@ -63,16 +63,16 @@ public sealed partial class ApcComponent : BaseApcNetComponent
 
     // Moffstation - Start - potato APC cooking
     /// <summary>
+    /// If true, will set <see cref="PermaTripped"/> to true once the APC trips.
+    /// </summary>
+    [DataField]
+    public bool EnablePermaTripping;
+
+    /// <summary>
     /// If true, APC cannot be turned back on ever again.
     /// </summary>
     [DataField]
     public bool PermaTripped;
-
-    /// <summary>
-    /// If not null, will spawn the entity and set <see cref="PermaTripped"/> to true.
-    /// </summary>
-    [DataField]
-    public EntProtoId? SpawnedEntityOnTrip;
     // Moffstation - End
 
     // TODO ECS power a little better!

--- a/Content.Server/Power/Components/ApcComponent.cs
+++ b/Content.Server/Power/Components/ApcComponent.cs
@@ -1,7 +1,6 @@
 using Content.Server.Power.NodeGroups;
 using Content.Shared.APC;
 using Robust.Shared.Audio;
-using Robust.Shared.Prototypes; // Moffstation - potato APC cooking
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Power.Components;
@@ -73,6 +72,18 @@ public sealed partial class ApcComponent : BaseApcNetComponent
     /// </summary>
     [DataField]
     public bool PermaTripped;
+
+    /// <summary>
+    /// Sound to play on permatripping.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier PermaTrippedAudio = new SoundPathSpecifier("/Audio/Effects/sizzle.ogg");
+
+    /// <summary>
+    /// Popup LocId to display on permatripping.
+    /// </summary>
+    [DataField]
+    public LocId PermaTrippedPopup = "apc-component-permatripped-popup";
     // Moffstation - End
 
     // TODO ECS power a little better!

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -1,4 +1,3 @@
-using Content.Server.Construction.Components; // Moffstation - potato APC cooking
 using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Power.Pow3r;
@@ -29,10 +28,7 @@ public sealed class ApcSystem : EntitySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
-    // Moffstation - Start - potato APC cooking
-    [Dependency] private readonly EntityManager _entMan = default!;
-    [Dependency] private readonly SharedBatterySystem _battery = default!;
-    // Moffstation - End
+    [Dependency] private readonly SharedBatterySystem _battery = default!; // Moffstation - potato APC cooking
 
     public override void Initialize()
     {
@@ -80,14 +76,12 @@ public sealed class ApcSystem : EntitySystem
                     {
                         apc.TripFlag = true;
                         // Moffstation - Start - potato APC cooking
-                        if (apc.SpawnedEntityOnTrip != null)
+                        if (apc.EnablePermaTripping)
                         {
                             apc.PermaTripped = true;
-                            _entMan.SpawnEntity(apc.SpawnedEntityOnTrip, Transform(uid).Coordinates);
                             apc.MaxLoad = 0;
                             _battery.SetCharge(uid, 0);
                             _battery.SetMaxCharge(uid, 0);
-                            RemComp<ConstructionComponent>(uid); // no infinite fries
                         }
                         // Moffstation - End
                         ApcToggleBreaker(uid, apc, battery); // off, we already checked MainBreakerEnabled above

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Construction.Components; // Moffstation - potato APC cooking
 using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Power.Pow3r;
@@ -9,6 +10,7 @@ using Content.Shared.Emag.Systems;
 using Content.Shared.Emp;
 using Content.Shared.Popups;
 using Content.Shared.Power;
+using Content.Shared.Power.EntitySystems; // Moffstation - potato APC cooking
 using Content.Shared.Rounding;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
@@ -27,6 +29,10 @@ public sealed class ApcSystem : EntitySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
+    // Moffstation - Start - potato APC cooking
+    [Dependency] private readonly EntityManager _entMan = default!;
+    [Dependency] private readonly SharedBatterySystem _battery = default!;
+    // Moffstation - End
 
     public override void Initialize()
     {
@@ -73,6 +79,17 @@ public sealed class ApcSystem : EntitySystem
                     if (curTime - apc.TripStartTime > apc.TripTime)
                     {
                         apc.TripFlag = true;
+                        // Moffstation - Start - potato APC cooking
+                        if (apc.SpawnedEntityOnTrip != null)
+                        {
+                            apc.PermaTripped = true;
+                            _entMan.SpawnEntity(apc.SpawnedEntityOnTrip, Transform(uid).Coordinates);
+                            apc.MaxLoad = 0;
+                            _battery.SetCharge(uid, 0);
+                            _battery.SetMaxCharge(uid, 0);
+                            RemComp<ConstructionComponent>(uid); // no infinite fries
+                        }
+                        // Moffstation - End
                         ApcToggleBreaker(uid, apc, battery); // off, we already checked MainBreakerEnabled above
                     }
                 }
@@ -213,7 +230,8 @@ public sealed class ApcSystem : EntitySystem
             (int) MathF.Ceiling(battery.CurrentSupply), apc.LastExternalState,
             charge,
             apc.MaxLoad,
-            apc.TripFlag);
+            apc.TripFlag,
+            apc.PermaTripped); // Moffstation - potato APC cooking
 
         _ui.SetUiState((uid, ui), ApcUiKey.Key, state);
     }

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -133,6 +133,14 @@ public sealed class ApcSystem : EntitySystem
 
         if (_accessReader.IsAllowed(args.Actor, uid))
         {
+            // Moffstation - Start - potato APC cooking
+            if (component.PermaTripped)
+            {
+                _popup.PopupCursor(Loc.GetString("apc-component-permatripped-tooltip"),
+                    args.Actor, PopupType.Medium);
+                return;
+            }
+            // Moffstation - End
             ApcToggleBreaker(uid, component, user: args.Actor);
         }
         else

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -82,6 +82,8 @@ public sealed class ApcSystem : EntitySystem
                             apc.MaxLoad = 0;
                             _battery.SetCharge(uid, 0);
                             _battery.SetMaxCharge(uid, 0);
+                            _popup.PopupCoordinates(Loc.GetString(apc.PermaTrippedPopup), Transform(uid).Coordinates, PopupType.MediumCaution);
+                            _audio.PlayPvs(apc.PermaTrippedAudio, uid);
                         }
                         // Moffstation - End
                         ApcToggleBreaker(uid, apc, battery); // off, we already checked MainBreakerEnabled above

--- a/Content.Server/_Moffstation/Construction/Conditions/ApcPermaTrip.cs
+++ b/Content.Server/_Moffstation/Construction/Conditions/ApcPermaTrip.cs
@@ -1,0 +1,37 @@
+using Content.Server.Power.Components;
+using Content.Shared.Construction;
+using Content.Shared.Examine;
+using JetBrains.Annotations;
+
+namespace Content.Server._Moffstation.Construction.Conditions;
+
+[UsedImplicitly, DataDefinition]
+public sealed partial class ApcPermaTrip : IGraphCondition
+{
+    [DataField]
+    public bool IsPermaTripped { get; private set; } = true;
+
+    public bool Condition(EntityUid uid, IEntityManager entityManager)
+    {
+        if (!entityManager.TryGetComponent<ApcComponent>(uid, out var apc))
+            return !IsPermaTripped;
+        return IsPermaTripped == apc.PermaTripped;
+    }
+
+    public bool DoExamine(ExaminedEvent args)
+    {
+        if (IsPermaTripped)
+            args.PushMarkup(Loc.GetString("construction-examine-condition-permatripped"));
+        return IsPermaTripped;
+    }
+
+    public IEnumerable<ConstructionGuideEntry> GenerateGuideEntry()
+    {
+        yield return new ConstructionGuideEntry()
+        {
+            Localization = IsPermaTripped
+                ? "construction-step-condition-permatripped"
+                : "construction-step-condition-not-permatripped",
+        };
+    }
+}

--- a/Content.Shared/APC/SharedApc.cs
+++ b/Content.Shared/APC/SharedApc.cs
@@ -183,8 +183,9 @@ namespace Content.Shared.APC
         public readonly float Charge;
         public readonly float MaxLoad;
         public readonly bool Tripped;
+        public readonly bool PermaTripped; // Moffstation - potato APC cooking
 
-        public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge, float maxLoad, bool tripped)
+        public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge, float maxLoad, bool tripped, bool permaTripped) // Moffstation - potato APC cooking
         {
             MainBreaker = mainBreaker;
             Power = power;
@@ -192,18 +193,22 @@ namespace Content.Shared.APC
             Charge = charge;
             MaxLoad = maxLoad;
             Tripped = tripped;
+            PermaTripped = permaTripped; // Moffstation - potato APC cooking
         }
 
         public bool Equals(ApcBoundInterfaceState? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
+            // Moffstation - Start - potato APC cooking
             return MainBreaker == other.MainBreaker &&
                    Power == other.Power &&
                    ApcExternalPower == other.ApcExternalPower &&
                    MathHelper.CloseTo(Charge, other.Charge) &&
                    MathHelper.CloseTo(MaxLoad, other.MaxLoad) &&
-                   Tripped == other.Tripped;
+                   Tripped == other.Tripped &&
+                   PermaTripped == other.PermaTripped;
+            // Moffstation - End
         }
 
         public override bool Equals(object? obj)

--- a/Resources/Locale/en-US/_Moffstation/construction/conditions/apc.ftl
+++ b/Resources/Locale/en-US/_Moffstation/construction/conditions/apc.ftl
@@ -1,0 +1,3 @@
+construction-examine-condition-permatripped = First, critically overload the APC.
+construction-step-condition-permatripped = The APC must be critically overloaded.
+construction-step-condition-not-permatripped = The APC must not be critically overloaded.

--- a/Resources/Locale/en-US/_Moffstation/ui/power-apc.ftl
+++ b/Resources/Locale/en-US/_Moffstation/ui/power-apc.ftl
@@ -1,2 +1,3 @@
 apc-component-permatripped-tooltip = Battery fried!
 apc-menu-power-state-label-dead = DEAD
+apc-component-permatripped-popup = Something smells tasty...

--- a/Resources/Locale/en-US/_Moffstation/ui/power-apc.ftl
+++ b/Resources/Locale/en-US/_Moffstation/ui/power-apc.ftl
@@ -1,0 +1,2 @@
+apc-component-permatripped-tooltip = Battery fried!
+apc-menu-power-state-label-dead = DEAD

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/APC.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/APC.yml
@@ -128,9 +128,28 @@
         conditions:
         - !type:WirePanel
           open: true
+        # Moffstation - Start - potato APC cooking
+        - !type:ApcPermaTrip
+          isPermaTripped: false
+        # Moffstation - End
         steps:
         - tool: Prying
           doAfter: 4
+      # Moffstation - Start - potato APC cooking
+      - to: apcFrameWithBoard
+        completed:
+        - !type:GivePrototype
+          prototype: FoodMealFries
+          amount: 1
+        conditions:
+        - !type:WirePanel
+          open: true
+        - !type:ApcPermaTrip
+          isPermaTripped: true
+        steps:
+        - tool: Prying
+          doAfter: 4
+      # Moffstation - End
 
     - node: apcSmall
       entity: APCSmallBreaker

--- a/Resources/Prototypes/_Moffstation/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Structures/Power/apc.yml
@@ -15,7 +15,7 @@
   components:
   - type: Apc
     maxLoad: 1000
-    spawnedEntityOnTrip: FoodMealFries
+    enablePermaTripping: true
   - type: Construction
     graph: APC
     node: apcPotato

--- a/Resources/Prototypes/_Moffstation/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Structures/Power/apc.yml
@@ -15,6 +15,7 @@
   components:
   - type: Apc
     maxLoad: 1000
+    spawnedEntityOnTrip: FoodMealFries
   - type: Construction
     graph: APC
     node: apcPotato


### PR DESCRIPTION
## About the PR
Resolves #1266 
Potato APC will do the following:
- Pop out the space fries;
- Get some text in the UI telling you it's fried;
- Disables deconstruction (so that you don't get the potato battery back);
- Sets max draw, current and max battery to 0.

## Why / Balance
The reason why I picked space fries is because they don't have cheesy flavor (unlike baked potato). They do have a salty flavor, but that's probably because of all the wires in that potato battery.

## Technical details
Extra DataFields, handle them in the system, add the permatripped status to the BUI and handle it in UI.

## Media
https://github.com/user-attachments/assets/d9e10d38-571b-4512-b4a5-4ddfeda64033

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- add: Potato APC battery cooks into space fries when overloaded.