### PR TITLE
added sound variance for sound mecha hydraulic

### DIFF
--- a/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
+++ b/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
@@ -43,10 +43,13 @@ public sealed partial class MechGrabberComponent : Component
     /// </summary>
     [DataField("grabSound")]
     public SoundSpecifier GrabSound = new SoundPathSpecifier("/Audio/Mecha/sound_mecha_hydraulic.ogg");
-    // Moffstation - Add sound variation
-    {  
-        Params = AudioParams.Default.WithVariation(0.125f)  
-    };
+    
+	// Moffstation - Begin - Add sound variation
+    /// <summary>
+    /// The parameters used when playing the GrabSound
+    /// </summary>
+    [DataField]
+    public AudioParams GrabSoundParams = AudioParams.Default.WithVariation(0.0375f);
     // Moffstation - End
 
     public EntityUid? AudioStream;

--- a/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
+++ b/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
@@ -43,6 +43,11 @@ public sealed partial class MechGrabberComponent : Component
     /// </summary>
     [DataField("grabSound")]
     public SoundSpecifier GrabSound = new SoundPathSpecifier("/Audio/Mecha/sound_mecha_hydraulic.ogg");
+    // Moffstation - Add sound variation
+    {  
+        Params = AudioParams.Default.WithVariation(0.125f)  
+    };
+    // Moffstation - End
 
     public EntityUid? AudioStream;
 

--- a/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
+++ b/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
@@ -155,7 +155,7 @@ public sealed partial class MechGrabberSystem : EntitySystem
             return;
 
         args.Handled = true;
-        component.AudioStream = _audio.PlayPvs(component.GrabSound, uid)?.Entity;
+        component.AudioStream = _audio.PlayPvs(component.GrabSound, uid, component.GrabSoundParams)?.Entity; // Moffstation - Add sound variation
         var doAfterArgs = new DoAfterArgs(EntityManager, args.User, component.GrabDelay, new GrabberDoAfterEvent(), uid, target: target, used: uid)
         {
             BreakOnMove = true


### PR DESCRIPTION
## About the PR
edited MechGrabberComponent.cs to have variation params

## Why / Balance
Running Cargo in-game, you hear sound_mecha_hydraulic A LOT, with no variation or change, just the exact same sound hundreds of times, back to back. This change adds the variation param to the sound to just make it a bit easier to handle.

## Technical details
MechGrabberComponet was given the following change:
```cs
    public SoundSpecifier GrabSound = new SoundPathSpecifier("/Audio/Mecha/sound_mecha_hydraulic.ogg");
    // Moffstation - Add sound variation
    {  
        Params = AudioParams.Default.WithVariation(0.125f)  
    };
    // Moffstation - End
 ```

## Test plan
Spawn a Ripley APLU, apply the clamp, enter and pick up cargo, listen for sound

## Requirements
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
none found while testing

## Changelog
:cl:
- tweak: Changed the sound of the Ripley APLU to have variance.
