### PR TITLE
With Replacement option for Entity Selectors

### DIFF
--- a/Content.Shared/EntityTable/EntitySelectors/AllSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/AllSelector.cs
@@ -14,7 +14,8 @@ public sealed partial class AllSelector : EntityTableSelector
     protected override IEnumerable<EntProtoId> GetSpawnsImplementation(System.Random rand,
         IEntityManager entMan,
         IPrototypeManager proto,
-        EntityTableContext ctx)
+        EntityTableContext ctx,
+        Dictionary<EntityTableSelector, float>? children) // Moffstation - WithReplacement Selector
     {
         foreach (var child in Children)
         {

--- a/Content.Shared/EntityTable/EntitySelectors/EntSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/EntSelector.cs
@@ -19,7 +19,8 @@ public sealed partial class EntSelector : EntityTableSelector
     protected override IEnumerable<EntProtoId> GetSpawnsImplementation(System.Random rand,
         IEntityManager entMan,
         IPrototypeManager proto,
-        EntityTableContext ctx)
+        EntityTableContext ctx,
+        Dictionary<EntityTableSelector, float>? children) // Moffstation - WithReplacement Selector
     {
         var num = Amount.Get(rand);
         for (var i = 0; i < num; i++)

--- a/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
@@ -58,7 +58,10 @@ public abstract partial class EntityTableSelector
         if (!CheckConditions(entMan, proto, ctx))
             yield break;
 
-        if (!WithReplacement && localPool == null) localPool = new Dictionary<EntityTableSelector, float>(); // Moffstation - WithReplacement Selector
+        // Moffstation - Start - WithReplacement Selector
+        if (!WithReplacement && localPool == null)
+            localPool = new Dictionary<EntityTableSelector, float>();
+        // Moffstation - End
 
         var rolls = Rolls.Get(rand);
         for (var i = 0; i < rolls; i++)
@@ -66,7 +69,10 @@ public abstract partial class EntityTableSelector
             if (!rand.Prob(Prob))
                 continue;
             
-            if (localPool != null && localPool.Count == 0 && i > 0) yield break; // Moffstation - WithReplacement Selector
+            // Moffstation - Start -WithReplacement Selector
+            if (localPool != null && localPool.Count == 0 && i > 0)
+                yield break;
+            // Moffstation - End
 
             foreach (var spawn in GetSpawnsImplementation(rand, entMan, proto, ctx, localPool)) // Moffstation - WithReplacement Selector
             {

--- a/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
@@ -28,11 +28,13 @@ public abstract partial class EntityTableSelector
     [DataField]
     public double Prob = 1;
 
+    // Moffstation - Start - WithReplacement Selector
     /// <summary>
-    /// If the selected entity is replaced once it has been picked.
+    /// If the selected entity is replaced in the list once it has been selected.
     /// </summary>
     [DataField]
     public bool WithReplacement = true;
+    // Moffstation - End
 
     /// <summary>
     /// A list of conditions that must evaluate to 'true' for the selector to apply.

--- a/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
@@ -29,6 +29,12 @@ public abstract partial class EntityTableSelector
     public double Prob = 1;
 
     /// <summary>
+    /// If the selected entity is replaced once it has been picked.
+    /// </summary>
+    [DataField]
+    public bool WithReplacement = true;
+
+    /// <summary>
     /// A list of conditions that must evaluate to 'true' for the selector to apply.
     /// </summary>
     [DataField]
@@ -44,18 +50,23 @@ public abstract partial class EntityTableSelector
     public IEnumerable<EntProtoId> GetSpawns(System.Random rand,
         IEntityManager entMan,
         IPrototypeManager proto,
-        EntityTableContext ctx)
+        EntityTableContext ctx,
+        Dictionary<EntityTableSelector, float>? localPool = null) // Moffstation - WithReplacement Selector
     {
         if (!CheckConditions(entMan, proto, ctx))
             yield break;
+
+        if (!WithReplacement && localPool == null) localPool = new Dictionary<EntityTableSelector, float>(); // Moffstation - WithReplacement Selector
 
         var rolls = Rolls.Get(rand);
         for (var i = 0; i < rolls; i++)
         {
             if (!rand.Prob(Prob))
                 continue;
+            
+            if (localPool != null && localPool.Count == 0 && i > 0) yield break; // Moffstation - WithReplacement Selector
 
-            foreach (var spawn in GetSpawnsImplementation(rand, entMan, proto, ctx))
+            foreach (var spawn in GetSpawnsImplementation(rand, entMan, proto, ctx, localPool)) // Moffstation - WithReplacement Selector
             {
                 yield return spawn;
             }
@@ -115,7 +126,8 @@ public abstract partial class EntityTableSelector
     protected abstract IEnumerable<EntProtoId> GetSpawnsImplementation(System.Random rand,
         IEntityManager entMan,
         IPrototypeManager proto,
-        EntityTableContext ctx);
+        EntityTableContext ctx,
+        Dictionary<EntityTableSelector, float>? localPool); // Moffstation - WithReplacement Selector
 
     protected abstract IEnumerable<(EntProtoId spawn, double)> ListSpawnsImplementation(IEntityManager entMan,
         IPrototypeManager proto,

--- a/Content.Shared/EntityTable/EntitySelectors/GroupSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/GroupSelector.cs
@@ -15,16 +15,24 @@ public sealed partial class GroupSelector : EntityTableSelector
     protected override IEnumerable<EntProtoId> GetSpawnsImplementation(System.Random rand,
         IEntityManager entMan,
         IPrototypeManager proto,
-        EntityTableContext ctx)
+        EntityTableContext ctx,
+        Dictionary<EntityTableSelector, float>? localPool) // Moffstation - WithReplacement Selector
     {
-        var children = new Dictionary<EntityTableSelector, float>(Children.Count);
-        foreach (var child in Children)
-        {
-            // Don't include invalid groups
-            if (!child.CheckConditions(entMan, proto, ctx))
-                continue;
+        // Moffstation - Start - WithReplacement Selector
+        var children = localPool ?? new Dictionary<EntityTableSelector, float>(Children.Count);
+        var populated = children.Count > 0;
+        // Moffstation - End
 
-            children.Add(child, child.Weight);
+        if (!populated) // Moffstation - WithReplacement Selector
+        {
+            foreach (var child in Children)
+            {
+                // Don't include invalid groups
+                if (!child.CheckConditions(entMan, proto, ctx))
+                    continue;
+
+                children.Add(child, child.Weight);
+            }
         }
 
         if (children.Count == 0)
@@ -32,6 +40,8 @@ public sealed partial class GroupSelector : EntityTableSelector
 
         var pick = SharedRandomExtensions.Pick(children, rand);
 
+        if (!WithReplacement || localPool != null) children.Remove(pick); // Moffstation - WithReplacement Selector
+        
         return pick.GetSpawns(rand, entMan, proto, ctx);
     }
 

--- a/Content.Shared/EntityTable/EntitySelectors/GroupSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/GroupSelector.cs
@@ -40,8 +40,11 @@ public sealed partial class GroupSelector : EntityTableSelector
 
         var pick = SharedRandomExtensions.Pick(children, rand);
 
-        if (!WithReplacement || localPool != null) children.Remove(pick); // Moffstation - WithReplacement Selector
-        
+        // Moffstation - Start - WithReplacement Selector
+        if (!WithReplacement || localPool != null)
+            children.Remove(pick);
+        // Moffstation - End
+
         return pick.GetSpawns(rand, entMan, proto, ctx);
     }
 

--- a/Content.Shared/EntityTable/EntitySelectors/NestedSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/NestedSelector.cs
@@ -14,9 +14,10 @@ public sealed partial class NestedSelector : EntityTableSelector
     protected override IEnumerable<EntProtoId> GetSpawnsImplementation(System.Random rand,
         IEntityManager entMan,
         IPrototypeManager proto,
-        EntityTableContext ctx)
+        EntityTableContext ctx,
+        Dictionary<EntityTableSelector, float>? children) // Moffstation - WithReplacement Selector
     {
-        return proto.Index(TableId).Table.GetSpawns(rand, entMan, proto, ctx);
+        return proto.Index(TableId).Table.GetSpawns(rand, entMan, proto, ctx, children); // Moffstation - WithReplacement Selector
     }
 
     protected override IEnumerable<(EntProtoId spawn, double)> ListSpawnsImplementation(IEntityManager entMan, IPrototypeManager proto, EntityTableContext ctx)

--- a/Content.Shared/EntityTable/EntitySelectors/NoneSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/NoneSelector.cs
@@ -10,7 +10,8 @@ public sealed partial class NoneSelector : EntityTableSelector
     protected override IEnumerable<EntProtoId> GetSpawnsImplementation(System.Random rand,
         IEntityManager entMan,
         IPrototypeManager proto,
-        EntityTableContext ctx)
+        EntityTableContext ctx,
+        Dictionary<EntityTableSelector, float>? children) // Moffstation - WithReplacement Selector
     {
         yield break;
     }

--- a/Content.Shared/EntityTable/EntityTableSystem.cs
+++ b/Content.Shared/EntityTable/EntityTableSystem.cs
@@ -17,14 +17,14 @@ public sealed partial class EntityTableSystem : EntitySystem
         return GetSpawns(entTableProto.Table, rand, ctx);
     }
 
-    public IEnumerable<EntProtoId> GetSpawns(EntityTableSelector? table, System.Random? rand = null, EntityTableContext? ctx = null)
+    public IEnumerable<EntProtoId> GetSpawns(EntityTableSelector? table, System.Random? rand = null, EntityTableContext? ctx = null, Dictionary<EntityTableSelector, float>? localPool = null) // Moffstation - WithReplacement Selector
     {
         if (table == null)
             return new List<EntProtoId>();
 
         rand ??= _random.GetRandom();
         ctx ??= new EntityTableContext();
-        return table.GetSpawns(rand, EntityManager, _prototypeManager, ctx);
+        return table.GetSpawns(rand, EntityManager, _prototypeManager, ctx, localPool); // Moffstation - WithReplacement Selector
     }
 
     public IEnumerable<(EntProtoId spawn, double)> ListSpawns(EntityTablePrototype entTableProto, EntityTableContext? ctx = null)


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Added the option for EntityTableContainerFill so that you can define whether or not you want a selected item in the list to be removed from further rolls, or be replaced. This gives the yamler the ability to allow duplicates to spawn inside of a crate, or have all items inside the crate be unique.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is desired for the Radio Host PR to remove duplicate Vinyls and CD from spawning. Without it, it is possible for players to get incredibly unlucky and receive with duplicated Vinyls at roundstart or from a purchase crate. There is no benefit to having a duplicate Vinyl so it is a wasted roll. Being able to force all the rolls to be unique would mean this would never happen.

I would PR this upstream but there is the **"situation"** that is happening up there so there is no point at the moment.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Previously, when an EntitySelectorTable would select what it would spawn, it wouldn't create a local Dictionary of the list of entities to spawn. And would just simply run the implemented method however many times it needed until it has satisfied the number of rolls.

Now there is a dictionary established. By default it is null. If WithReplacement is false, it would create a new dictionary to store the list of spawn-able entities in. If will only create one if the dictionary was null when the Table is called to avoid duplicating or overriding the dictionary every time it ran.

Then in the group selector, it will fill the list once, and every time a entity is randomly picked from that list, that entity is removed from the list. Once the list hits 0, it will return early to avoid an error of it trying to select from a list that is empty/null.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
You can test Group Selectors by using the below yaml. Simply spawn the item and check it's contents.
Since withReplacement = false, there should be no duplicates.
Then comment out withReplacement = false. This should set it to True by default, allowing duplicates.
Spawn it again.
```
- type: entityTable
  parent: SteelGenericCrate
  id: EntityTableTest1
  name: Entity Table Test 1
  components:
  - type: EntityTableContainerFill
    containers:
      entity_storage: !type:GroupSelector
        rolls: 3
        withReplacement: false # By default it is true. False means all items selected will be unique.
        children:
        - !type:EntSelector
          id: CrowbarRed
        - !type:EntSelector
          id: Wrench
        - !type:EntSelector
          id: Wirecutter
        - !type:EntSelector
          id: Screwdriver
```

You can test it with Nested Selectors as well by using the below yaml.

```
- type: entityTable
  id: WithReplacementTest
  table: !type:GroupSelector
    children:
    - id: CrowbarRed
    - id: Wrench
    - id: Wirecutter
    - id: Screwdriver

- type: entityTable
  parent: SteelGenericCrate
  id: EntityTableTest2
  name: Entity Table Test 2
  components:
  - type: EntityTableContainerFill
    containers:
      entity_storage: !type:NestedSelector
        tableId: WithReplacementTest
        rolls: 3
        withReplacement: false # By default it is true. False means all items selected will be unique.
```

You can add the following code below any Id in the children lists to mess with the probability of X spawning in the crate. You will observe this function working.

```
weight: X
```

You can also increase the number of rolls to be greater than the number of children in the list. You will see shit not explode, and it will simply spawn 1 of each of the child entities, and exiting without spawning any duplicates.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
Not really needed.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
Nothing to see here.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
