### PR TITLE
Revert xeno buff

### DIFF
--- a/Resources/Locale/en-US/_Moffstation/collective-mind/collective-mind.ftl
+++ b/Resources/Locale/en-US/_Moffstation/collective-mind/collective-mind.ftl
@@ -1,1 +1,0 @@
-collective-mind-xeno = Xeno

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -60,11 +60,10 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      150: Dead
+      50: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
-      75: 0.7
-      120: 0.5
+      25: 0.5
   - type: Stamina
     baseCritThreshold: 200
   - type: Bloodstream
@@ -79,10 +78,8 @@
      collection: AlienClaw
     animation: WeaponArcBite
     damage:
-      types:
-        blunt: 10
-  - type: MovementSpeedModifier
-    baseSprintSpeed: 4.0 # Slightly slower than a person
+      groups:
+        Brute: 6
   - type: DamageStateVisuals
     states:
       Alive:
@@ -137,21 +134,12 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      400: Dead
+      100: Dead
   - type: Stamina
     baseCritThreshold: 300
   - type: SlowOnDamage
     speedModifierThresholds:
-      200: 0.7
-      320: 0.5
-  - type: MeleeWeapon
-    damage:
-      types:
-        Blunt: 13
-        Piercing: 7
-    bluntStaminaDamageFactor: 1.0
-  - type: MovementSpeedModifier
-    baseSprintSpeed: 3.0 # Mining suit can barely outrun them
+      50: 0.7
   - type: Fixtures
     fixtures:
       fix1:
@@ -179,19 +167,16 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Dead
+      80: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
-      50: 0.7
-      75: 0.5
+      40: 0.7
   - type: MeleeWeapon
     damage:
-      types:
-        Blunt: 8
-        Piercing: 4
-    bluntStaminaDamageFactor: 1.0
+      groups:
+        Brute: 6
   - type: MovementSpeedModifier
-    baseSprintSpeed: 5.0
+    baseSprintSpeed: 4
   - type: Fixtures
     fixtures:
       fix1:
@@ -219,19 +204,15 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      500: Dead # Dragon health
+      300: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
-      250: 0.7
-      400: 0.5
+      150: 0.7
   - type: MovementSpeedModifier
-    baseSprintSpeed: 3.0 # Mining suit can barely outrun them
   - type: MeleeWeapon
     damage:
-     types:
-       Blunt: 25
-       Piercing: 10
-    bluntStaminaDamageFactor: 1.0
+     groups:
+       Brute: 12
   - type: Fixtures
     fixtures:
       fix1:
@@ -262,18 +243,16 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      200: Dead
+      100: Dead
   - type: MovementSpeedModifier
-    baseSprintSpeed: 4.5
+    baseSprintSpeed: 4
   - type: MeleeWeapon
     damage:
-     types:
-       Slash: 20
-       Piercing: 10
+     groups:
+       Brute: 10
   - type: SlowOnDamage
     speedModifierThresholds:
-      100: 0.7
-      160: 0.5
+      50: 0.7
   - type: Fixtures
     fixtures:
       fix1:
@@ -299,12 +278,11 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
   - type: MovementSpeedModifier
-    baseSprintSpeed: 10.0 # Scary fast
+    baseSprintSpeed: 6.0
   - type: MeleeWeapon
     damage:
-     types:
-       Slash: 10
-       Piercing: 5
+     groups:
+       Brute: 5
   - type: Fixtures
     fixtures:
       fix1:
@@ -346,11 +324,10 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Dead
+      50: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
-      50: 0.7
-      80: 0.5
+      25: 0.7
   - type: HTN
     rootTask:
       task: SimpleRangedHostileCompound

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -89,6 +89,7 @@
       Dead:
         Base: dead
   - type: Puller
+    needsHands: false # Moffstation - Xeno changes
   - type: Butcherable
     spawned:
     - id: FoodMeatXeno
@@ -101,7 +102,7 @@
     description: ghost-role-information-xeno-description
     rules: ghost-role-information-xeno-rules
     raffle:
-      settings: default
+      settings: short # Moffstation - Xeno changes
   - type: GhostTakeoverAvailable
   - type: TypingIndicator
     proto: alien
@@ -523,6 +524,7 @@
       Dead:
         Base: dead
   - type: Puller
+    needsHands: false # Moffstation - Xeno changes
   - type: Butcherable
     spawned:
     - id: FoodMeatXeno

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -3,7 +3,7 @@
   name: burrower
   id: MobXeno
   parent: SimpleSpaceMobBase
-  description: A small Xeno which uses its claws to break things and force open doors. # Moffstation - (Xeno Buffs)
+  description: They mostly come at night. Mostly.
   components:
   - type: Insulated
   - type: CombatMode
@@ -24,7 +24,7 @@
   - type: Prying
     pryPowered: true
     force: true
-    speedModifier: 4 # Moffstation - (Xeno Buffs)
+    speedModifier: 1.5
     useSound:
       path: /Audio/Items/crowbar.ogg
   - type: Reactive
@@ -57,16 +57,13 @@
     allowedStates:
     - Alive
     - Dead
-  # Moffstation - Begin (Xeno Buffs) - NOTE: there are a few extra SlowOnDamage and MovementSpeedModifier components which already inherit everything from their parent in the xenos.
   - type: MobThresholds
     thresholds:
       0: Alive
-      #50: Dead
       150: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
-      #25: 0.5
-      90: 0.7
+      75: 0.7
       120: 0.5
   - type: Stamina
     baseCritThreshold: 200
@@ -82,14 +79,10 @@
      collection: AlienClaw
     animation: WeaponArcBite
     damage:
-      #groups:
-        #Piercing: 6
       types:
-        Blunt: 2
-        Slash: 10
-        Structural: 40
-  - type: NightVision
-  # Moffstation - End
+        blunt: 10
+  - type: MovementSpeedModifier
+    baseSprintSpeed: 4.0 # Slightly slower than a person
   - type: DamageStateVisuals
     states:
       Alive:
@@ -99,7 +92,6 @@
       Dead:
         Base: dead
   - type: Puller
-    needsHands: false # Moffstation - even more Xeno buffs
   - type: Butcherable
     spawned:
     - id: FoodMeatXeno
@@ -112,13 +104,11 @@
     description: ghost-role-information-xeno-description
     rules: ghost-role-information-xeno-rules
     raffle:
-      settings: short # Moffstation - even more Xeno buffs
+      settings: default # Moffstation - short raffles
   - type: GhostTakeoverAvailable
   - type: TypingIndicator
     proto: alien
   - type: Temperature
-    currentTemperature: 310.15
-  - type: TemperatureDamage
     heatDamageThreshold: 360
     coldDamageThreshold: -150
   - type: Tag
@@ -126,7 +116,6 @@
       - CannotSuicide
       - DoorBumpOpener
       - FootstepSound
-      - Xeno # Moffstation - (Xeno Buffs)
   - type: NoSlip
   - type: Perishable #Ummmm the acid kills a lot of the bacteria or something
     molsPerSecondPerUnitMass: 0.0005
@@ -137,7 +126,6 @@
   name: praetorian
   parent: MobXeno
   id: MobXenoPraetorian
-  description: A large Xeno which can soak up a huge amount of damage. # Moffstation - (Xeno Buffs)
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -146,27 +134,24 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  # Moffstation - Begin (Xeno Buffs)
   - type: MobThresholds
     thresholds:
       0: Alive
-      #100: Dead
-      300: Dead
+      400: Dead
   - type: Stamina
     baseCritThreshold: 300
   - type: SlowOnDamage
     speedModifierThresholds:
-      #50: 0.7
-      180: 0.7
-      240: 0.5
+      200: 0.7
+      320: 0.5
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
-        Slash: 15
-  - type: Prying
-    speedModifier: 2
-  # Moffstation - End
+        Blunt: 13
+        Piercing: 7
+    bluntStaminaDamageFactor: 1.0
+  - type: MovementSpeedModifier
+    baseSprintSpeed: 3.0 # Mining suit can barely outrun them
   - type: Fixtures
     fixtures:
       fix1:
@@ -183,7 +168,6 @@
   name: drone
   parent: MobXeno
   id: MobXenoDrone
-  description: A small xeno which carries things around for the hive. # Moffstation - (Xeno Buffs)
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -192,27 +176,22 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  # Moffstation - Begin (Xeno Buffs)
   - type: MobThresholds
     thresholds:
       0: Alive
-      #80: Dead
       100: Dead
   - type: SlowOnDamage
-    #speedModifierThresholds:
-      #40: 0.7
+    speedModifierThresholds:
+      50: 0.7
+      75: 0.5
   - type: MeleeWeapon
     damage:
-      #groups:
-        #Slash: 6
       types:
-        Blunt: 10
-        Slash: 5
-  #- type: MovementSpeedModifier
-    #baseSprintSpeed: 4
-  - type: Prying
-    speedModifier: 2
-  # Moffstation - End
+        Blunt: 8
+        Piercing: 4
+    bluntStaminaDamageFactor: 1.0
+  - type: MovementSpeedModifier
+    baseSprintSpeed: 5.0
   - type: Fixtures
     fixtures:
       fix1:
@@ -229,7 +208,6 @@
   name: queen
   parent: MobXeno
   id: MobXenoQueen
-  description: A massive Xeno who leads the hive. # Moffstation - (Xeno Buffs)
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -238,29 +216,22 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  # Moffstation - Begin (Xeno Buffs)
   - type: MobThresholds
     thresholds:
       0: Alive
-      #300: Dead
-      600: Dead
+      500: Dead # Dragon health
   - type: SlowOnDamage
     speedModifierThresholds:
-      #150: 0.7
-      360: 0.7
-      480: 0.5
-  #- type: MovementSpeedModifier
+      250: 0.7
+      400: 0.5
+  - type: MovementSpeedModifier
+    baseSprintSpeed: 3.0 # Mining suit can barely outrun them
   - type: MeleeWeapon
     damage:
-      #groups:
-        #Slash: 12
-      types:
-        Blunt: 10
-        Slash: 25
-        Structural: 40
-  - type: Prying
-    speedModifier: 2
-  # Moffstation - End
+     types:
+       Blunt: 25
+       Piercing: 10
+    bluntStaminaDamageFactor: 1.0
   - type: Fixtures
     fixtures:
       fix1:
@@ -280,7 +251,6 @@
   name: ravager
   parent: MobXeno
   id: MobXenoRavager
-  description: A large Xeno which uses its massive claws to hunt prey. # Moffstation - (Xeno Buffs)
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -289,27 +259,21 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  # Moffstation - Begin (Xeno Buffs)
-  #- type: MobThresholds
-    #thresholds:
-      #0: Alive
-      #100: Dead
-  #- type: MovementSpeedModifier
-    #baseSprintSpeed: 4
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      200: Dead
+  - type: MovementSpeedModifier
+    baseSprintSpeed: 4.5
   - type: MeleeWeapon
-    attackRate: 1.5
     damage:
-      #groups:
-        #Slash: 10
      types:
        Slash: 20
-       Structural: 20
+       Piercing: 10
   - type: SlowOnDamage
-    #speedModifierThresholds:
-      #50: 0.7
-  - type: Prying
-    speedModifier: 2
-  # Moffstation - End
+    speedModifierThresholds:
+      100: 0.7
+      160: 0.5
   - type: Fixtures
     fixtures:
       fix1:
@@ -326,7 +290,6 @@
   name: runner
   parent: MobXeno
   id: MobXenoRunner
-  description: A small, extremely fast Xeno. # Moffstation - (Xeno Buffs)
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -336,19 +299,12 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
   - type: MovementSpeedModifier
-    baseSprintSpeed: 6.0
-  # Moffstation - Begin (Xeno Buffs)
+    baseSprintSpeed: 10.0 # Scary fast
   - type: MeleeWeapon
-    attackRate: 2
     damage:
-      #groups:
-        #Slash: 5
-      types:
-        Blunt: 3
-        Slash: 7
-  - type: Prying
-    speedModifier: 2
-  # Moffstation - End
+     types:
+       Slash: 10
+       Piercing: 5
   - type: Fixtures
     fixtures:
       fix1:
@@ -379,7 +335,6 @@
   name: spitter
   parent: MobXeno
   id: MobXenoSpitter
-  description: A large Xeno which can spit acid at long distances. # Moffstation - (Xeno Buffs)
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -388,22 +343,14 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  # Moffstation - Begin (Xeno Buffs)
-  #- type: MobThresholds
-    #thresholds:
-      #0: Alive
-      #50: Dead
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Dead
   - type: SlowOnDamage
-    #speedModifierThresholds:
-      #25: 0.7
-  - type: MeleeWeapon
-    damage:
-      types:
-        Blunt: 7
-        Slash: 3
-  - type: Prying
-    speedModifier: 2
-  # Moffstation - End
+    speedModifierThresholds:
+      50: 0.7
+      80: 0.5
   - type: HTN
     rootTask:
       task: SimpleRangedHostileCompound

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -75,11 +75,11 @@
     altDisarm: false
     angle: 0
     soundHit:
-     collection: AlienClaw
+      collection: AlienClaw
     animation: WeaponArcBite
     damage:
-      groups:
-        Brute: 6
+      types:
+        Piercing: 6
   - type: DamageStateVisuals
     states:
       Alive:
@@ -101,18 +101,20 @@
     description: ghost-role-information-xeno-description
     rules: ghost-role-information-xeno-rules
     raffle:
-      settings: default # Moffstation - short raffles
+      settings: default
   - type: GhostTakeoverAvailable
   - type: TypingIndicator
     proto: alien
   - type: Temperature
+    currentTemperature: 310.15
+  - type: TemperatureDamage
     heatDamageThreshold: 360
     coldDamageThreshold: -150
   - type: Tag
     tags:
-      - CannotSuicide
-      - DoorBumpOpener
-      - FootstepSound
+    - CannotSuicide
+    - DoorBumpOpener
+    - FootstepSound
   - type: NoSlip
   - type: Perishable #Ummmm the acid kills a lot of the bacteria or something
     molsPerSecondPerUnitMass: 0.0005
@@ -173,8 +175,8 @@
       40: 0.7
   - type: MeleeWeapon
     damage:
-      groups:
-        Brute: 6
+      types:
+        Slash: 6
   - type: MovementSpeedModifier
     baseSprintSpeed: 4
   - type: Fixtures
@@ -211,8 +213,8 @@
   - type: MovementSpeedModifier
   - type: MeleeWeapon
     damage:
-     groups:
-       Brute: 12
+      types:
+        Slash: 12
   - type: Fixtures
     fixtures:
       fix1:
@@ -248,8 +250,8 @@
     baseSprintSpeed: 4
   - type: MeleeWeapon
     damage:
-     groups:
-       Brute: 10
+      types:
+        Slash: 10
   - type: SlowOnDamage
     speedModifierThresholds:
       50: 0.7
@@ -281,8 +283,8 @@
     baseSprintSpeed: 6.0
   - type: MeleeWeapon
     damage:
-     groups:
-       Brute: 5
+      types:
+        Slash: 5
   - type: Fixtures
     fixtures:
       fix1:
@@ -342,7 +344,7 @@
     useKey: false
     selectedMode: FullAuto
     availableModes:
-      - FullAuto
+    - FullAuto
     soundGunshot: /Audio/Weapons/Xeno/alien_spitacid.ogg
   - type: Fixtures
     fixtures:
@@ -507,7 +509,7 @@
     altDisarm: false
     angle: 0
     soundHit:
-     collection: AlienClaw
+      collection: AlienClaw
     animation: WeaponArcBite
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1003,7 +1003,7 @@
     - type: Projectile
       damage:
         types:
-          Caustic: 15 #Caustic : 5 Moffstation - (Xeno Buffs)
+          Caustic: 25 # Moffstation - Xeno Buffs
     - type: Sprite
       sprite: Objects/Weapons/Guns/Projectiles/xeno_toxic.rsi
       layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1003,7 +1003,7 @@
     - type: Projectile
       damage:
         types:
-          Caustic: 25 # Moffstation - Xeno Buffs
+          Caustic: 5
     - type: Sprite
       sprite: Objects/Weapons/Guns/Projectiles/xeno_toxic.rsi
       layers:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Reverts the buffs to xenos from #475 and #198 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Both players and admins have complained about xenos being overtuned. Not only is it difficult for players to fight even a single xeno, but its also difficult for admins running events to spawn xenos in a way that is fun and balanced for players (not to mention if we want to try and use xenos elsewhere).
## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
flat reverts to the commits
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- tweak: Xeno stats have been changed back to their original values

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
