### PR TITLE
Add components for changing sprites on triggering

### DIFF
--- a/Content.Client/_Moffstation/Visuals/GenericVisualizerExtendedComponent.cs
+++ b/Content.Client/_Moffstation/Visuals/GenericVisualizerExtendedComponent.cs
@@ -1,0 +1,24 @@
+﻿using Content.Shared.Hands.Components;
+using Robust.Client.GameObjects;
+
+namespace Content.Client._Moffstation.Visuals;
+
+/// This component is analogous to <see cref="GenericVisualizerComponent"/>, but extended to inhand, clothing and
+/// storage visuals.
+[RegisterComponent, Access(typeof(GenericVisualizerExtendedSystem))]
+public sealed partial class GenericVisualizerExtendedComponent : Component
+{
+    /// <see cref="GenericVisualizerComponent.Visuals"/>, but for each hand.
+    [DataField]
+    public Dictionary<HandLocation, Dictionary<Enum, Dictionary<string, Dictionary<string, PrototypeLayerData>>>>
+        InhandVisuals = new();
+
+    /// <see cref="GenericVisualizerComponent.Visuals"/>, but for each clothing slot.
+    [DataField]
+    public Dictionary<string, Dictionary<Enum, Dictionary<string, Dictionary<string, PrototypeLayerData>>>>
+        ClothingVisuals = new();
+
+    /// <see cref="GenericVisualizerComponent.Visuals"/>, but for storage visuals.
+    [DataField]
+    public Dictionary<Enum, Dictionary<string, Dictionary<string, PrototypeLayerData>>> StoredVisuals = new();
+}

--- a/Content.Client/_Moffstation/Visuals/GenericVisualizerExtendedSystem.cs
+++ b/Content.Client/_Moffstation/Visuals/GenericVisualizerExtendedSystem.cs
@@ -9,15 +9,15 @@ using Robust.Shared.Containers;
 namespace Content.Client._Moffstation.Visuals;
 
 /// Implements the behavior of <see cref="GenericVisualizerComponent"/>. Analogous to <see cref="GenericVisualizerSystem"/>.
-public sealed class GenericVisualizerExtendedSystem : VisualizerSystem<GenericVisualizerExtendedComponent>
+public sealed partial class GenericVisualizerExtendedSystem : VisualizerSystem<GenericVisualizerExtendedComponent>
 {
     /// Used as a default in certain places to simplify logic.
     private static readonly Dictionary<Enum, Dictionary<string, Dictionary<string, PrototypeLayerData>>> Empty = new();
 
-    [Dependency] private readonly SharedItemSystem _itemSys = default!;
-    [Dependency] private readonly SharedAppearanceSystem _appearanceSys = default!;
+    [Dependency] private SharedItemSystem _itemSys = default!;
+    [Dependency] private SharedAppearanceSystem _appearanceSys = default!;
 
-    [Dependency] private readonly EntityQuery<AppearanceComponent> _appearanceQuery = default!;
+    [Dependency] private EntityQuery<AppearanceComponent> _appearanceQuery = default!;
 
     public override void Initialize()
     {

--- a/Content.Client/_Moffstation/Visuals/GenericVisualizerExtendedSystem.cs
+++ b/Content.Client/_Moffstation/Visuals/GenericVisualizerExtendedSystem.cs
@@ -1,0 +1,127 @@
+﻿using Content.Client.Clothing;
+using Content.Client.Items.Systems;
+using Content.Shared.Clothing;
+using Content.Shared.Hands;
+using Content.Shared.Item;
+using Robust.Client.GameObjects;
+using Robust.Shared.Containers;
+
+namespace Content.Client._Moffstation.Visuals;
+
+/// Implements the behavior of <see cref="GenericVisualizerComponent"/>. Analogous to <see cref="GenericVisualizerSystem"/>.
+public sealed class GenericVisualizerExtendedSystem : VisualizerSystem<GenericVisualizerExtendedComponent>
+{
+    /// Used as a default in certain places to simplify logic.
+    private static readonly Dictionary<Enum, Dictionary<string, Dictionary<string, PrototypeLayerData>>> Empty = new();
+
+    [Dependency] private readonly SharedItemSystem _itemSys = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearanceSys = default!;
+
+    [Dependency] private readonly EntityQuery<AppearanceComponent> _appearanceQuery = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // The `after`s here are to make sure we get the default layers first, so that we can override them.
+
+        SubscribeLocalEvent<GenericVisualizerExtendedComponent, EntGotInsertedIntoContainerMessage>(
+            OnEntGotInsertedIntoContainer);
+        SubscribeLocalEvent<GenericVisualizerExtendedComponent, GetInhandVisualsEvent>(OnGetHeldVisuals,
+            after: [typeof(ItemSystem)]);
+        SubscribeLocalEvent<GenericVisualizerExtendedComponent, GetEquipmentVisualsEvent>(OnGetEquipmentVisuals,
+            after: [typeof(ClientClothingSystem)]);
+        SubscribeLocalEvent<GenericVisualizerExtendedComponent, GetStoredVisualsEvent>(OnGetStoredVisuals);
+    }
+
+    protected override void OnAppearanceChange(
+        EntityUid uid,
+        GenericVisualizerExtendedComponent component,
+        ref AppearanceChangeEvent args
+    )
+    {
+        // Force other visuals to change when appearance data changes.
+        _itemSys.VisualsChanged(uid);
+    }
+
+    private void OnEntGotInsertedIntoContainer(
+        Entity<GenericVisualizerExtendedComponent> entity,
+        ref EntGotInsertedIntoContainerMessage args
+    )
+    {
+        // Force other visuals to change when put into storage. Realistically, this is used to immediately update
+        // storage visuals for items which spawn inside of inventories.
+        _itemSys.VisualsChanged(entity);
+    }
+
+    private void OnGetStoredVisuals(Entity<GenericVisualizerExtendedComponent> entity, ref GetStoredVisualsEvent args)
+    {
+        AddLayersFromVisuals(entity.Owner, entity.Comp.StoredVisuals, ref args.Layers);
+    }
+
+    private void OnGetHeldVisuals(Entity<GenericVisualizerExtendedComponent> entity, ref GetInhandVisualsEvent args)
+    {
+        AddLayersFromVisuals(
+            entity.Owner,
+            entity.Comp.InhandVisuals.GetValueOrDefault(args.Location, Empty),
+            ref args.Layers
+        );
+    }
+
+    private void OnGetEquipmentVisuals(
+        Entity<GenericVisualizerExtendedComponent> entity,
+        ref GetEquipmentVisualsEvent args
+    )
+    {
+        AddLayersFromVisuals(
+            entity.Owner,
+            entity.Comp.ClothingVisuals.GetValueOrDefault(args.Slot, Empty),
+            ref args.Layers
+        );
+    }
+
+    /// Adds/overwrites visuals from <paramref name="visuals"/> into <paramref name="layers"/>. The actual visuals used
+    /// are based on <paramref name="entity"/>'s <see cref="AppearanceComponent">appearance data</see>.
+    private void AddLayersFromVisuals(
+        Entity<AppearanceComponent?> entity,
+        Dictionary<Enum, Dictionary<string, Dictionary<string, PrototypeLayerData>>> visuals,
+        ref List<(string, PrototypeLayerData)> layers
+    )
+    {
+        foreach (var layer in GetLayersFromVisuals(entity.Owner, visuals))
+        {
+            // "Overwrite" existing layers with the same key.
+            layers.RemoveAll(key => key.Item1 == layer.Item1);
+            layers.Add(layer);
+        }
+    }
+
+    /// Returns the "active" layers from <paramref name="visuals"/> based on <paramref name="entity"/>'s
+    /// <see cref="AppearanceComponent">appearance data</see>.
+    private IEnumerable<(string, PrototypeLayerData)> GetLayersFromVisuals(
+        Entity<AppearanceComponent?> entity,
+        Dictionary<Enum, Dictionary<string, Dictionary<string, PrototypeLayerData>>> visuals
+    )
+    {
+        if (!_appearanceQuery.Resolve(entity, ref entity.Comp))
+            yield break;
+
+        foreach (var (appearanceKey, layerDict) in visuals)
+        {
+            if (!_appearanceSys.TryGetData(entity, appearanceKey, out var obj, entity))
+                continue;
+
+            var appearanceValue = obj.ToString();
+            if (string.IsNullOrEmpty(appearanceValue))
+                continue;
+
+            foreach (var (layerKeyRaw, layerDataDict) in layerDict)
+            {
+                if (!layerDataDict.TryGetValue(appearanceValue, out var layerData))
+                    continue;
+
+                yield return (layerKeyRaw, layerData);
+            }
+        }
+    }
+}

--- a/Content.Server/Entry/IgnoredComponents.cs
+++ b/Content.Server/Entry/IgnoredComponents.cs
@@ -4,6 +4,7 @@ namespace Content.Server.Entry
     public static class IgnoredComponents
     {
         public static string[] List => new[] {
+            "GenericVisualizerExtended", // Moffstation - Add client-only visualizer component
             "ConstructionGhost",
             "IconSmooth",
             "InteractionOutline",

--- a/Content.Shared/_Moffstation/Atmos/EntitySystems/GasTankVisualsSystem.cs
+++ b/Content.Shared/_Moffstation/Atmos/EntitySystems/GasTankVisualsSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._Moffstation.Atmos.Components;
 using Content.Shared._Moffstation.Atmos.Visuals;
+using Content.Shared._Moffstation.Extensions;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Moffstation.Atmos.EntitySystems;
@@ -53,39 +54,26 @@ public sealed partial class GasTankVisualsSystem : EntitySystem
 
         entity.Comp1.Visuals = colorValues;
         _appearance.SetData(entity, GasTankVisualsLayers.Tank, colorValues.TankColor, entity.Comp2);
-        SetOrRemoveAppearanceData(
+        _appearance.SetOrRemoveData(
             (entity, entity.Comp2),
             GasTankVisualsLayers.StripeMiddle,
             colorValues.MiddleStripeColor
         );
-        SetOrRemoveAppearanceData((entity, entity.Comp2), GasTankVisualsLayers.StripeLow, colorValues.LowerStripeColor);
+        _appearance.SetOrRemoveData(
+            (entity, entity.Comp2),
+            GasTankVisualsLayers.StripeLow,
+            colorValues.LowerStripeColor
+        );
 
         return true;
     }
 
     private GasTankColorValues? GetColorValues(GasTankVisuals visuals) => visuals switch
-        {
-            GasTankVisuals.GasTankVisualsPrototype proto => _proto.Resolve(proto.Prototype, out var style)
-                ? style.ColorValues
-                : null,
-            GasTankVisuals.GasTankVisualsColorValues values => values,
-            _ => throw new ArgumentOutOfRangeException(),
-        };
-
-    /// <summary>
-    /// If <paramref name="value"/> is null, <see cref="SharedAppearanceSystem.RemoveData">removes</see>
-    /// <paramref name="key"/> from <paramref name="entity"/>'s appearance data, otherwise
-    /// <see cref="SharedAppearanceSystem.SetData">sets</see> it to <paramref name="value"/>.
-    /// </summary>
-    private void SetOrRemoveAppearanceData(Entity<AppearanceComponent?> entity, Enum key, object? value)
     {
-        if (value is not null)
-        {
-            _appearance.SetData(entity, key, value, entity);
-        }
-        else
-        {
-            _appearance.RemoveData(entity, key, entity);
-        }
-    }
+        GasTankVisuals.GasTankVisualsPrototype proto => _proto.Resolve(proto.Prototype, out var style)
+            ? style.ColorValues
+            : null,
+        GasTankVisuals.GasTankVisualsColorValues values => values,
+        _ => visuals.ThrowUnknownInheritor<GasTankVisuals, GasTankColorValues?>(),
+    };
 }

--- a/Content.Shared/_Moffstation/Atmos/Visuals/GasTankColorValues.cs
+++ b/Content.Shared/_Moffstation/Atmos/Visuals/GasTankColorValues.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._Moffstation.Atmos.Components;
 using Content.Shared._Moffstation.Atmos.EntitySystems;
+using Content.Shared._Moffstation.Extensions;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
@@ -107,7 +108,7 @@ public sealed partial class GasTankVisualStylePrototype : IPrototype
 /// <see cref="GasTankVisualsSystem.GetColorValues"/> (but that should only happen internally to that system).
 /// </summary>
 [ImplicitDataDefinitionForInheritors, Serializable, NetSerializable]
-public abstract partial class GasTankVisuals
+public abstract partial class GasTankVisuals : ISealedInheritance
 {
     private GasTankVisuals()
     {

--- a/Content.Shared/_Moffstation/Extensions/AppearanceSystemExt.cs
+++ b/Content.Shared/_Moffstation/Extensions/AppearanceSystemExt.cs
@@ -1,0 +1,21 @@
+﻿namespace Content.Shared._Moffstation.Extensions;
+
+public static partial class AppearanceSystemExt
+{
+    extension(SharedAppearanceSystem appearanceSystem)
+    {
+        /// <see cref="SharedAppearanceSystem.SetData"/> if <paramref name="value"/> is not <c>null</c>, otherwise
+        /// <see cref="SharedAppearanceSystem.RemoveData"/>.
+        public void SetOrRemoveData(Entity<AppearanceComponent?> entity, Enum key, object? value)
+        {
+            if (value != null)
+            {
+                appearanceSystem.SetData(entity, key, value, entity);
+            }
+            else
+            {
+                appearanceSystem.RemoveData(entity, key, entity);
+            }
+        }
+    }
+}

--- a/Content.Shared/_Moffstation/Extensions/ISealedInheritance.cs
+++ b/Content.Shared/_Moffstation/Extensions/ISealedInheritance.cs
@@ -1,4 +1,6 @@
-﻿namespace Content.Shared._Moffstation.Extensions;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Content.Shared._Moffstation.Extensions;
 
 /// This interface marks a type as having sealed inheritance, enabling access to
 /// <see cref="ISealedInheritanceExt.ThrowUnknownInheritor{TSealed, TRet}(TSealed)"/>
@@ -9,10 +11,12 @@ public static class ISealedInheritanceExt
     extension<TSealed>(TSealed s) where TSealed : ISealedInheritance
     {
         /// Throws, complaining that <typeparamref name="TSealed"/> is, well, sealed, and the given receiver's type is unknown.
+        [DoesNotReturn]
         public void ThrowUnknownInheritor() => s.ThrowUnknownInheritor<TSealed, int>();
 
         /// Throws, complaining that <typeparamref name="TSealed"/> is, well, sealed, and the given receiver's type is
         /// unknown. "returns" <typeparamref name="TRet"/> to appease the One True God, the typechecker.
+        [DoesNotReturn]
         public TRet ThrowUnknownInheritor<TRet>() => throw new(
             $"Unreachable: {typeof(TSealed).FullName} has sealed inheritance, but {s.GetType().FullName} is unknown."
         );

--- a/Content.Shared/_Moffstation/Trigger/Components/Effects/SetAppearanceOnTriggerComponent.cs
+++ b/Content.Shared/_Moffstation/Trigger/Components/Effects/SetAppearanceOnTriggerComponent.cs
@@ -22,7 +22,7 @@ public sealed partial class SetAppearanceOnTriggerComponent : BaseXOnTriggerComp
 
 /// A component which stores <see cref="AppearanceComponent">appearance data</see> to be applied
 /// <see cref="RestoreAt">at some point in the future</see>.
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
 [Access(typeof(SetAppearanceOnTriggerSystem))]
 public sealed partial class SetAppearanceOnTriggerRestorationComponent : Component
 {

--- a/Content.Shared/_Moffstation/Trigger/Components/Effects/SetAppearanceOnTriggerComponent.cs
+++ b/Content.Shared/_Moffstation/Trigger/Components/Effects/SetAppearanceOnTriggerComponent.cs
@@ -1,0 +1,36 @@
+﻿using Content.Shared._Moffstation.Trigger.Systems;
+using Content.Shared.Trigger.Components.Effects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Moffstation.Trigger.Components.Effects;
+
+/// A <see cref="BaseXOnTriggerComponent"/> which sets <see cref="AppearanceComponent">appearance data</see> as
+/// specified in <see cref="Data"/>. This appearance data remains for <see cref="Duration"/> and then is reset to its
+/// previous state using <see cref="SetAppearanceOnTriggerRestorationComponent"/>.
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SetAppearanceOnTriggerSystem))]
+public sealed partial class SetAppearanceOnTriggerComponent : BaseXOnTriggerComponent
+{
+    /// Appearance data to set when the entity is triggered.
+    [DataField(required: true)]
+    public Dictionary<Enum, string> Data = new();
+
+    /// How long the triggered appearance data is set for. If null, it remains indefinitely.
+    [DataField]
+    public TimeSpan? Duration = null;
+}
+
+/// A component which stores <see cref="AppearanceComponent">appearance data</see> to be applied
+/// <see cref="RestoreAt">at some point in the future</see>.
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[Access(typeof(SetAppearanceOnTriggerSystem))]
+public sealed partial class SetAppearanceOnTriggerRestorationComponent : BaseXOnTriggerComponent
+{
+    /// The appearance data state to restore.
+    [DataField]
+    public List<(Enum, object?)> RestoreData = new();
+
+    /// When <see cref="RestoreData"/> should be applied.
+    [DataField(required: true), AutoPausedField]
+    public TimeSpan RestoreAt;
+}

--- a/Content.Shared/_Moffstation/Trigger/Components/Effects/SetAppearanceOnTriggerComponent.cs
+++ b/Content.Shared/_Moffstation/Trigger/Components/Effects/SetAppearanceOnTriggerComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class SetAppearanceOnTriggerComponent : BaseXOnTriggerComp
 /// <see cref="RestoreAt">at some point in the future</see>.
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 [Access(typeof(SetAppearanceOnTriggerSystem))]
-public sealed partial class SetAppearanceOnTriggerRestorationComponent : BaseXOnTriggerComponent
+public sealed partial class SetAppearanceOnTriggerRestorationComponent : Component
 {
     /// The appearance data state to restore.
     [DataField]

--- a/Content.Shared/_Moffstation/Trigger/Systems/SetAppearanceOnTriggerSystem.cs
+++ b/Content.Shared/_Moffstation/Trigger/Systems/SetAppearanceOnTriggerSystem.cs
@@ -84,7 +84,7 @@ public sealed partial class SetAppearanceOnTriggerSystem : XOnTriggerSystem<SetA
 
             foreach (var (key, data) in comp.RestoreData)
             {
-                _appearance.SetOrRemoveData(appearance.Nullable(), key, data);
+                _appearance.SetOrRemoveData(appearance.AsNullable(), key, data);
             }
 
             RemCompDeferred(ent, comp);

--- a/Content.Shared/_Moffstation/Trigger/Systems/SetAppearanceOnTriggerSystem.cs
+++ b/Content.Shared/_Moffstation/Trigger/Systems/SetAppearanceOnTriggerSystem.cs
@@ -1,0 +1,106 @@
+﻿using Content.Shared._Moffstation.Extensions;
+using Content.Shared._Moffstation.Trigger.Components.Effects;
+using Content.Shared.Trigger;
+using JetBrains.Annotations;
+using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._Moffstation.Trigger.Systems;
+
+/// This system implements the behavior of <see cref="SetAppearanceOnTriggerComponent"/>.
+public sealed partial class SetAppearanceOnTriggerSystem : XOnTriggerSystem<SetAppearanceOnTriggerComponent>
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+
+    [Dependency] private readonly EntityQuery<AppearanceComponent> _appearanceQuery = default!;
+
+    [Dependency]
+    private readonly EntityQuery<SetAppearanceOnTriggerRestorationComponent> _setAppearanceOnTriggerRestorationQuery =
+        default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SetAppearanceOnTriggerComponent, MapInitEvent>(OnMapInit);
+    }
+
+    protected override void OnTrigger(
+        Entity<SetAppearanceOnTriggerComponent> ent,
+        EntityUid target,
+        ref TriggerEvent args
+    )
+    {
+        if (GetAppearance(ent) is not { } appearance)
+            return;
+
+        // If we have a restore time already, just update the restore time based on this trigger invocation.
+        var alreadySet = _setAppearanceOnTriggerRestorationQuery.TryComp(ent, out var restoreComp);
+
+        if (ent.Comp.Duration is { } duration)
+        {
+            restoreComp ??= EnsureComp<SetAppearanceOnTriggerRestorationComponent>(ent);
+            restoreComp.RestoreAt = _timing.CurTime + duration;
+        }
+
+        // We're already set. Trying to set the restore data at this point would override legitimate restore data with
+        // our set data, so just return now.
+        if (alreadySet)
+            return;
+
+        restoreComp?.RestoreData.Clear();
+        foreach (var (key, data) in ent.Comp.Data)
+        {
+            if (restoreComp != null)
+            {
+                _appearance.TryGetData(ent, key, out var restoreData, appearance);
+                restoreComp.RestoreData.Add((key, restoreData));
+            }
+
+            _appearance.SetData(ent, key, data, appearance);
+        }
+    }
+
+    private void OnMapInit(Entity<SetAppearanceOnTriggerComponent> ent, ref MapInitEvent args)
+    {
+        // Helpful debug assert to tell you that you need AppearanceComponent for this component to work.
+        DebugTools.Assert(
+            _appearanceQuery.HasComp(ent),
+            $"{ToPrettyString(ent)} has {nameof(SetAppearanceOnTriggerComponent)} but no {nameof(AppearanceComponent)}. {nameof(SetAppearanceOnTriggerComponent)} doesn't do anything without {nameof(AppearanceComponent)} on the same entity."
+        );
+    }
+
+    /// Handles restoring appearance data.
+    public override void Update(float frameTime)
+    {
+        var q = AllEntityQuery<SetAppearanceOnTriggerRestorationComponent>();
+        while (q.MoveNext(out var ent, out var comp))
+        {
+            if (comp.RestoreAt > _timing.CurTime ||
+                GetAppearance(ent) is not { } appearance)
+                continue;
+
+            foreach (var (key, data) in comp.RestoreData)
+            {
+                _appearance.SetOrRemoveData(appearance, key, data);
+            }
+
+            RemCompDeferred(ent, comp);
+        }
+    }
+
+    private Entity<AppearanceComponent>? GetAppearance(EntityUid ent)
+    {
+        AppearanceComponent? comp = null;
+        return _appearanceQuery.Resolve(ent, ref comp) ? (ent, comp) : null;
+    }
+}
+
+[Serializable, NetSerializable]
+public enum SetAppearanceOnTriggerVisuals : byte
+{
+    [UsedImplicitly]
+    Key,
+}

--- a/Content.Shared/_Moffstation/Trigger/Systems/SetAppearanceOnTriggerSystem.cs
+++ b/Content.Shared/_Moffstation/Trigger/Systems/SetAppearanceOnTriggerSystem.cs
@@ -11,14 +11,13 @@ namespace Content.Shared._Moffstation.Trigger.Systems;
 /// This system implements the behavior of <see cref="SetAppearanceOnTriggerComponent"/>.
 public sealed partial class SetAppearanceOnTriggerSystem : XOnTriggerSystem<SetAppearanceOnTriggerComponent>
 {
-    [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private SharedAppearanceSystem _appearance = default!;
 
-    [Dependency] private readonly EntityQuery<AppearanceComponent> _appearanceQuery = default!;
+    [Dependency] private EntityQuery<AppearanceComponent> _appearanceQuery = default!;
 
     [Dependency]
-    private readonly EntityQuery<SetAppearanceOnTriggerRestorationComponent> _setAppearanceOnTriggerRestorationQuery =
-        default!;
+    private EntityQuery<SetAppearanceOnTriggerRestorationComponent> _setAppearanceOnTriggerRestorationQuery = default!;
 
     public override void Initialize()
     {
@@ -75,7 +74,7 @@ public sealed partial class SetAppearanceOnTriggerSystem : XOnTriggerSystem<SetA
     /// Handles restoring appearance data.
     public override void Update(float frameTime)
     {
-        var q = AllEntityQuery<SetAppearanceOnTriggerRestorationComponent>();
+        var q = EntityQueryEnumerator<SetAppearanceOnTriggerRestorationComponent>();
         while (q.MoveNext(out var ent, out var comp))
         {
             if (comp.RestoreAt > _timing.CurTime ||

--- a/Content.Shared/_Moffstation/Trigger/Systems/SetAppearanceOnTriggerSystem.cs
+++ b/Content.Shared/_Moffstation/Trigger/Systems/SetAppearanceOnTriggerSystem.cs
@@ -84,7 +84,7 @@ public sealed partial class SetAppearanceOnTriggerSystem : XOnTriggerSystem<SetA
 
             foreach (var (key, data) in comp.RestoreData)
             {
-                _appearance.SetOrRemoveData(appearance, key, data);
+                _appearance.SetOrRemoveData(appearance.Nullable(), key, data);
             }
 
             RemCompDeferred(ent, comp);


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Nothing immediate, just new components.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
@AffleWaffle was looking for this capability and I said I'd whip it up in a day.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
#### `GenericVisualizerExtendedComponent`
Basically `GenericVisualizerComponent`, but it can do inhand sprites, storage sprites and clothing sprites.
My hubris knows no bounds.
The fun part of this one is that it gets an entry in `Content.Server.Entry.IgnoredComponents.List` :^)

#### `SetAppearanceOnTriggerComponent`
Sets appearance data when the entity is triggered.

#### A handful of other purely technical changes
- `AppearanceSystemExt`'s `SharedAppearanceSystem.SetOrRemoveData` extension
- use the above in paintable tanks code because I recalled writing the same basic thing as a member of that system previously.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

<img width="1297" height="909" alt="image" src="https://github.com/user-attachments/assets/3131fdd3-b7ec-4f99-9a53-e3c044152e93" />

Modified fireaxe to turn into a katana inhand when hitting something.

<img width="593" height="710" alt="image" src="https://github.com/user-attachments/assets/63cf7f10-c537-4f83-8c50-d194ffe47349" />

This is what I added to make the fireaxe change to a katana in-hand after hitting the wall.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a; addative

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
n/a; nothing player-facing


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
