### PR TITLE
Expand Ai Whitelist to Shuttle consoles, Lathes, Smes's, Substations, and Daws

### DIFF
--- a/Resources/Locale/en-US/_Moffstation/wires/wire-names.ftl
+++ b/Resources/Locale/en-US/_Moffstation/wires/wire-names.ftl
@@ -1,0 +1,4 @@
+﻿wires-board-name-smes = SMES
+wires-board-name-substation = Substation
+wires-board-name-lathe = Lathe
+wires-board-name-daw = Digital Audio Workstation

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -456,7 +456,7 @@
     - HideContextMenu
     - StationAi
     - NoConsoleSound
-    - CanPilot #Moffstation - Expanded Ai Whitelist
+    - CanPilot # Moffstation - Expanded Ai Whitelist
   - type: StartingMindRole
     mindRole: "MindRoleSiliconBrain"
     silent: true

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -456,6 +456,7 @@
     - HideContextMenu
     - StationAi
     - NoConsoleSound
+    - CanPilot #Moffstation - Expanded Ai Whitelist
   - type: StartingMindRole
     mindRole: "MindRoleSiliconBrain"
     silent: true

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
@@ -168,3 +168,4 @@
   - type: Instrument
     allowPercussion: true
     allowProgramChange: true
+  - type: StationAiWhitelist #Moffstation - Expanded Station AI Whitelist

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
@@ -168,4 +168,15 @@
   - type: Instrument
     allowPercussion: true
     allowProgramChange: true
-  - type: StationAiWhitelist #Moffstation - Expanded Station AI Whitelist
+  # Moffstation - Begin - Expanded Ai Whitelist
+  - type: StationAiWhitelist
+  - type: Wires
+    boardName: wires-board-name-daw
+    layoutId: ComputerAi
+  - type: UserInterface
+    interfaces:
+      enum.InstrumentUiKey.Key:
+        type: InstrumentBoundUserInterface
+      enum.WiresUiKey.Key:
+        type: WiresBoundUserInterface
+  # Moffstation - End

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -114,7 +114,7 @@
     color: "#43ccb5"
 
 - type: entity
-  parent: BaseComputer
+  parent: BaseComputerAiAccess # Moffstation - Expanded Ai whitelist
   id: BaseComputerShuttle
   name: shuttle console
   description: Used to pilot a shuttle.

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -54,7 +54,7 @@
   - type: PowerState
     idlePowerDraw: 150
     workingPowerDraw: 1000
-  - type: StationAiWhitelist #Moffstation - Expanded Ai Whitelist
+  - type: StationAiWhitelist # Moffstation - Expanded Ai Whitelist
   # Moffstation - Start
   - type: DeviceLinkSink
     ports:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -42,6 +42,10 @@
         type: LatheBoundUserInterface
       enum.ResearchClientUiKey.Key:
         type: ResearchClientBoundUserInterface
+      # Moffstation - Begin - Expanded Ai Whitelist
+      enum.WiresUiKey.Key:
+        type: WiresBoundUserInterface
+      # Moffstation - End
   - type: Transform
     anchored: true
   - type: Pullable
@@ -54,7 +58,12 @@
   - type: PowerState
     idlePowerDraw: 150
     workingPowerDraw: 1000
-  - type: StationAiWhitelist # Moffstation - Expanded Ai Whitelist
+  # Moffstation - Begin - Expanded Ai Whitelist
+  - type: StationAiWhitelist
+  - type: Wires
+    boardName: wires-board-name-lathe
+    layoutId: ComputerAi
+  # Moffstation - End
   # Moffstation - Start
   - type: DeviceLinkSink
     ports:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -54,6 +54,7 @@
   - type: PowerState
     idlePowerDraw: 150
     workingPowerDraw: 1000
+  - type: StationAiWhitelist #Moffstation - Expanded Ai Whitelist
   # Moffstation - Start
   - type: DeviceLinkSink
     ports:

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -105,8 +105,9 @@
     # Impstation - Start
     - type: AccessReader
       access: [["Engineering"]]
-    - type: ActivatableUIRequiresAccess 
+    - type: ActivatableUIRequiresAccess
     # Impstation - End
+    - type: StationAiWhitelist #Moffstation - Expanded Ai Whitelist
 
     # Interface
     - type: BatteryInterface

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -107,7 +107,7 @@
       access: [["Engineering"]]
     - type: ActivatableUIRequiresAccess
     # Impstation - End
-    - type: StationAiWhitelist #Moffstation - Expanded Ai Whitelist
+    - type: StationAiWhitelist # Moffstation - Expanded Ai Whitelist
 
     # Interface
     - type: BatteryInterface

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -75,6 +75,11 @@
       castShadows: false
     - type: WiresPanel
     - type: WiresVisuals
+    # Moffstation - Begin - Expanded Ai Whitelist
+    - type: Wires
+      boardName: wires-board-name-smes
+      layoutId: ComputerAi
+    # Moffstation - End
     - type: Machine
       board: SMESMachineCircuitboard
     - type: StationInfiniteBatteryTarget
@@ -119,6 +124,10 @@
       interfaces:
         enum.BatteryUiKey.Key:
           type: BatteryBoundUserInterface
+        # Moffstation - Begin - Expanded Ai Whitelist
+        enum.WiresUiKey.Key:
+          type: WiresBoundUserInterface
+        # Moffstation - End
     - type: ActivatableUI
       key: enum.BatteryUiKey.Key
 

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -46,6 +46,10 @@
     interfaces:
       enum.BatteryUiKey.Key:
         type: BatteryBoundUserInterface
+      # Moffstation - Begin - Expanded Ai Whitelist
+      enum.WiresUiKey.Key:
+        type: WiresBoundUserInterface
+      # Moffstation - End
   - type: ActivatableUI
     key: enum.BatteryUiKey.Key
 
@@ -150,7 +154,12 @@
     requirePower: true
     highVoltageNode: input
     mediumVoltageNode: output
-  - type: StationAiWhitelist # Moffstation - Expanded Ai Whitelist
+  # Moffstation - Begin - Expanded Ai Whitelist
+  - type: StationAiWhitelist
+  - type: Wires
+    boardName: wires-board-name-substation
+    layoutId: ComputerAi
+  # Moffstation - End
 
 # Compact Wall Substation Base
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -33,7 +33,7 @@
   # Impstation - Start
   - type: AccessReader
     access: [["Engineering"]]
-  - type: ActivatableUIRequiresAccess 
+  - type: ActivatableUIRequiresAccess
   # Impstation - End
 
   # Interface
@@ -150,6 +150,7 @@
     requirePower: true
     highVoltageNode: input
     mediumVoltageNode: output
+  - type: StationAiWhitelist #Moffstation - Expanded Ai Whitelist
 
 # Compact Wall Substation Base
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -150,7 +150,7 @@
     requirePower: true
     highVoltageNode: input
     mediumVoltageNode: output
-  - type: StationAiWhitelist #Moffstation - Expanded Ai Whitelist
+  - type: StationAiWhitelist # Moffstation - Expanded Ai Whitelist
 
 # Compact Wall Substation Base
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -57,6 +57,7 @@
     - type: GuideHelp
       guides:
       - ShuttleCraft
+    - type: StationAiWhitelist #Moffstation - Expanded Ai Whitelist
   placement:
     mode: SnapgridCenter
 

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -57,7 +57,6 @@
     - type: GuideHelp
       guides:
       - ShuttleCraft
-    - type: StationAiWhitelist #Moffstation - Expanded Ai Whitelist
   placement:
     mode: SnapgridCenter
 


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
I added the StationAiWhitelist component to shuttle consoles, lathes, smes's, substations, daws, and added the CanPilot tag to the Station Ai itself

## Why / Balance
Shuttle consoles: Given the stated direction of Moff moving towards more event driven gameplay, necessarily a lot of those events will involve shuttles coming and going from the station (IE: the Event Actors design doc mentions shuttles in its considerations and keeping the pool full sections). Giving developers the option to add "station" ais to the shuttles, will, I think, help provide diversity in said events. As the game is currently, for most rounds the biggest change would be the AIs ability to remotely pilot the cargo shuttle via the cargo shuttle console, which I also think is a positive change. Additionally, it can lead to more fun interactions/gimmicks, IE: Pirates stealing the stations ai and installing it onto their shuttle. Adding the CanPilot Tag is also necessary to allow piloting shuttles to actually work.

Substations/Smes's: The biggest reason these are not whitelisted upstream is to prevent easy loosing. Given our nature as a whitelisted server, this is less of an issue, and it just makes sense for the AI to be able to use these. I view this as similar to changes we have made like removing emitter warnings. Using substations and SMES's can also be important for piloting shuttles under limited power supplies.

Lathes: This is mostly QOL: seeing if something is printable via the lathe is a lot easier then searching the research list for it, and it just makes sense for the AI to be able to use these. It also adds sabotage potential via hyperlathes.

Daws: Its a DIGITAL audio workstation, and it adds another reason to go through the complicated process of building one.

## Technical details
Just yaml

## Test plan
On the Dev map, spawn and take over an Ai core on the shuttle. Fly it around, and FTL it. Spawn lathes, a DAW, and substations and SMES to test and see if the whitelist works. Cut the ai wire on the shuttle console, and ensure the AI can no longer pilot the shuttle. Cut the AI wires on the lathes, the DAW, the substation and the SMES and ensure the AI cannot access them.

## Media
<img width="1427" height="990" alt="image" src="https://github.com/user-attachments/assets/a88e2e10-59fa-4334-a03e-72109eda9cea" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x ] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x ] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x ] I have tested this pull request and written instructions on how to test it
- [ x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog

:cl:
- tweak: Allowed the Station Ai to use Lathes, Substations, Smes banks, Digital Audio Workstations, and pilot shuttles.
- tweak: Added AI access and Power wires to Lathes, Substations SMES banks, and Digital Audio Workstations

