### PR TITLE
move insertion of gun mods to be before calculating effects of inserted gun mods

### DIFF
--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -84,10 +84,11 @@ public sealed class GunUpgradeSystem : EntitySystem
             return;
         }
 
+        args.Handled = _container.Insert(args.Used, _container.GetContainer(ent, ent.Comp.UpgradesContainerId)); // Moffstation - Moved from three lines down.
         _audio.PlayPredicted(ent.Comp.InsertSound, ent, args.User);
         _popup.PopupClient(Loc.GetString("gun-upgrade-popup-insert", ("upgrade", args.Used),("gun", ent.Owner)), args.User);
         _gun.RefreshModifiers(ent.Owner);
-        args.Handled = _container.Insert(args.Used, _container.GetContainer(ent, ent.Comp.UpgradesContainerId));
+        // args.Handled = _container.Insert(args.Used, _container.GetContainer(ent, ent.Comp.UpgradesContainerId)); // Moffstation - Move higher so that the mod is inserted BEFORE recalculating gun effects.
 
         _adminLog.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(args.User):player} inserted gun upgrade {ToPrettyString(args.Used)} into {ToPrettyString(ent.Owner)}.");
     }


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Bugfix so that PKA mods apply their effects immediately instead of needing you to wield the thing to force it to update.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfix

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Previously, it worked like
- click PKA mod on PKA
- "you clicked the PKA" handler runs
  - it does a bunch of checks
  - it refreshes gun mod modifiers
  - it finally inserts the PKA mod

The issue is that the insertion happens after the modifier recalculation, which looks at inserted modules to determine effects.
Dumb bug.

Fix by reordering. e z p z

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
not fun to demo

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- fix: PKA mods no longer require you to wield the PKA they're inserted into to apply their effects.


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
