### PR TITLE
Fix random borg blindness/dark vision

### DIFF
--- a/Content.Client/UserInterface/Systems/DamageOverlays/DamageOverlayUiController.cs
+++ b/Content.Client/UserInterface/Systems/DamageOverlays/DamageOverlayUiController.cs
@@ -69,6 +69,7 @@ public sealed class DamageOverlayUiController : UIController
 
     private void ClearOverlay()
     {
+        _overlay.State = MobState.Alive; // MoffStation
         _overlay.DeadLevel = 0f;
         _overlay.CritLevel = 0f;
         _overlay.PainLevel = 0f;


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Fixes https://github.com/space-wizards/space-station-14/issues/25112

## Test Plan
> Idea taken from upstream because its goated.

Reproduction steps from @slarticodefast here -> https://github.com/space-wizards/space-station-14/issues/25112#issuecomment-2537716868

- implant yourself with a death acidifier
- crit yourself and activate the acidifier to gib
- golobby, forcemap Core (the dev map does not have borg job slots)
- select cyborg as job
- ready up and startround


## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Borgs have overlays disabled. During comp startup, ClearOverlay is called twice (maybe some cleanup that can be done here? I didn't study it too intently).
In each time, it sets the damage values of the overlay to zero. The problem, the overlay itself reapplies damage because its internal MobState is never changed from MobState.Dead. I can think of a few ways to fix this. First is what I've done here. Hard set the mob state to alive when the overlay is cleared. This works because the mobstate will be reapplied below if for some reason it must be different immediately after clearoverlay is called. The second was to reinit a new DamageOverlay when the player is attached as appose to when the UIController is inited. I personally think this is probably better but I wasn't sure so I figured I'd shoot this out there and see what happens.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- fix: Borg vision should no longer "randomly" be occluded by the damage overlay.
