### PR TITLE
Turn off automatic map votes during integration tests

### DIFF
--- a/Content.IntegrationTests/Pair/TestPair.cs
+++ b/Content.IntegrationTests/Pair/TestPair.cs
@@ -5,6 +5,7 @@ using Content.Client.Parallax.Managers;
 using Content.IntegrationTests.Tests.Destructible;
 using Content.IntegrationTests.Tests.DeviceNetwork;
 using Content.Server.GameTicking;
+using Content.Shared._Moffstation.CCVar;
 using Content.Shared.CCVar;
 using Content.Shared.Players;
 using Robust.Shared.ContentPack;
@@ -36,6 +37,14 @@ public sealed partial class TestPair : RobustIntegrationTest.TestPair
             if (e.System is SharedMapSystem map)
                 map.Log.Level = LogLevel.Warning;
         };
+
+        // Moffstation - Begin - Disable map vote on restart for integration tests as it tries to send vote net messages to dummy clients.
+        await Server.WaitPost(() =>
+        {
+            Server.Log.Info($"Resetting cvar {MoffCCVars.AutoStartMapVote.Name} to {false}");
+                Server.CfgMan.SetCVar(MoffCCVars.AutoStartMapVote, false);
+        });
+        // Moffstation - End
 
         var settings = (PoolSettings)Settings;
         if (!settings.DummyTicker)


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We're seeing intermittent CI failures on other PRs where the vote manager is trying to send net messages to clients, and that throws exceptions because the clients are fake dummies with stub connections which throw when they get messages sent to them.
My guess is that the map votes when rounds restart are the net messages being sent, so turning off the automatic votes stops the exceptions.
Hopefully.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Add a cvar turn-off in integration test pair acquisition.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
fuck if I know, mang; this is all about HUNCHES and VIBES.
If we still see the net "Not implemented" issues in other PRs after this, we should probably revert this.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
n/a


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
