### PR TITLE
Use readied player count for gamemode selection

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -26,7 +26,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using Content.Shared._Goob.LastWords;
-using Content.Shared._Moffstation.CCVar; // Goob Station - End of Round Screen
+using Content.Shared._Moffstation.CCVar;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -25,7 +25,8 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
-using Content.Shared._Goob.LastWords; // Goob Station - End of Round Screen
+using Content.Shared._Goob.LastWords;
+using Content.Shared._Moffstation.CCVar; // Goob Station - End of Round Screen
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
@@ -360,7 +361,7 @@ namespace Content.Server.GameTicking
         // Moffstation - Start - Player count calculated depending on cvar
         public int DynamicPlayerCount()
         {
-            return _cfg.GetCVar(CCVars.GameRulesCountReadied)
+            return _cfg.GetCVar(MoffCCVars.GameRulesCountReadied)
                 ? ReadyPlayerCount()
                 : _playerManager.PlayerCount;
         }

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -418,12 +418,4 @@ public sealed partial class CCVars
     /// </remarks>
     public static readonly CVarDef<int> TileStackLimit =
         CVarDef.Create("game.tile_stack_limit", 5, CVar.SERVER | CVar.REPLICATED);
-
-    // Moffstation - Begin
-    /// <summary>
-    /// if true, the player count check for rules will be based on the number of players readied, versus the total number in the lobby.
-    /// </summary>
-    public static readonly CVarDef<bool>
-        GameRulesCountReadied = CVarDef.Create("game.rules_count_readied", false, CVar.SERVERONLY);
-    // Moffstation - End
 }

--- a/Content.Shared/_Moffstation/CCVar/CCVars.Moff.cs
+++ b/Content.Shared/_Moffstation/CCVar/CCVars.Moff.cs
@@ -58,4 +58,12 @@ public sealed class MoffCCVars
     /// </summary>
     public static readonly CVarDef<int> MapVoteCount =
         CVarDef.Create("votekick.map_vote_count", 3, CVar.SERVERONLY);
+
+    // Moffstation - Begin
+    /// <summary>
+    /// if true, the player count check for rules will be based on the number of players readied, versus the total number in the lobby.
+    /// </summary>
+    public static readonly CVarDef<bool>
+        GameRulesCountReadied = CVarDef.Create("game.rules_count_readied", true, CVar.SERVERONLY);
+    // Moffstation - End
 }

--- a/Content.Shared/_Moffstation/CCVar/CCVars.Moff.cs
+++ b/Content.Shared/_Moffstation/CCVar/CCVars.Moff.cs
@@ -59,11 +59,9 @@ public sealed class MoffCCVars
     public static readonly CVarDef<int> MapVoteCount =
         CVarDef.Create("votekick.map_vote_count", 3, CVar.SERVERONLY);
 
-    // Moffstation - Begin
     /// <summary>
     /// if true, the player count check for rules will be based on the number of players readied, versus the total number in the lobby.
     /// </summary>
     public static readonly CVarDef<bool>
         GameRulesCountReadied = CVarDef.Create("game.rules_count_readied", true, CVar.SERVERONLY);
-    // Moffstation - End
 }

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -138,7 +138,7 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 30 # Moffstation - Bumped up the min players for nukeops.
+    minPlayers: 20
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml
   - type: AntagSelection
@@ -397,7 +397,7 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 25 # Moffstation - Bumped up the min players for zombies
+    minPlayers: 20
     delay:
       min: 600
       max: 900


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Gamemodes are now determined based off the readied players, rather than the total playercount. Also puts the antags back at their regular playercount, which were previously adjusted to compensate.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The total player count was introduced when Moff was a very lowpop server, and people wanted the chance to play other gamemodes. For the most part this is no longer an issue, as we have a wider ranging playercount now.
## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
moved the CVAR into our namespace
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- tweak: Gamemodes are now selected based on the number of readied players

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
