### PR TITLE
Resomi night vision fixes

### DIFF
--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -1,7 +1,9 @@
 using System.Linq;
+using Content.Shared._Moffstation.Overlay.Components;
 using Content.Shared._Starlight.Flash.Components;
 using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
+using Content.Shared.Clothing;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Examine;
 using Content.Shared.Eye.Blinding.Components;
@@ -70,6 +72,7 @@ public abstract class SharedFlashSystem : EntitySystem
         // Moffstation - Start - Night Vision blocked by flash immunity
         SubscribeLocalEvent<DidEquipEvent>(OnDidEquip);
         SubscribeLocalEvent<DidUnequipEvent>(OnDidUnequip);
+        SubscribeLocalEvent<NightVisionComponent, WearerMaskToggledEvent>(OnMaskToggled);
         SubscribeLocalEvent<FlashImmunityComponent, ComponentStartup>(OnFlashImmunityStartup);
         SubscribeLocalEvent<FlashImmunityComponent, ComponentRemove>(OnFlashImmunityRemove);
         // Moffstation - End
@@ -325,25 +328,29 @@ public abstract class SharedFlashSystem : EntitySystem
     // Moffstation - Start - Night Vision blocked by flash immunity
     private void OnDidEquip(DidEquipEvent args)
     {
-        if (!TryComp<FlashImmunityComponent>(args.Equipment, out var comp)
-            || !comp.Enabled)
+        if (!IsFlashImmune(args.EquipTarget))
             return;
 
-        // Adding equipment which definitely has enabled flash immunity means we definitely are flash immune now.
         var ev = new FlashImmunityChangedEvent(true);
         RaiseLocalEvent(args.EquipTarget, ref ev);
     }
 
     private void OnDidUnequip(DidUnequipEvent args)
     {
-        if (!TryComp<FlashImmunityComponent>(args.Equipment, out var comp) ||
-            !comp.Enabled ||
-            // If we still can't be flashed after removing the equipment, there's no change.
-            IsFlashImmune(args.EquipTarget))
+        if (IsFlashImmune(args.EquipTarget))
             return;
 
         var ev = new FlashImmunityChangedEvent(false);
         RaiseLocalEvent(args.EquipTarget, ref ev);
+    }
+
+    private void OnMaskToggled(Entity<NightVisionComponent> entity, ref WearerMaskToggledEvent args)
+    {
+        // this is mostly for interactions w/ syndie/welding gas mask
+        // because flipping those down gets rid of your flash protection - mayzmae 2026-05-07
+
+        var ev = new FlashImmunityChangedEvent(IsFlashImmune(entity.Owner));
+        RaiseLocalEvent(entity, ref ev);
     }
 
     private void OnFlashImmunityStartup(Entity<FlashImmunityComponent> entity, ref ComponentStartup args)

--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Content.Shared._Moffstation.Overlay.Components;
 using Content.Shared._Starlight.Flash.Components;
 using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
@@ -25,6 +24,7 @@ using Content.Shared.Traits.Assorted;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -48,6 +48,8 @@ public abstract class SharedFlashSystem : EntitySystem
 
     [Dependency] private readonly EntityQuery<StatusEffectsComponent> _statusEffectsQuery = default!;
     [Dependency] private readonly EntityQuery<DamagedByFlashingComponent> _damagedByFlashingQuery = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!; // Moffstation
+    [Dependency] private readonly SharedContainerSystem _container = default!; // Moffstation
 
     private HashSet<EntityUid> _entSet = new();
 
@@ -72,7 +74,7 @@ public abstract class SharedFlashSystem : EntitySystem
         // Moffstation - Start - Night Vision blocked by flash immunity
         SubscribeLocalEvent<DidEquipEvent>(OnDidEquip);
         SubscribeLocalEvent<DidUnequipEvent>(OnDidUnequip);
-        SubscribeLocalEvent<NightVisionComponent, WearerMaskToggledEvent>(OnMaskToggled);
+        SubscribeLocalEvent<FlashImmunityComponent, ItemMaskToggledEvent>(OnItemMaskToggled);
         SubscribeLocalEvent<FlashImmunityComponent, ComponentStartup>(OnFlashImmunityStartup);
         SubscribeLocalEvent<FlashImmunityComponent, ComponentRemove>(OnFlashImmunityRemove);
         // Moffstation - End

--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -344,13 +344,16 @@ public abstract class SharedFlashSystem : EntitySystem
         RaiseLocalEvent(args.EquipTarget, ref ev);
     }
 
-    private void OnMaskToggled(Entity<NightVisionComponent> entity, ref WearerMaskToggledEvent args)
+    // Handle cases where toggling a mask also toggles flash immunity.
+    private void OnItemMaskToggled(Entity<FlashImmunityComponent> entity, ref ItemMaskToggledEvent args)
     {
-        // this is mostly for interactions w/ syndie/welding gas mask
-        // because flipping those down gets rid of your flash protection - mayzmae 2026-05-07
+        if (!_inventory.TryGetContainingSlot(entity.Owner, out _) ||
+            !_container.TryGetContainingContainer(entity.Owner, out var container))
+            return;
 
-        var ev = new FlashImmunityChangedEvent(IsFlashImmune(entity.Owner));
-        RaiseLocalEvent(entity, ref ev);
+        var wearer = container.Owner;
+        var ev = new FlashImmunityChangedEvent(IsFlashImmune(wearer));
+        RaiseLocalEvent(wearer, ref ev);
     }
 
     private void OnFlashImmunityStartup(Entity<FlashImmunityComponent> entity, ref ComponentStartup args)


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Yesterday I came to notice that there was a bug affecting Resomi where their night vision gets disabled when you put flash protection items in your pockets, and it isn't re-enabled by toggling the syndicate or welding gas masks. This PR doesn't do anything more than fix those two issues

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
For the most part this is just a bug fix. Though this might affect balance with masks as you can gain night vision by flipping them down instead of taking them off entirely, I feel like this was an oversight as you'd still lose your flash protection

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- tweak: Resomi night vision can be re-enabled by toggling a syndicate or welding gas mask
- fix: Resomi night vision won't disable if flash protecting items are in their pockets

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
