### PR TITLE
ResomiDensity

### DIFF
--- a/Resources/Prototypes/_Moffstation/Body/Species/resomi.yml
+++ b/Resources/Prototypes/_Moffstation/Body/Species/resomi.yml
@@ -386,6 +386,18 @@
   - type: TemperatureProtection
     heatingCoefficient: 1.2
     coolingCoefficient: 0.50
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.35
+        density: 95 #tiny
+        restitution: 0.0
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
   - type: NightVision
   - type: FlashModifier
     modifier: 2


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->
<img width="292" height="148" alt="Screenshot_63" src="https://github.com/user-attachments/assets/454316e4-d41e-41b5-8fa7-aad44eaa5dd8" />


## About the PR
<!-- What did you change? -->
Resomis now share the same density as Avalis.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's not a major change but the Avalis had a smaller density than all the other races with the comment of them being a "tiny birb" this should definitely also apply to Resomis which are inherently smaller, their guidebook mentions their smaller stature as the reason why they take more damage as such I see no logic as to why they shouldn't at least share if not have a smaller mass.
The difference is very small but does change the mass of a creature which has some mechanics in the game like the table mass weight (though it's pending a refractor but it's likely to see more use in the future)

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
`ctrl+c` `ctrl+v` from Avali

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
