### PR TITLE
Hopefully fix concurrent enumeration change intermittent test failure

### DIFF
--- a/Content.Client/Content.Client.csproj
+++ b/Content.Client/Content.Client.csproj
@@ -21,11 +21,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Content.Shared\Content.Shared.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="_Moffstation\Robotics\" />
-    <Folder Include="_Moffstation\Silicons\" />
-  </ItemGroup>
   <Import Project="..\RobustToolbox\MSBuild\Robust.Properties.targets" />
   <Import Project="..\RobustToolbox\MSBuild\XamlIL.targets" />
 </Project>

--- a/Content.Client/_Moffstation/NightVision/DirtyNightVisionComponent.cs
+++ b/Content.Client/_Moffstation/NightVision/DirtyNightVisionComponent.cs
@@ -1,0 +1,6 @@
+﻿namespace Content.Client._Moffstation.NightVision;
+
+/// This marker component exists only to indicate that its owning entity needs to have NightVision applied. Does nothing
+/// if on an entity without <see cref="Content.Shared._Moffstation.NightVision"/>
+[RegisterComponent]
+public sealed partial class DirtyNightVisionComponent : Component;

--- a/Content.Client/_Moffstation/NightVision/NightVisionSystem.cs
+++ b/Content.Client/_Moffstation/NightVision/NightVisionSystem.cs
@@ -81,7 +81,7 @@ public sealed class NightVisionSystem : EntitySystem
     private void RemoveEffect(Entity<NightVisionComponent> entity)
     {
         _overlayMan.RemoveOverlay<NightVisionOverlay>();
-        QueueDel(entity.Comp.Effect);
+        PredictedQueueDel(entity.Comp.Effect);
         entity.Comp.Effect = null;
         RemCompDeferred<DirtyNightVisionComponent>(entity);
     }

--- a/Content.Client/_Moffstation/NightVision/NightVisionSystem.cs
+++ b/Content.Client/_Moffstation/NightVision/NightVisionSystem.cs
@@ -1,25 +1,23 @@
 using Content.Client._Starlight.Overlay;
-using Content.Shared._Moffstation.Overlay.Components;
+using Content.Shared._Moffstation.NightVision;
 using Content.Shared.Flash;
-using Content.Shared.Flash.Components;
-using Content.Shared.Inventory;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
-namespace Content.Client._Moffstation.Overlay.Systems;
+namespace Content.Client._Moffstation.NightVision;
 
-/// <summary>
 /// This system implements the behavior of <see cref="NightVisionComponent"/>.
-/// </summary>
 public sealed class NightVisionSystem : EntitySystem
 {
+    [Dependency] private readonly SharedFlashSystem _flash = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
     [Dependency] private readonly TransformSystem _xformSys = default!;
-    [Dependency] private readonly SharedFlashSystem _flash = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -35,6 +33,10 @@ public sealed class NightVisionSystem : EntitySystem
 
     private void OnFlashImmunityChanged(Entity<NightVisionComponent> ent, ref FlashImmunityChangedEvent args)
     {
+        // Prevent effect flickering due to rollbacks.
+        if (!_gameTiming.IsFirstTimePredicted)
+            return;
+
         if (args.FlashImmune)
         {
             RemoveEffect(ent);
@@ -72,16 +74,35 @@ public sealed class NightVisionSystem : EntitySystem
             _flash.IsFlashImmune(entity))
             return;
 
-        _overlayMan.AddOverlay(new NightVisionOverlay());
-        var effect = SpawnAttachedTo(entity.Comp.EffectPrototype, Transform(entity).Coordinates);
-        _xformSys.SetParent(effect, entity);
-        entity.Comp.Effect = effect;
+        // "Enqueue" activation of night vision.
+        EnsureComp<DirtyNightVisionComponent>(entity);
     }
 
     private void RemoveEffect(Entity<NightVisionComponent> entity)
     {
         _overlayMan.RemoveOverlay<NightVisionOverlay>();
-        PredictedQueueDel(entity.Comp.Effect);
+        QueueDel(entity.Comp.Effect);
         entity.Comp.Effect = null;
+        RemCompDeferred<DirtyNightVisionComponent>(entity);
+    }
+
+    public override void Update(float frameTime)
+    {
+        // We use the marker+update pattern for changing here due a pernicious intermittent issue where night vision
+        // would be turned on while an entity was being deleted as part of round-end which would cause
+        // https://github.com/moff-station/moff-station-14/issues/1293 (or something like it) due to adding entities
+        // during state application, which iterates over existing entities.
+        var q = AllEntityQuery<NightVisionComponent, DirtyNightVisionComponent>();
+        while (q.MoveNext(out var ent, out var comp, out _))
+        {
+            if (comp.Effect != null)
+                continue;
+
+            _overlayMan.AddOverlay(new NightVisionOverlay());
+            var effect = SpawnAttachedTo(comp.EffectPrototype, Transform(ent).Coordinates);
+            _xformSys.SetParent(effect, ent);
+            comp.Effect = effect;
+            RemCompDeferred<DirtyNightVisionComponent>(ent);
+        }
     }
 }

--- a/Content.Shared/_Moffstation/Clothing/ModularHud/Systems/SharedModularHudSystem.cs
+++ b/Content.Shared/_Moffstation/Clothing/ModularHud/Systems/SharedModularHudSystem.cs
@@ -8,7 +8,6 @@ using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.Flash;
-using Content.Shared.Foldable;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement.Components;
 using Content.Shared.Interaction;

--- a/Content.Shared/_Moffstation/NightVision/NightVisionComponent.cs
+++ b/Content.Shared/_Moffstation/NightVision/NightVisionComponent.cs
@@ -1,7 +1,7 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
-namespace Content.Shared._Moffstation.Overlay.Components;
+namespace Content.Shared._Moffstation.NightVision;
 
 /// When this component is on a player-controlled entity, it applies a night vision visual effect
 /// (<see cref="Content.Client._Starlight.Overlay.NightVisionOverlay"/>) and creates a
@@ -12,7 +12,7 @@ public sealed partial class NightVisionComponent : Component
     [DataField, AutoNetworkedField]
     public EntProtoId EffectPrototype = "EffectNightVision";
 
-    /// The instance of <see cref="EffectPrototype"/>..
+    /// The instance of <see cref="EffectPrototype"/>.
     [ViewVariables]
     public EntityUid? Effect;
 }


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Maybe fixes #1293 ?
Through great effort, I tracked down what was causing _one_ `concurrent modification of enumerable` issue, though I'm not sure it's what we're seeing all the time.
Basically, while applying state from the server, the client will enumerate over all `MetadataComponent`s on the client, and if something on the client adds a new entity, a new metadata component is added to the same enumerable, causing the issue. In this case, it's because modular HUDs get their modules removed, which triggers flash immunity to fall off of a resomi captain's glasses, meaning the nightvision effect (an entity) is spawned in the middle of state application.

The smoking gun.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix good

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
I explained the justification above.
My solution is twofold:
- move to a "mark and make changes in `update`" pattern
- avoid modifying nightvision application with a `firstTimePredicted` 
  - because the above change introduced effect flicker when putting on glasses. Very gross.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
Not player facing


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
