### PR TITLE
[Fix] Geras is now hostile to non-slime creatures and possesses a HUD icon

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -160,7 +160,7 @@
   components:
     - type: NpcFactionMember
       factions:
-        - SimpleHostile
+        - FeralSlime # Moffstation - Geras
     - type: GhostRole
       description: ghost-role-information-angry-slimes-description
       rules: ghost-role-information-freeagent-rules # Moffstation - Free agent vent critters
@@ -200,7 +200,7 @@
   components:
     - type: NpcFactionMember
       factions:
-        - SimpleHostile
+        - FeralSlime # Moffstation - Geras
     - type: GhostRole
       description: ghost-role-information-angry-slimes-description
       rules: ghost-role-information-freeagent-rules # Moffstation - Free agent vent critters
@@ -239,7 +239,7 @@
   components:
     - type: NpcFactionMember
       factions:
-        - SimpleHostile
+        - FeralSlime # Moffstation - Geras
     - type: GhostRole
       description: ghost-role-information-angry-slimes-description
       rules: ghost-role-information-freeagent-rules # Moffstation - Free agent vent critters

--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/NPCs/slimes.yml
@@ -110,6 +110,12 @@
         - id: OrganSlimePersonCore
         - id: OrganSlimePersonLungs
         - id: OrganGerasTorso
+  - type: NpcFactionMember
+    factions:
+    - FeralSlime # Not actually feral, but feral slimes won't attack them
+  - type: StatusIcon
+    bounds: -0.5,-0.5,0.5,0.5
+  - type: JobStatus
   - type: Tag
     tags:
     - FootstepSound

--- a/Resources/Prototypes/_Moffstation/ai_factions.yml
+++ b/Resources/Prototypes/_Moffstation/ai_factions.yml
@@ -11,3 +11,19 @@
   - Wizard
   - Xenoborg
   - Syndicate
+
+- type: npcFaction
+  id: FeralSlime
+  hostile:
+  - AllHostile
+  - BloodBrother
+  - Dragon
+  - NanoTrasen
+  - PetsNT
+  - Pirate
+  - SimpleHostile
+  - Syndicate
+  - Wizard
+  - Xeno
+  - Xenoborg
+  - Zombie

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -12,6 +12,7 @@
   - Xenoborg
   - BloodBrother # Harmony
   - Pirate # Moffstation
+  - FeralSlime # Moffstation
 
 - type: npcFaction
   id: NanoTrasen
@@ -27,6 +28,7 @@
   - Xenoborg
   - BloodBrother # Harmony
   - Pirate # Moffstation
+  - FeralSlime # Moffstation
 
 - type: npcFaction
   id: Mouse
@@ -49,6 +51,7 @@
   - Xeno
   - AllHostile
   - Dragon
+  - FeralSlime # Moffstation
 
 - type: npcFaction
   id: SimpleHostile
@@ -66,6 +69,7 @@
   - Xenoborg
   - BloodBrother # Harmony
   - Pirate # Moffstation
+  - FeralSlime # Moffstation
 
 - type: npcFaction
   id: SimpleNeutral
@@ -83,6 +87,7 @@
   - Wizard
   - Xenoborg
   - Pirate # Moffstation
+  - FeralSlime # Moffstation
 
 - type: npcFaction
   id: Xeno
@@ -99,6 +104,7 @@
   - Xenoborg
   - BloodBrother # Harmony
   - Pirate # Moffstation
+  - FeralSlime # Moffstation
 
 - type: npcFaction
   id: Zombie
@@ -116,6 +122,7 @@
   - Xenoborg
   - BloodBrother # Harmony
   - Pirate # Moffstation
+  - FeralSlime # Moffstation
 
 - type: npcFaction
   id: Revolutionary
@@ -127,6 +134,7 @@
   - AllHostile
   - Wizard
   - Xenoborg
+  - FeralSlime # Moffstation
 
 - type: npcFaction
   id: AllHostile
@@ -146,6 +154,7 @@
   - Xenoborg
   - BloodBrother # Harmony
   - Pirate # Moffstation
+  - FeralSlime # Moffstation
 
 - type: npcFaction
   id: Wizard
@@ -165,6 +174,7 @@
   - Xenoborg
   - BloodBrother # Harmony
   - Pirate # Moffstation
+  - FeralSlime # Moffstation
 
 - type: npcFaction
   id: Xenoborg
@@ -183,3 +193,4 @@
   # cause they are hostile to them
   - SimpleHostile
   - AllHostile
+  - FeralSlime # Moffstation


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
This pull request fixes the following:
- Lack of HUD icon for Geras slimes.
- Geras slimes being flagged as neutral to most simple hostile mobs, rather than just explicitly feral slimes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfixes. The first issue is intended to maintain parity for the player experience, while the secondary is a fix for certain unintended behaviors, like slime salvagers going on xeno expeditions knowing they're friendly to the xenos. 

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
yml changes. Created new faction for feral slimes, remarked our feral slimes and geras prototype, as well as added Status Icon and Job Status components to our geras prototype.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Spawn Urist McWobble, take control. Activate geras, and then spawn an angry blue slime. Then spawn in a Xeno of your choice. Finally, equip an ID, and change to a different Urist with a pair of glasses that can read IDs.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

<img width="232" height="133" alt="image" src="https://github.com/user-attachments/assets/f17fab44-64c0-408b-a399-f9e26633a73f" />

_Captain Urist McWobble!_

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- fix: Geras slimes now properly show their ID on HUDs.
- fix: Geras slimes are no longer considered neutral towards non-slime mobs.