### PR TITLE
popping modules from equipped HUDs no longer leaves the HUD effect on…

### DIFF
--- a/Content.Shared/_Moffstation/Clothing/ModularHud/Systems/SharedModularHudSystem.cs
+++ b/Content.Shared/_Moffstation/Clothing/ModularHud/Systems/SharedModularHudSystem.cs
@@ -84,8 +84,8 @@ public abstract partial class SharedModularHudSystem : EntitySystem
         SubscribeLocalEvent<ModularHudComponent, ComponentRemove>(OnComponentRemove);
         SubscribeLocalEvent<ModularHudComponent, GotEquippedEvent>(OnGotEquipped);
         SubscribeLocalEvent<ModularHudComponent, GotUnequippedEvent>(OnGotUneqipped);
-        SubscribeLocalEvent<ModularHudComponent, EntInsertedIntoContainerMessage>(OnContainerModifiedMessage);
-        SubscribeLocalEvent<ModularHudComponent, EntRemovedFromContainerMessage>(OnContainerModifiedMessage);
+        SubscribeLocalEvent<ModularHudComponent, EntInsertedIntoContainerMessage>(OnEntInsertedIntoContainerMessage);
+        SubscribeLocalEvent<ModularHudComponent, EntRemovedFromContainerMessage>(OnEntRemovedFromContainerMessage);
         SubscribeLocalEvent<ModularHudComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<ModularHudComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<ModularHudComponent, HudModulesRemovalDoAfterEvent>(OnHudModulesRemovalDoAfter);
@@ -357,26 +357,28 @@ public abstract partial class SharedModularHudSystem : EntitySystem
         }
     }
 
-    /// Refresh the effects provided by the module added/removed.
-    private void OnContainerModifiedMessage<TArgs>(
+    private void OnEntInsertedIntoContainerMessage(
         Entity<ModularHudComponent> entity,
-        ref TArgs args
-    ) where TArgs : ContainerModifiedMessage
+        ref EntInsertedIntoContainerMessage args
+    )
     {
         if (args.Container.ID != entity.Comp.ModuleContainerId ||
             !HasComp<ModularHudModuleComponent>(args.Entity))
             return;
 
-        var parentUid = Transform(entity).ParentUid;
-        if (HasComp<InventoryComponent>(parentUid) &&
-            _inventory.InSlotWithAnyFlags(entity.Owner, entity.Comp.ActiveSlots))
-        {
-            RefreshVisualsAndEffects(entity, parentUid);
-        }
-        else
-        {
-            RefreshVisualsAndEffects(entity, null);
-        }
+        RefreshVisualsAndEffects(entity, equippee: null);
+    }
+
+    private void OnEntRemovedFromContainerMessage(
+        Entity<ModularHudComponent> entity,
+        ref EntRemovedFromContainerMessage args
+    )
+    {
+        if (args.Container.ID != entity.Comp.ModuleContainerId ||
+            !TryComp<ModularHudModuleComponent>(args.Entity, out var comp))
+            return;
+
+        RefreshVisualsAndEffects(entity, equippee: null, [(args.Entity, comp)]);
     }
 
     private void OnGotEquipped(Entity<ModularHudComponent> entity, ref GotEquippedEvent args)
@@ -391,16 +393,22 @@ public abstract partial class SharedModularHudSystem : EntitySystem
 
     /// This function contains a functional grab-bag of whatever function calls / event raisings need to happen to cause
     /// the disparate HUD effects to be updated when the modular HUD is un/equipped.
-    private void RefreshVisualsAndEffects(Entity<ModularHudComponent> entity, EntityUid? equippee)
+    /// If <paramref name="equippee"/> is passed in as null, will use <see cref="GetWearer"/> to try to find an equippee.
+    /// <paramref name="extraModules"/> is provided to allow for removed modules to have their effects updated.
+    private void RefreshVisualsAndEffects(
+        Entity<ModularHudComponent> entity,
+        EntityUid? equippee,
+        IEnumerable<Entity<ModularHudModuleComponent>>? extraModules = null
+    )
     {
-        if (equippee is { } e)
+        if ((equippee ?? GetWearer(entity)) is { } e)
         {
             _blurryVision.UpdateBlurMagnitude(e);
             var flashEv = new FlashImmunityChangedEvent(_flash.IsFlashImmune(e));
             RaiseLocalEvent(e, ref flashEv);
         }
 
-        RefreshEffectsForModules(GetModules(entity));
+        RefreshEffectsForModules(GetModules(entity).Concat(extraModules ?? []));
         SyncVisuals(entity);
     }
 
@@ -491,6 +499,17 @@ public abstract partial class SharedModularHudSystem : EntitySystem
             // Otherwise, remove the appearance data so that the visuals system doesn't try to do anything with it.
             _appearance.RemoveData(entity, Frame, appearance);
         }
+    }
+
+    /// Gets the entity wearing <paramref name="hud"/> if it's equipped in <see cref="ModularHudComponent.ActiveSlots"/>.
+    /// Returns null if the given HUD is not being worn or is worn in an inactive slot (eg. pocket).
+    private EntityUid? GetWearer(Entity<ModularHudComponent> hud)
+    {
+        var parentUid = Transform(hud).ParentUid;
+        return HasComp<InventoryComponent>(parentUid) &&
+               _inventory.InSlotWithAnyFlags(hud.Owner, hud.Comp.ActiveSlots)
+            ? parentUid
+            : null;
     }
 
     /// This doafter event is raised when the doafter to remove the HUD's modules is complete.


### PR DESCRIPTION
… you indefinitely

<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR / WHY???
Bugfix: https://discord.com/channels/1322447119252062260/1498992210832785428/1498992210832785428

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Basically, the bug was that the "refresh your HUDs" occurred AFTER the module was removed, so it didn't know which HUDs to update, meaning the old ones stuck around.
Now, removing the module has a handler which specifically includes the removed module.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
smol

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- fix: Removing modules from modular HUDs while the HUD is equipped will no longer cause the removed module's HUD effect to linger indefinitely.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
