### PR TITLE
Personal items for borgs

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -119,7 +119,7 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
             // Make sure custom names get handled, what is gameticker control flow whoopy.
             if (loadout != null)
             {
-                EquipRoleName(jobEntity, loadout, roleProto!);
+                EquipSpecialRoleLoadout(jobEntity, loadout, roleProto!); // Moffstation - Enable special loadouts by job
             }
 
             DoJobSpecials(job, jobEntity);

--- a/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
@@ -59,7 +59,7 @@ public sealed partial class LoadoutPrototype : IPrototype, IEquipmentLoadout
     // Moffstation - Begin - Special loadouts; enables eg. personal items on cyborgs
     /// A dictfrom <see cref="JobPrototype.JobEntity"/> to special loadouts to apply to them.
     [DataField]
-    public Dictionary<ProtoId<JobPrototype>, SpecialLoadout> SpecialJobLoadouts = new();
+    public Dictionary<ProtoId<RoleLoadoutPrototype>, SpecialLoadout> SpecialJobLoadouts = new();
     // Moffstation - End
 }
 

--- a/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
@@ -55,4 +55,25 @@ public sealed partial class LoadoutPrototype : IPrototype, IEquipmentLoadout
     /// <inheritdoc />
     [DataField]
     public Dictionary<string, List<EntProtoId>> Storage { get; set; } = new();
+
+    // Moffstation - Begin - Special loadouts; enables eg. personal items on cyborgs
+    /// A dictfrom <see cref="JobPrototype.JobEntity"/> to special loadouts to apply to them.
+    [DataField]
+    public Dictionary<ProtoId<JobPrototype>, SpecialLoadout> SpecialJobLoadouts = new();
+    // Moffstation - End
 }
+
+// Moffstation - Begin - Special loadouts enable loadouts for non-humanoid jobs. I hope that we get to delete this someday thanks to comprehensive loadout improvements!
+[DataDefinition]
+public sealed partial class SpecialLoadout : IEquipmentLoadout
+{
+    [DataField]
+    public Dictionary<string, EntProtoId> Equipment { get; set; } = new();
+
+    [DataField]
+    public List<EntProtoId> Inhand { get; set; } = new();
+
+    [DataField]
+    public Dictionary<string, List<EntProtoId>> Storage { get; set; } = new();
+}
+// Moffstation - Begin

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -52,6 +52,31 @@ public abstract partial class SharedStationSpawningSystem : EntitySystem
         EquipRoleName(entity, loadout, roleProto);
     }
 
+    // Moffstation - Begin - Enable special per-role loadouts on loadout protos. Enables personal items on cyborgs.
+    public void EquipSpecialRoleLoadout(EntityUid entity, RoleLoadout loadout, RoleLoadoutPrototype roleProto)
+    {
+        // Order loadout selections by the order they appear on the prototype.
+        foreach (var group in loadout.SelectedLoadouts.OrderBy(x => roleProto.Groups.FindIndex(e => e == x.Key)))
+        {
+            foreach (var items in group.Value)
+            {
+                if (!PrototypeManager.TryIndex(items.Prototype, out var loadoutProto))
+                {
+                    Log.Error($"Unable to find loadout prototype for {items.Prototype}");
+                    continue;
+                }
+
+                if (loadoutProto.SpecialJobLoadouts.TryGetValue(roleProto.ID, out var specialLoadout))
+                {
+                    EquipStartingGear(entity, specialLoadout, raiseEvent: false);
+                }
+            }
+        }
+
+        EquipRoleName(entity, loadout, roleProto);
+    }
+    // Moffstation - End
+
     /// <summary>
     /// Applies the role's name as applicable to the entity.
     /// </summary>

--- a/Content.Shared/_Umbra/Preferences/Loadouts/Effects/PersonalItemLoadoutEffect.cs
+++ b/Content.Shared/_Umbra/Preferences/Loadouts/Effects/PersonalItemLoadoutEffect.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Shared.Preferences;
 using Content.Shared.Preferences.Loadouts;
 using Content.Shared.Preferences.Loadouts.Effects;
@@ -28,17 +29,11 @@ public sealed partial class PersonalItemLoadoutEffect : LoadoutEffect
         RoleLoadout loadout,
         ICommonSession? session,
         IDependencyCollection collection,
-        [NotNullWhen(false)] out FormattedMessage? reason)
+        [NotNullWhen(false)] out FormattedMessage? reason
+    )
     {
-        var foundMatchingName = false;
-        foreach (var name in CharacterName)
-        {
-            if (name.Equals(profile.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                foundMatchingName = true;
-                break;
-            }
-        }
+        var loadoutName = loadout.EntityName ?? profile.Name;
+        var foundMatchingName = CharacterName.Any(it => it.Equals(loadoutName, StringComparison.OrdinalIgnoreCase));
 
         if (!foundMatchingName)
         {
@@ -50,15 +45,9 @@ public sealed partial class PersonalItemLoadoutEffect : LoadoutEffect
 
         if (!(Jobs.Count == 0 || Jobs.Contains(loadout.Role)))
         {
-            var jobNames = new List<string>();
-            foreach (var jobId in Jobs)
-            {
-                jobNames.Add(Loc.GetString(jobId));
-            }
-
             reason = FormattedMessage.FromUnformatted(Loc.GetString(
                 "loadout-personalitem-joblocked",
-                ("job", string.Join(", ", jobNames)),
+                ("job", string.Join(", ", Jobs.Select(it => Loc.GetString(it)))),
                 ("received", Loc.GetString(loadout.Role))));
 
             return false;

--- a/Resources/Prototypes/Loadouts/RoleLoadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/RoleLoadouts/role_loadouts.yml
@@ -38,6 +38,10 @@
   id: JobBorg
   nameDataset: NamesBorg
   canCustomizeName: true
+  # Moffstation - Begin - Borgs can get personal items
+  groups:
+  - PersonalItemsJobAgnostic # Umbra
+  # Moffstation - End
 
 - type: roleLoadout
   id: JobStationAi

--- a/Resources/Prototypes/_Moffstation/PersonalItems/Wearables/privatemumbles/Bintendo/bintendohat.yml
+++ b/Resources/Prototypes/_Moffstation/PersonalItems/Wearables/privatemumbles/Bintendo/bintendohat.yml
@@ -19,6 +19,10 @@
   storage:
     back:
     - PersonalItemBintendoHat
+  specialJobLoadouts:
+    JobBorg:
+      equipment:
+        head: PersonalItemBintendoHat
   effects:
   - !type:PersonalItemLoadoutEffect
     character:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Strictly, this enables arbitrary loadout stuff on arbitrary non-humanoid roles, so you could, in theory, equip something to a xenoborg mothership core, but I've only tested it with borgs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
At least one cyborg player likes to use a personal item on their cyborg, and presently that requires an ahelp to get working.
This both enables player expression and alleviates burden on admins.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
- Add field to loadout prototype which allows for specifying hands, equipment and storage loadout items for nonstandard jobs, by the job proto ID.
- Add function to the loadout system which actually handles spawning + equipping these items
- Small modification to the codepath which spawns cyborgs (and other non-humanoid players) to actually apply the new loadout stuff above
- Modify the personal loadout effect so that it allows for using the loadout item if the name _override_ on the loadout matches the name on the effect. So this'd mean you could have `Kazakadrixri` as the profile name, `Nomenclatura` as the loadout name, and then use a personal item with the name `Nomenclatura` in its requirements; because the loadout matches the requirement.
- Tested it on Bintendo's hat

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Load client+server
`golobby`
Edit cyborg loadout:
- name: `Bintendo`
- select Bintendo's Hat from personal items

Turn on random characters cvar
Set map to Amber
Start round
Join as cyborg
Note that Bintendo wears Bintendo's hat

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

https://github.com/user-attachments/assets/c01cdf5b-0f48-42ed-8c86-612e01f2d13e

<img width="583" height="301" alt="image" src="https://github.com/user-attachments/assets/b657d869-ff84-4afb-bf57-f88ab7c9e47b" />

Demo that you can see Bintendo's hat as equippable whjen the underlying profile isn't `Bintendo`

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a; addative

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- add: Cyborgs can now select personal items as part of their loadout
- tweak: The requirement that a character's name must match a personal item's owner is slightly relaxed to also allow selecting the personal item if the LOADOUT name matches the personal item's owner. For example, a cyborg with a loadout name override matching a personal item can use that personal item even if the normal humanoid name of the profile does not match.
- add: Bintendo's hat can spawn on a cyborg's head if it's selected.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
