### PR TITLE
fixed the guidebook page saying Resomi twice instead of Avali.

### DIFF
--- a/Resources/ServerInfo/Guidebook/Mobs/Species.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Species.xml
@@ -18,7 +18,7 @@
   <Box>
     <GuideEntityEmbed Entity="AppearanceVulpkanin" Caption="Vulpkanin"/>
     <GuideEntityEmbed Entity="AppearanceResomi" Caption="Resomi"/> <!-- Moffstation -->
-    <GuideEntityEmbed Entity="AppearanceAvali" Caption="Resomi"/> <!-- Moffstation -->
+    <GuideEntityEmbed Entity="AppearanceAvali" Caption="Avali"/> <!-- Moffstation -->
   </Box>
 
 </Document>


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
I fixed a minor typo

## Media
<img width="552" height="440" alt="image" src="https://github.com/user-attachments/assets/1e7ba205-f975-4df7-ba16-938dd6918f7d" />
At the bottom right, it says Resomi instead of Avali. This typo no longer exists.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
no changelog really nessecary