### PR TITLE
[Internal] Update our github repo's readme to point to our moffdocs wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Space Station 14 is a remake of SS13 that runs on Robust Toolbox, a homegrown en
 
 ## Documentation/Wiki
 
-Upstream's [docs site](https://docs.spacestation14.io/) has documentation on SS14s content, engine, game design and more.
-
+Moffstation's [docs site](https://moff-station.github.io/moff-docs/) has documentation on Moffstation's content, engine, game design, and more.
 ## Contributing
 
 We are happy to accept contributions from anybody. Note that because Moffstation is a fork of upstream Space Station 14, we will not accept any contributions that do not follow both upstream's [contribution guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) and our own [contribution guidelines](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Space Station 14 is a remake of SS13 that runs on Robust Toolbox, a homegrown en
 ## Documentation/Wiki
 
 Moffstation's [docs site](https://moff-station.github.io/moff-docs/) has documentation on Moffstation's content, engine, game design, and more.
+
 ## Contributing
 
 We are happy to accept contributions from anybody. Note that because Moffstation is a fork of upstream Space Station 14, we will not accept any contributions that do not follow both upstream's [contribution guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) and our own [contribution guidelines](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Space Station 14 is a remake of SS13 that runs on Robust Toolbox, a homegrown en
 
 Moffstation's [docs site](https://moff-station.github.io/moff-docs/) has documentation on Moffstation's content, engine, game design, and more.
 
+Upstream's [docs site](https://docs.spacestation14.io/) has documentation on SS14s content, engine, game design and more.
+
 ## Contributing
 
 We are happy to accept contributions from anybody. Note that because Moffstation is a fork of upstream Space Station 14, we will not accept any contributions that do not follow both upstream's [contribution guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) and our own [contribution guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
changed our repository's README.md file to point to https://moff-station.github.io/moff-docs/, our new documents wiki.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Maintenance.

If we're going to begin work on fleshing out our public documentation, it may be important to make it readily accessible.