### PR TITLE
Makes salvage borgs 65% tankier than standard borgs

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -371,7 +371,18 @@
   # Moffstation - Start - Salvage Borg Resprite
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.5
-    baseSprintSpeed: 3.5
+    baseSprintSpeed: 3.5 # Moffstation: Slower because haha big stompy sounds
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      165: Critical # Moffstation: Just enough to not be oneshot by a mine
+      495: Dead # Same as destruction threshold. Borgs act exactly like crit when dead, except for ghosting on move
+    stateAlertDict:
+      Alive: BorgHealth
+      Critical: BorgCrit
+      Dead: BorgDead
+    showOverlays: false
+    allowRevives: true
   - type: FootstepModifier
     footstepSoundCollection:
       path: /Audio/Mecha/sound_mecha_powerloader_step.ogg

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -371,11 +371,11 @@
   # Moffstation - Start - Salvage Borg Resprite
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.5
-    baseSprintSpeed: 3.5 # Moffstation: Slower because haha big stompy sounds
+    baseSprintSpeed: 3.5 # Slower because haha big stompy sounds
   - type: MobThresholds
     thresholds:
       0: Alive
-      165: Critical # Moffstation: Just enough to not be oneshot by a mine
+      165: Critical # Just enough to not be oneshot by a mine
       495: Dead # Same as destruction threshold. Borgs act exactly like crit when dead, except for ghosting on move
     stateAlertDict:
       Alive: BorgHealth
@@ -383,6 +383,31 @@
       Dead: BorgDead
     showOverlays: false
     allowRevives: true
+  - type: Destructible # Redefine all of this with the new thresholds!
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 125
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Machines/warning_buzzer.ogg
+          params:
+            volume: 5
+    - trigger:
+        !type:DamageTrigger
+        damage: 495
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:EmptyContainersBehaviour
+        containers:
+        - borg_brain
+        - borg_module
+        - cell_slot
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
   - type: FootstepModifier
     footstepSoundCollection:
       path: /Audio/Mecha/sound_mecha_powerloader_step.ogg

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -370,7 +370,7 @@
     noMindState: borg_e_r # Moffstation - Early merge of Borg RSI fix
   # Moffstation - Start - Salvage Borg Resprite
   - type: MovementSpeedModifier
-    baseWalkSpeed: 1.5
+    baseWalkSpeed: 2.5
     baseSprintSpeed: 3.5 # Moffstation: Slower because haha big stompy sounds
   - type: MobThresholds
     thresholds:

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -123,8 +123,19 @@
   # Moffstation - Start - Salvage Borg Resprite
   addComponents:
   - type: MovementSpeedModifier
-    baseWalkSpeed: 1.5
-    baseSprintSpeed: 3.5
+    baseWalkSpeed: 2.5
+    baseSprintSpeed: 3.5 # Moffstation: Slower because haha big stompy sounds
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      165: Critical # Moffstation: Just enough to not be oneshot by a mine
+      495: Dead # Same as destruction threshold. Borgs act exactly like crit when dead, except for ghosting on move
+    stateAlertDict:
+      Alive: BorgHealth
+      Critical: BorgCrit
+      Dead: BorgDead
+    showOverlays: false
+    allowRevives: true
   footstepCollection:
     path: /Audio/Mecha/sound_mecha_powerloader_step.ogg
     params:

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -124,11 +124,11 @@
   addComponents:
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.5
-    baseSprintSpeed: 3.5 # Moffstation: Slower because haha big stompy sounds
+    baseSprintSpeed: 3.5 # Slower because haha big stompy sounds
   - type: MobThresholds
     thresholds:
       0: Alive
-      165: Critical # Moffstation: Just enough to not be oneshot by a mine
+      165: Critical # Just enough to not be oneshot by a mine
       495: Dead # Same as destruction threshold. Borgs act exactly like crit when dead, except for ghosting on move
     stateAlertDict:
       Alive: BorgHealth
@@ -136,6 +136,31 @@
       Dead: BorgDead
     showOverlays: false
     allowRevives: true
+  - type: Destructible # Redefine all of this with the new thresholds!
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 125
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Machines/warning_buzzer.ogg
+          params:
+            volume: 5
+    - trigger:
+        !type:DamageTrigger
+        damage: 495
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:EmptyContainersBehaviour
+        containers:
+        - borg_brain
+        - borg_module
+        - cell_slot
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
   footstepCollection:
     path: /Audio/Mecha/sound_mecha_powerloader_step.ogg
     params:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title; both their crit and destruction thresholds are increased.
Also their walk speed is raised to the same speed as other borgs because (1) why do borgs walk? for RP, I guess? (2) it was _really_ slow.

These changes were also made to derelict salvage borgs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- 65% because that's just enough to stand on top of a salvage mine and survive.
- Davyei went like 50% of the way with making them slower and giving them big stompy sounds, and now I finish the job by "justifying" that with more health; salvage borgs go out into space to be battered by strange monsters, meteors, and occasionally hostile tech -- it makes sense they'd have a chunkier chassis, right?

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
- Tweaked numbers and added the `MobThresholds` component with adjusted numbers.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- tweak: Salvage borg and derelict salvage borg walk speed as been increased to the same speed as other cyborgs'.
- tweak: Salvage borg and derelict salvage borgs can now take more damage before being incapacitated and before being destroyed.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
