### PR TITLE
Make secure lockers harder to steal

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
@@ -66,6 +66,11 @@
     damageModifierSet: StructuralMetallic
   - type: Injurable
     damageContainer: StructuralInorganic
+  # Moffstation - Begin - Make secure lockers harder to steal
+  - type: LockedAnchorable
+  - type: Transform
+    anchored: true
+  # Moffstation - End
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
@@ -70,6 +70,8 @@
   - type: LockedAnchorable
   - type: Transform
     anchored: true
+  - type: Physics
+    bodyType: Static
   # Moffstation - End
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -31,11 +31,6 @@
     stateBaseClosed: secure
     stateDoorOpen: secure_open
     stateDoorClosed: secure_door
-  # Moffstation - Begin - Make secure lockers harder to steal
-  - type: LockedAnchorable
-  - type: Transform
-    anchored: true
-  # Moffstation - End
 
 # Cargo
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -77,7 +77,7 @@
   - type: LockedAnchorable
   - type: Transform
     anchored: true
-    #Moffstation - End
+  # Moffstation - End
 
 - type: entity
   id: LockerHeadOfPersonnel

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -73,6 +73,11 @@
     stateDoorClosed: cap_door
   - type: AccessReader
     access: [["Captain"]]
+  # Moffstation - Make captains locker harder to steal
+  - type: LockedAnchorable
+  - type: Transform
+    anchored: true
+    #Moffstation - End
 
 - type: entity
   id: LockerHeadOfPersonnel

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -31,6 +31,11 @@
     stateBaseClosed: secure
     stateDoorOpen: secure_open
     stateDoorClosed: secure_door
+  # Moffstation - Begin - Make secure lockers harder to steal
+  - type: LockedAnchorable
+  - type: Transform
+    anchored: true
+  # Moffstation - End
 
 # Cargo
 - type: entity
@@ -73,11 +78,6 @@
     stateDoorClosed: cap_door
   - type: AccessReader
     access: [["Captain"]]
-  # Moffstation - Begin - Make captains locker harder to steal
-  - type: LockedAnchorable
-  - type: Transform
-    anchored: true
-  # Moffstation - End
 
 - type: entity
   id: LockerHeadOfPersonnel

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -73,7 +73,7 @@
     stateDoorClosed: cap_door
   - type: AccessReader
     access: [["Captain"]]
-  # Moffstation - Make captains locker harder to steal
+  # Moffstation - Begin - Make captains locker harder to steal
   - type: LockedAnchorable
   - type: Transform
     anchored: true


### PR DESCRIPTION

## About the PR
Secure lockers now spawns anchored, and is unable to be unanchored without being unlocked (similar to APEs)

## Why / Balance
https://discord.com/channels/1322447119252062260/1507163515633270805
In short: The captains locker is incredibly easy to steal on some stations, with it being possible to steal the locker in roughly 20 seconds if you have an RCD or tools. This makes captains locker an easy source of AA, that can only be countered by the captain hoarding all their IDs, which isn't fun.
This PR should make the locker require more preparation in order to get the contents of captains locker, with someone either having to purchase tools such as an access breaker to get in, or break it with something like a bat and risk getting heard (albeit most stations have captains locker far enough away from everywhere else that you can do this pretty easily) 

This has been changed for all secure lockers, but the reasoning is similar
## Technical details

## Test plan
Go onto a station or spawn a secure locker, try to unanchor it
Unlock it and unanchor it

## Media
<img width="455" height="531" alt="image" src="https://github.com/user-attachments/assets/d4162e52-4e4d-44a1-8f4f-6c5831839220" />


## Requirements
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
:cl:
- tweak: Made secure lockers unable to change anchor state while locked.
- tweak: Made secure lockers start anchored.