### PR TITLE
Paradox clone integration test fix

### DIFF
--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -1,14 +1,14 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Server.Station.Components;
-using Content.Shared._Moffstation.Pirate.Components; // Moffstation
+using Content.Shared._Moffstation.Pirate.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Station.Components;
 using Robust.Shared.Collections;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
-using Content.Shared._Moffstation.Extensions;
+using Robust.Shared.Utility;
 
 namespace Content.Server.GameTicking.Rules;
 

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -8,6 +8,7 @@ using Content.Shared.Station.Components;
 using Robust.Shared.Collections;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Content.Shared._Moffstation.Extensions;
 
 namespace Content.Server.GameTicking.Rules;
 

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -135,6 +135,7 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
 // Moffstation - Start - Paradox Clone integration test fix
         if (!found)
         {
+            this.AssertOrLogError("Failed to pick suitable random location for paradox clone spawn. Resorting to brute enumeration of tiles");
             // Fallback: iterate all tiles on the grid systematically
             // Collect valid positions and shuffle so it's not the same spot every time
             var validTiles = new List<Vector2i>();

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -116,7 +116,7 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
         var found = false;
         var aabb = gridComp.LocalAABB;
 
-        for (var i = 0; i < 10; i++)
+        for (var i = 0; i < 100; i++) //Moffstation paradox clone integration test fix
         {
             var randomX = RobustRandom.Next((int) aabb.Left, (int) aabb.Right);
             var randomY = RobustRandom.Next((int) aabb.Bottom, (int) aabb.Top);
@@ -132,7 +132,23 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
             targetCoords = _map.GridTileToLocal(targetGrid, gridComp, tile);
             break;
         }
-
+// Moffstation - Start - Paradox Clone integration test fix
+        if (!found)
+        {
+            // Fallback: iterate all tiles on the grid systematically
+            foreach (var gridTile in _map.GetAllTiles(targetGrid, gridComp))
+            {
+                var pos = gridTile.GridIndices;
+                if (!_atmosphere.IsTileSpace(targetGrid, Transform(targetGrid).MapUid, pos)
+                    && !_atmosphere.IsTileAirBlockedCached(targetGrid, pos))
+                {
+                    tile = pos;
+                    targetCoords = _map.GridTileToLocal(targetGrid, gridComp, tile);
+                    return true;
+                }
+            }
+        }
+// Moffstation - End
         return found;
     }
 

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -133,31 +133,30 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
             targetCoords = _map.GridTileToLocal(targetGrid, gridComp, tile);
             break;
         }
-// Moffstation - Start - Paradox Clone integration test fix
+
+        // Moffstation - Start - Paradox Clone integration test fix
+        // Fallback: iterate all tiles on the grid systematically, picking a random one as the target coords.
         if (!found)
         {
-            this.AssertOrLogError("Failed to pick suitable random location for paradox clone spawn. Resorting to brute enumeration of tiles");
-            // Fallback: iterate all tiles on the grid systematically
-            // Collect valid positions and shuffle so it's not the same spot every time
-            var validTiles = new List<Vector2i>();
-            foreach (var gridTile in _map.GetAllTiles(targetGrid, gridComp))
+            Log.Warning(
+                "Failed to pick suitable random location for paradox clone spawn. Resorting to brute enumeration of tiles");
+            var tGrid = targetGrid; // Rebind to local to use in lambdas.
+            var map = Transform(tGrid).MapUid;
+            var allValidCoords = _map.GetAllTiles(targetGrid, gridComp)
+                .Select(t => t.GridIndices)
+                .Where(index => !(_atmosphere.IsTileSpace(tGrid, map, index)
+                                  || _atmosphere.IsTileAirBlockedCached(tGrid, index)))
+                .ToList();
+
+            RobustRandom.Shuffle(allValidCoords);
+            if (allValidCoords.TryFirstOrNull(out var first))
             {
-                var pos = gridTile.GridIndices;
-                if (!_atmosphere.IsTileSpace(targetGrid, Transform(targetGrid).MapUid, pos)
-                    && !_atmosphere.IsTileAirBlockedCached(targetGrid, pos))
-                {
-                    validTiles.Add(pos);
-                }
-            }
-            if (validTiles.Count > 0)
-            {
-                RobustRandom.Shuffle(validTiles);
-                tile = validTiles[0];
-                targetCoords = _map.GridTileToLocal(targetGrid, gridComp, tile);
-                return true;
+                found = true;
+                targetCoords = _map.GridTileToLocal(tGrid, gridComp, first.Value);
             }
         }
-// Moffstation - End
+        // Moffstation - End
+
         return found;
     }
 

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Server.Station.Components;
@@ -136,8 +135,6 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
 // Moffstation - Start - Paradox Clone integration test fix
         if (!found)
         {
-            var sw = Stopwatch.StartNew();
-
             // Fallback: iterate all tiles on the grid systematically
             // Collect valid positions and shuffle so it's not the same spot every time
             var validTiles = new List<Vector2i>();
@@ -150,10 +147,6 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
                     validTiles.Add(pos);
                 }
             }
-
-            sw.Stop();
-            Log.Info($"TryFindRandomTileOnStation fallback scanned {validTiles.Count} valid tiles in {sw.Elapsed.TotalMilliseconds:F1}ms");
-
             if (validTiles.Count > 0)
             {
                 RobustRandom.Shuffle(validTiles);

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Server.Station.Components;
@@ -135,17 +136,30 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
 // Moffstation - Start - Paradox Clone integration test fix
         if (!found)
         {
+            var sw = Stopwatch.StartNew();
+
             // Fallback: iterate all tiles on the grid systematically
+            // Collect valid positions and shuffle so it's not the same spot every time
+            var validTiles = new List<Vector2i>();
             foreach (var gridTile in _map.GetAllTiles(targetGrid, gridComp))
             {
                 var pos = gridTile.GridIndices;
                 if (!_atmosphere.IsTileSpace(targetGrid, Transform(targetGrid).MapUid, pos)
                     && !_atmosphere.IsTileAirBlockedCached(targetGrid, pos))
                 {
-                    tile = pos;
-                    targetCoords = _map.GridTileToLocal(targetGrid, gridComp, tile);
-                    return true;
+                    validTiles.Add(pos);
                 }
+            }
+
+            sw.Stop();
+            Log.Info($"TryFindRandomTileOnStation fallback scanned {validTiles.Count} valid tiles in {sw.Elapsed.TotalMilliseconds:F1}ms");
+
+            if (validTiles.Count > 0)
+            {
+                RobustRandom.Shuffle(validTiles);
+                tile = validTiles[0];
+                targetCoords = _map.GridTileToLocal(targetGrid, gridComp, tile);
+                return true;
             }
         }
 // Moffstation - End


### PR DESCRIPTION
## About the PR
Now the Antag Spawners Check 100 tiles and also have a fallback instead of giving up

## Why / Balance
caused seemingly random test failures cause 10 tiles on reach is prone to failing

## Technical details
as said before it now checks 100 tiles first and after doing so it moves to shuffling the list of all tiles on the grid that gets created earlier, and then picking one. (Stress testing by running the command every 20ms and forcing the fallback revealed the fallback takes at most 13ms so no performances killers or anything)

## Test plan
<!--
-Uh watch the integration test not fail :godo:
-->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] Lack Sleep
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
nu uh 