### PR TITLE
Salvage Cyborg Ore Bag Magnet

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -634,7 +634,6 @@
     - item: MiningDrill
     - item: Shovel
     - item: MineralScannerUnpowered
-    - item: BorgOreBag
     # Moffstation - Start - Add orehand for salvage borgs
     - hand:
         emptyRepresentative: Coal1
@@ -643,6 +642,7 @@
           tags:
           - Ore
           - ArtifactFragment
+          - Orebag
     # Moffstation -End
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: mining-module }

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -33,6 +33,9 @@
   - type: QuickPickup
   - type: AreaPickup
   # Moffstation - End
+  - type: Tag
+    tags:
+    - Orebag
 
 - type: entity
   parent: OreBag

--- a/Resources/Prototypes/InventoryTemplates/borg.yml
+++ b/Resources/Prototypes/InventoryTemplates/borg.yml
@@ -47,6 +47,18 @@
     displayName: Head
     offset: 0.015625, 0
 # Moffstation - Start - Giving Borgs Neck slots
+  - name: belt
+    slotTexture: belt
+    fullTextureName: template_small
+    slotFlags: BELT
+    slotGroup: SecondHotbar
+    stripTime: 6
+    uiWindowPos: 3,1
+    strippingWindowPos: 1,5
+    displayName: Belt
+    whitelist:
+      tags:
+        - Orebag
   - name: neck
     slotTexture: neck
     slotFlags: NECK

--- a/Resources/Prototypes/_Moffstation/tags.yml
+++ b/Resources/Prototypes/_Moffstation/tags.yml
@@ -19,6 +19,9 @@
 - type: Tag
   id: SharkminnowLeather
 
+- type: Tag
+  id: Orebag
+
 # Pirate bounty objectives
 
 - type: Tag


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
**Unfinished but I need maintainers agreement to implement it with said idea before putting more work into it** 
This is intended as a hotfix with someone hopefully reworking the class for it but it's good enough in my opinion where it doesn't cause any issues to be implemented for a longer duration.
Added a belt slot for the Salvage borg which can only equipped whitelisted items which as of now are only the ore bags (Only the basic one for now). This lets them benefit from the magnet property of the ore bag. Their "ore" hand can now also pick up ore bags so the borg can take it "off" and keep in the slot if they don't want to pick up the ore. (This could be changed so only another person could take off and swap their bag.)


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Salvage borg had a very rough journey from lacking magboots and being unable to follow salvagers on no gravity places to not being able to pick up ores and having to manually do it making it an uncessarily tedious experience.

Having located the problem of the automagnet only working on equipped items and the orebag having it selected as a belt slot only made it so that I couldn't force the auto magnet to work while in the borg "slot" or "hand" as it is it's own class which I don't have the skills to edit so I made do with yml changes.

The only downsides of this are that the ore bag now needs to be manually procured and later on printed if upgraded for the cyborg as it doesn't come with the module. (It can be changed so that the borg can just put the bag it gets from the module into it's own beltslot but then we have the issue of the borg just being able to cheaply print modules to give out ore bags). The intergrated ore bags were larger to make more specialized but we can't have that now without salvagers also being able to use them and the sprite goes over the salvborg eyes if they are facing south (though I think there is a way to disable sprites specifically for them on that slot)

The workaround to all of this is to add the a unique tag to the integrated orebag and blacklist that from all the species base belt slot (it's 3 lines of code per species) so one but the borgs can equip it.

If someone edits the class to have an option to work while in your hand then we can edit the integrated ore bag which is exclusive to borgs to work in said hand otherwise this is the best that I could do which works.

TODO:
- Add fitting sprites(cooler option) or remove them entirely from the borg
- Remove the intergrated ore bag from the advanced module
- Lower the price of the advanced mining module

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Janky belt addition


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

https://github.com/user-attachments/assets/da8f2484-406b-4599-b780-3d70edd0c254



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- add: Salvage borgs now have a unique belt slot which works only with their ore bag.
- fix: Salvage borgs can now benefit from the ore bag's auto pick-up magnet feature.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
