### PR TITLE
Integration antag weight fix

### DIFF
--- a/Content.IntegrationTests/Pair/TestPair.cs
+++ b/Content.IntegrationTests/Pair/TestPair.cs
@@ -4,7 +4,10 @@ using Content.Client.IoC;
 using Content.Client.Parallax.Managers;
 using Content.IntegrationTests.Tests.Destructible;
 using Content.IntegrationTests.Tests.DeviceNetwork;
+using Content.IntegrationTests._Moffstation.Antag; //Moffstation
+using Content.Server._Moffstation.Antag; //Moffstation
 using Content.Server.GameTicking;
+using Content.Server.IoC; //Moffstation
 using Content.Shared.CCVar;
 using Content.Shared.Players;
 using Robust.Shared.ContentPack;
@@ -121,6 +124,13 @@ public sealed partial class TestPair : RobustIntegrationTest.TestPair
             var entSysMan = IoCManager.Resolve<IEntitySystemManager>();
             entSysMan.LoadExtraSystemType<DeviceNetworkTestSystem>();
             entSysMan.LoadExtraSystemType<TestDestructibleListenerSystem>();
+
+            // Moffstation - Start - Dummy Antag Weights
+            IoCManager.Resolve<IModLoader>().SetModuleBaseCallbacks(new ServerModuleTestingCallbacks
+            {
+                ServerBeforeIoC = () => IoCManager.Register<IWeightedAntagManager, DummyWeightedAntagManager>(true)
+            });
+            // Moffstation - End
         };
         return opts;
     }

--- a/Content.IntegrationTests/_Moffstation/Antag/DummyWeightedAntagManager.cs
+++ b/Content.IntegrationTests/_Moffstation/Antag/DummyWeightedAntagManager.cs
@@ -1,0 +1,13 @@
+using Content.Server._Moffstation.Antag;
+using Robust.Shared.Network;
+
+namespace Content.IntegrationTests._Moffstation.Antag;
+
+public sealed class DummyWeightedAntagManager : IWeightedAntagManager
+{
+    public void Initialize() { }
+    public void Shutdown() { }
+    public void SetWeight(NetUserId userId, int newWeight) { }
+    public int GetWeight(NetUserId userId) => 0;
+    public System.Threading.Tasks.Task Save() => System.Threading.Tasks.Task.CompletedTask;
+}

--- a/Content.IntegrationTests/_Moffstation/Antag/DummyWeightedAntagManager.cs
+++ b/Content.IntegrationTests/_Moffstation/Antag/DummyWeightedAntagManager.cs
@@ -6,15 +6,12 @@ namespace Content.IntegrationTests._Moffstation.Antag;
 
 public sealed class DummyWeightedAntagManager : IWeightedAntagManager
 {
-    private readonly ISawmill _logger;
+    private readonly ISawmill _logger = Logger.GetSawmill("antag_weight");
 
-    public DummyWeightedAntagManager()
+    public void Initialize()
     {
-        _logger = Logger.GetSawmill("antag_weight");
         _logger.Info("Using DummyWeightedAntagManager — antag weights will not be persisted");
     }
-
-    public void Initialize() { }
     public void Shutdown() { }
     public void SetWeight(NetUserId userId, int newWeight) { }
     public int GetWeight(NetUserId userId) => 0;

--- a/Content.IntegrationTests/_Moffstation/Antag/DummyWeightedAntagManager.cs
+++ b/Content.IntegrationTests/_Moffstation/Antag/DummyWeightedAntagManager.cs
@@ -1,10 +1,19 @@
 using Content.Server._Moffstation.Antag;
+using Robust.Shared.Log;
 using Robust.Shared.Network;
 
 namespace Content.IntegrationTests._Moffstation.Antag;
 
 public sealed class DummyWeightedAntagManager : IWeightedAntagManager
 {
+    private readonly ISawmill _logger;
+
+    public DummyWeightedAntagManager()
+    {
+        _logger = Logger.GetSawmill("antag_weight");
+        _logger.Info("Using DummyWeightedAntagManager — antag weights will not be persisted");
+    }
+
     public void Initialize() { }
     public void Shutdown() { }
     public void SetWeight(NetUserId userId, int newWeight) { }

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -74,7 +74,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     [Dependency] private RoleSystem _role = default!;
     [Dependency] private TransformSystem _transform = default!;
 
-    [Dependency] private WeightedAntagManager _weightedAntagMan = default!; // Moffstation
+    [Dependency] private IWeightedAntagManager _weightedAntagMan = default!; //Moffstation Dummy Antag Weights
 
     // arbitrary random number to give late joining some mild interest.
     public const float LateJoinRandomChance = 0.5f;

--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -83,7 +83,7 @@ namespace Content.Server.Entry
         [Dependency] private ServerUpdateManager _updateManager = default!;
         [Dependency] private ServerFeedbackManager _feedbackManager = null!;
 
-        [Dependency] private WeightedAntagManager _weightedAntags = default!; // Moffstation
+        [Dependency] private IWeightedAntagManager _weightedAntags = default!; // Moffstation
 
         public override void PreInit()
         {

--- a/Content.Server/IoC/ServerContentIoC.cs
+++ b/Content.Server/IoC/ServerContentIoC.cs
@@ -83,6 +83,6 @@ internal static class ServerContentIoC
         deps.Register<DiscordChatLink>();
         deps.Register<ServerFeedbackManager>();
         deps.Register<ISharedFeedbackManager, ServerFeedbackManager>();
-        deps.Register<WeightedAntagManager>();
+        deps.Register<IWeightedAntagManager, WeightedAntagManager>(); //Moffstaion - Dummy Antag Manager for Integration tests
     }
 }

--- a/Content.Server/_Moffstation/Antag/Commands/AntagWeights.cs
+++ b/Content.Server/_Moffstation/Antag/Commands/AntagWeights.cs
@@ -12,7 +12,7 @@ namespace Content.Server._Moffstation.Antag.Commands;
 public sealed partial class AntagWeights : LocalizedEntityCommands
 {
     [Dependency] private IPlayerManager _players = default!;
-    [Dependency] private WeightedAntagManager _antagWeight = default!;
+    [Dependency] private IWeightedAntagManager _antagWeight = default!; //Moffstation Dummy Antag Weights
 
     public override string Command => "antagweights";
 
@@ -43,7 +43,7 @@ public sealed partial class AntagWeights : LocalizedEntityCommands
 public sealed partial class SetAntagWeight : LocalizedEntityCommands
 {
     [Dependency] private IPlayerManager _players = default!;
-    [Dependency] private WeightedAntagManager _antagWeight = default!;
+    [Dependency] private IWeightedAntagManager _antagWeight = default!; //Moffstation Dummy Antag Weights
     [Dependency] private IAdminLogManager _adminLogger = default!;
 
     public override string Command => "setantagweight";

--- a/Content.Server/_Moffstation/Antag/IWeightedAntagManager.cs
+++ b/Content.Server/_Moffstation/Antag/IWeightedAntagManager.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using Robust.Shared.Network;
+
+namespace Content.Server._Moffstation.Antag;
+
+public interface IWeightedAntagManager
+{
+    void Initialize();
+    void Shutdown();
+    void SetWeight(NetUserId userId, int newWeight);
+    int GetWeight(NetUserId userId);
+    Task Save();
+}

--- a/Content.Server/_Moffstation/Antag/WeightedAntagManager.cs
+++ b/Content.Server/_Moffstation/Antag/WeightedAntagManager.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Network;
 
 namespace Content.Server._Moffstation.Antag;
 
-public sealed partial class WeightedAntagManager
+public sealed partial class WeightedAntagManager : IWeightedAntagManager //Moffstation - Dummay Weighted Antags
 {
     [Dependency] private IServerDbManager _db = default!;
     [Dependency] private ITaskManager _taskManager = default!;


### PR DESCRIPTION
## About the PR
Integration tests now use a Dummy Antag Weigth Manager so resolve Test Failures
## Why / Balance
Was Causing Intermitten Test Failures

## Technical details
Added an Interface for the Antag Weigth Manager,
added a Dummy Antag Weigth manager that while satifying all coditions to be used like the normal one, Funktional does nothing at all

## Test plan
-Run Integration tests
-Watch them succed
-Check the AntagGhostrole test to see if the [INFO] log letting you know that the dummy weights are used actualy works

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X ] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] have 2 Beers ready incase Centronias wants changes
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->