### PR TITLE
give all borgs GPS + maps in their traversal modules; but at what cost?

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -539,7 +539,7 @@
   - type: ItemBorgModule
     hands:
     - item: BorgFireExtinguisher
-    - item: BorgHandheldGPSBasic
+#    - item: BorgHandheldGPSBasic # Moffstation - The mass scanner is a GPS now, too.
     - item: HandheldStationMapUnpowered
     - item: HandHeldMassScannerBorg
   - type: BorgModuleIcon
@@ -696,8 +696,9 @@
     hands:
     - item: WeaponGrapplingGun
     - item: BorgFireExtinguisher
-    - item: BorgHandheldGPSBasic
+#    - item: BorgHandheldGPSBasic # Moffstation - The mass scanner is a GPS now, too.
     - item: HandHeldMassScannerBorg
+    - item: HandheldStationMapUnpowered # Moffstation - Make "traversal" modules strict upgrades of the generic thruster
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: grappling-module }
 
@@ -818,10 +819,12 @@
     hands:
     - item: RCDRecharging
     - item: BorgFireExtinguisher
-    - item: BorgHandheldGPSBasic
+#    - item: BorgHandheldGPSBasic # Moffstation - The mass scanner is a GPS now, too.
+    - item: HandHeldMassScannerBorg # Moffstation - so give them the mass scanner.
     - item: GasAnalyzer
     - item: HolofanProjectorBorg
     - item: GeigerCounter
+    - item: HandheldStationMapUnpowered # Moffstation - Make "traversal" modules strict upgrades of the generic thruster
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: rcd-module }
 
@@ -977,7 +980,9 @@
     - item: DefibrillatorOneHandedUnpowered
     - item: Crowbar
     - item: BorgFireExtinguisher
-    - item: BorgHandheldGPSBasic
+#    - item: BorgHandheldGPSBasic # Moffstation - The mass scanner is a GPS now, too.
+    - item: HandHeldMassScannerBorg # Moffstation - ... so give them the mass scanner.
+    - item: HandheldStationMapUnpowered # Moffstation - Make "traversal" modules strict upgrades of the generic thruster
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: defib-module }
 

--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -63,3 +63,4 @@
         startingItem: PowerCellMicroreactor
         disableEject: true
         swap: false
+  - type: HandheldGPS # Moffstation - upgrade borg GPS to mass scanners


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Makes the salvage borg traversal, mediborg rescue, and engiborg RCD modules strict upgrades to the generic thruster module.
Basically, they all get GPS, station map and mass scanner, if they were missing any of those before.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The modules in question were already kind of related because they had "thrusters" in the form of fire extinguishers. With the addition of borg magboots, these existing chassis specific modules suddenly became incompatible with the generic thruster module (because existing borg code doesn't let two modules grand the same component -- magboots in this case).

By making them strict upgrades, no longer are these chassis locked out from functionality on a generic module.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
I made a combo mass scanner+gps and gave that and a station map to all of the modules in question.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

<img width="806" height="1207" alt="image" src="https://github.com/user-attachments/assets/d227bc81-0a75-4265-8cf8-53d1f79d563f" />
Unfortunately the engiborg's RCD module is two rows because of this.
Personally, I don't care about the station map, but @tosatur specifically wanted that.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- add: Salvage borgs' traversal modules now include a station map
- add: Mediborgs' rescue module now includes a mass scanner and station map
- add: Engiborgs' RCD module now includes a mass scanner and station map
- tweak: Cyborgs' GPSes have been combined with a mass scanner to reduce the number of items they have to juggle. This affects the above modules as well as the generic thruster module.


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
