### PR TITLE
Decrease pirate gamemode player requirement down to 35

### DIFF
--- a/Resources/Prototypes/_Moffstation/GameRules/pirates.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/pirates.yml
@@ -21,7 +21,7 @@
   - type: LoadMapRule
     gridPath: /Maps/_Moffstation/Shuttles/shuttle-sp-scurvydog.yml
   - type: GameRule
-    minPlayers: 40
+    minPlayers: 35
   - type: AntagSelection
     selectionTime: PrePlayerSpawn
     definitions:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Decreases the minimum population required for pirates down to 35. (This time, without accidentally pulling changes from a different PR.)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, with a population requirement of 40, pirates are basically a never-seen gamemode. While the gamemode is divisive, it is difficult to work on developing and fixing issues with the gamemode if pirates never roll.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
single yml line change.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Decreased minimum pop for pirates down to 35.