### PR TITLE
Fix borg brains getting deleted in explosions

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -166,8 +166,8 @@
   - type: Injurable
     damageContainer: Silicon
   - type: Destructible
-    thresholds:
     generateOverkillThreshold: false # Moffstation - Fix Borg Brains Exploding
+    thresholds:
     - trigger:
         !type:DamageTrigger
         damage: 75

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -167,6 +167,7 @@
     damageContainer: Silicon
   - type: Destructible
     thresholds:
+    generateOverkillThreshold: false # Moffstation - Fix Borg Brains Exploding
     - trigger:
         !type:DamageTrigger
         damage: 75

--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -192,6 +192,7 @@
       50: Critical
       100: Dead
   - type: Destructible
+    generateOverkillThreshold: false
     thresholds:
     - trigger:
         !type:DamageTrigger


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
Fixed so that borg brains (and modules, and batteries) are not deleted when hit with a sufficently large explosion (like a martyr module). https://github.com/space-wizards/space-station-14/pull/43113 this pr upstream broke it, this should fix it.

## Why / Balance
Borgs getting RRd for no reason is bad

## Technical details
yaml

## Test plan
Create borg
Equip with martyr module
Explode
Verify everything remains intact

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x ] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [ x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [ x] I have tested this pull request and written instructions on how to test it
- [x ] I have added media to this PR or it does not require an in-game showcase.
<!x-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- fix: Borgs brains and Ais no longer get automatically destroyed in large enough explosions (such as martyr modules)


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
