### PR TITLE
"fix AI becoming god"

### DIFF
--- a/Content.Shared/Silicons/StationAi/SharedStationAiFixerConsoleSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiFixerConsoleSystem.cs
@@ -337,11 +337,10 @@ public abstract partial class SharedStationAiFixerConsoleSystem : EntitySystem
                     _mobState.ChangeMobState(ent.Comp.ActionTarget.Value, MobState.Alive);
                     break;
                 case StationAiFixerConsoleAction.Purge:
-                    if (!TryGetStationAiHolder(ent, out var holder))
+                    if (!TryGetStationAiHolder(ent, out _))
                         break;
-
-                    _container.RemoveEntity(holder.Value, ent.Comp.ActionTarget.Value, force: true);
-                    PredictedQueueDel(ent.Comp.ActionTarget);
+                    
+                    QueueDel(ent.Comp.ActionTarget);
 
                     ent.Comp.ActionTarget = null;
                     break;


### PR DESCRIPTION
Scar says this fixes [a bug where an AI in an intellicard being purged via a silicon restoration console will actually disembody the AI and allow it to haunt the station as an all-powerful spirit](https://discord.com/channels/1322447119252062260/1498067973762584656), thus the title.

Cherry picked from https://github.com/space-wizards/space-station-14/pull/42995/changes/1e478abf469a8556d89c832ce0ad5847c3e8867e

:cl: ScarKy0
- fix: The AI restoration console, when used on an intellicarded AI, will no longer untether the AI from its material prison.