### PR TITLE
Makes borg ore bags: toggleable; work regardless of being in a slot

### DIFF
--- a/Content.Shared/Storage/Components/MagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MagnetPickupComponent.cs
@@ -18,9 +18,10 @@ public sealed partial class MagnetPickupComponent : Component
 
     /// <summary>
     /// What container slot the magnet needs to be in to work.
+    /// Moffstation: Null indicates the magnet pickup functionality should always be active.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("slotFlags")]
-    public SlotFlags SlotFlags = SlotFlags.BELT;
+    public SlotFlags? SlotFlags = Inventory.SlotFlags.BELT; // Moffstation - Enable magnet pickup in any slot
 
     [ViewVariables(VVAccess.ReadWrite), DataField("range")]
     public float Range = 1f;

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -48,11 +48,11 @@ public sealed class MagnetPickupSystem : EntitySystem
             comp.NextScan += ScanDelay;
             Dirty(uid, comp);
 
-            if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
+            // Moffstation - Begin - Enable magnetization in no-slots.
+            if (comp.SlotFlags is {} slotFlags &&
+                !_inventory.InSlotWithAnyFlags((uid, xform, meta), slotFlags))
                 continue;
-
-            if ((slotDef.SlotFlags & comp.SlotFlags) == 0x0)
-                continue;
+            // Moffstation - End
 
             // No space
             if (!_storage.HasSpace((uid, storage)))

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -666,7 +666,7 @@
     - item: MiningDrillDiamond
     - item: Shovel
     - item: AdvancedMineralScannerUnpowered
-    - item: OreBagOfHolding
+    - item: OreBagOfHoldingBorg # Moffstation - Salvage borg ore bags always magnetize
     # Moffstation - Start - Add orehand for salvage borgs
     - hand:
         emptyRepresentative: Coal1

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -43,3 +43,11 @@
     - type: Storage
       grid:
       - 0,0,9,5
+    # Moffstation - Begin - Make borg ore bags magnetize in hands and toggleable
+    - type: ItemToggle
+    - type: ComponentToggler
+      components:
+      - type: MagnetPickup
+        slotFlags: null
+    # Moffstation - End
+

--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
@@ -1,0 +1,11 @@
+﻿- type: entity
+  parent: OreBagOfHolding
+  id: OreBagOfHoldingBorg
+  description: A robust bag of holding for built into the frame of a mining cyborg.
+  components:
+  - type: ItemToggle
+  - type: ComponentToggler
+    components:
+    - type: MagnetPickup
+      range: 2
+      slotFlags: null


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title. Both the basic bag and the advanced module's -of-holding one.

Closes #1354

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
ALL LIVES MUST SLOP IN THE QUALITY SLURP SLURP SLURP

Or, more realistically, it just saves some repetitive stress injuries, idk

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
- magnetized regardless of slot just required making the slot spec on the magnet component nullable and then updating the logic to treat "null slot" as "always on"
- toggling it uses the component toggler component

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
smoll

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- add: Borg ore bags can magnetize ore like their standard counterparts.
- add: Borg ore bags' magnetization is toggleable.


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
