### PR TITLE
Discord events for Moffup

### DIFF
--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Content.Server._Moffstation.Antag;
+using Content.Server._Moffstation.Discord.GuildEvent;
 using Content.Server.Acz;
 using Content.Server.Administration;
 using Content.Server.Administration.Logs;
@@ -46,6 +47,7 @@ namespace Content.Server.Entry
         private const string ConfigPresetsDirBuild = $"{ConfigPresetsDir}Build/";
 
         [Dependency] private CVarControlManager _cvarCtrl = default!;
+        [Dependency] private DiscordGuildEventManager _discordGuildEventManager = default!; // Moffstation
         [Dependency] private ContentLocalizationManager _loc = default!;
         [Dependency] private ContentNetworkResourceManager _netResMan = default!;
         [Dependency] private DiscordChatLink _discordChatLink = default!;
@@ -216,6 +218,7 @@ namespace Content.Server.Entry
             // We don't care when or how this finishes, just spin the task off into the void.
             _ = _discordLink.Shutdown();
             _discordChatLink.Shutdown();
+            _discordGuildEventManager.Shutdown(); // Moffstation - end Discord guild event on shutdown
         }
 
         private static void LoadConfigPresets(IConfigurationManager cfg, IResourceManager res, ISawmill sawmill)

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -136,6 +136,7 @@ namespace Content.Server.GameTicking
             }
 
             RaiseNetworkEvent(new TickerLobbyCountdownEvent(_roundStartTime, Paused));
+            RaiseLocalEvent(new TickerLobbyCountdownEvent(_roundStartTime, Paused)); // Moffstation - Raise to server as well
 
             _chatManager.DispatchServerAnnouncement(Loc.GetString(Paused
                 ? "game-ticker-pause-start"

--- a/Content.Server/IoC/ServerContentIoC.cs
+++ b/Content.Server/IoC/ServerContentIoC.cs
@@ -1,5 +1,6 @@
 using Content.Server._Moffstation.Antag;
 using Content.Server._Moffstation.Discord;
+using Content.Server._Moffstation.Discord.GuildEvent;
 using Content.Server.Administration;
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
@@ -68,7 +69,7 @@ internal static class ServerContentIoC
         deps.Register<UserDbDataManager>();
         deps.Register<ServerInfoManager>();
         deps.Register<DiscordWebhook>();
-        deps.Register<_Moffstation.Discord.GuildEvent.DiscordGuildEventManager>(); // Moffstation - Discord events
+        deps.Register<DiscordGuildEventManager>(); // Moffstation - Discord events
         deps.Register<VoteWebhooks>();
         deps.Register<ServerDbEntryManager>();
         deps.Register<ISharedPlaytimeManager, PlayTimeTrackingManager>();

--- a/Content.Server/IoC/ServerContentIoC.cs
+++ b/Content.Server/IoC/ServerContentIoC.cs
@@ -1,4 +1,5 @@
 using Content.Server._Moffstation.Antag;
+using Content.Server._Moffstation.Discord;
 using Content.Server.Administration;
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
@@ -67,6 +68,7 @@ internal static class ServerContentIoC
         deps.Register<UserDbDataManager>();
         deps.Register<ServerInfoManager>();
         deps.Register<DiscordWebhook>();
+        deps.Register<_Moffstation.Discord.GuildEvent.DiscordGuildEventManager>(); // Moffstation - Discord events
         deps.Register<VoteWebhooks>();
         deps.Register<ServerDbEntryManager>();
         deps.Register<ISharedPlaytimeManager, PlayTimeTrackingManager>();

--- a/Content.Server/_Moffstation/Discord/GuildEvent/DiscordGuildEventManager.cs
+++ b/Content.Server/_Moffstation/Discord/GuildEvent/DiscordGuildEventManager.cs
@@ -1,0 +1,203 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+
+namespace Content.Server._Moffstation.Discord.GuildEvent;
+
+public sealed partial class DiscordGuildEventManager : IPostInjectInit
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Dependency] private ILogManager _log = default!;
+    [Dependency] private IConfigurationManager _cfg = default!;
+
+    private const string BaseUrl = "https://discord.com/api/v10";
+    private readonly HttpClient _http = new();
+    private ISawmill _sawmill = default!;
+
+    private ulong? _activeEventId;
+    private readonly SemaphoreSlim _lock = new(1, 1);
+
+    void IPostInjectInit.PostInject()
+    {
+        _sawmill = _log.GetSawmill("discord.guild_events");
+    }
+
+    public void Shutdown()
+    {
+        if (_activeEventId == null)
+            return;
+        try
+        {
+            EndActiveEventAsync().GetAwaiter().GetResult();
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"Error ending Discord guild scheduled event on shutdown:\n{e}");
+        }
+    }
+
+    public async Task EnsureEventActiveAsync(string name, string description, string location)
+    {
+        if (!IsConfigured())
+            return;
+        await _lock.WaitAsync();
+        try
+        {
+            if (_activeEventId != null)
+            {
+                if (await GetExistingEventAsync(_activeEventId.Value) != null)
+                    return;
+                _activeEventId = null;
+            }
+
+            await CreateAndActivateEventAsync(name, description, location);
+
+            if (_activeEventId == null)
+                _sawmill.Warning("Failed to create Discord guild scheduled event.");
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"Error ensuring Discord round event active:\n{e}");
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task EndActiveEventAsync()
+    {
+        await _lock.WaitAsync();
+        try
+        {
+            if (_activeEventId == null)
+                return;
+            await EndEventAsync(_activeEventId.Value);
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"Error ending Discord guild scheduled event:\n{e}");
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    private bool IsConfigured()
+    {
+        return !string.IsNullOrWhiteSpace(_cfg.GetCVar(CCVars.DiscordToken))
+            && !string.IsNullOrWhiteSpace(_cfg.GetCVar(CCVars.DiscordGuildId));
+    }
+
+    private string GetEventsUrl()
+    {
+        return $"{BaseUrl}/guilds/{_cfg.GetCVar(CCVars.DiscordGuildId)}/scheduled-events";
+    }
+
+    private HttpRequestMessage BuildRequest(HttpMethod method, string url, object? body = null)
+    {
+        var request = new HttpRequestMessage(method, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bot", _cfg.GetCVar(CCVars.DiscordToken));
+        if (body != null)
+            request.Content = JsonContent.Create(body, options: JsonOptions);
+        return request;
+    }
+
+    private async Task CreateAndActivateEventAsync(string name, string description, string location)
+    {
+        var eventsUrl = GetEventsUrl();
+        var now = DateTime.UtcNow;
+        var createPayload = new ScheduledEventCreatePayload
+        {
+            Name = name,
+            Description = string.IsNullOrWhiteSpace(description) ? null : description,
+            EntityType = 3,
+            EntityMetadata = new ScheduledEventEntityMetadata { Location = location },
+            ScheduledStartTime = now.AddSeconds(1).ToString("o"),
+            ScheduledEndTime = now.AddHours(24).ToString("o"),
+            Status = 1,
+        };
+
+        var createResponse = await _http.SendAsync(BuildRequest(HttpMethod.Post, eventsUrl, createPayload));
+        if (!createResponse.IsSuccessStatusCode)
+        {
+            var body = await createResponse.Content.ReadAsStringAsync();
+            _sawmill.Error($"Failed to create guild scheduled event. Status: {createResponse.StatusCode}\n{body}");
+            return;
+        }
+
+        var created = await createResponse.Content.ReadFromJsonAsync<ScheduledEventResponse>(JsonOptions);
+        if (created == null)
+            return;
+
+        var activatePayload = new ScheduledEventPatchPayload { Status = 2 };
+        var activateResponse = await _http.SendAsync(BuildRequest(HttpMethod.Patch, $"{eventsUrl}/{created.Id}", activatePayload));
+        if (!activateResponse.IsSuccessStatusCode)
+            _sawmill.Warning($"Failed to activate guild scheduled event {created.Id}. Status: {activateResponse.StatusCode}");
+
+        _activeEventId = created.Id;
+    }
+
+    private async Task EndEventAsync(ulong eventId)
+    {
+        var eventsUrl = GetEventsUrl();
+        var payload = new ScheduledEventPatchPayload { Status = 3 };
+        var response = await _http.SendAsync(BuildRequest(HttpMethod.Patch, $"{eventsUrl}/{eventId}", payload));
+        if (!response.IsSuccessStatusCode)
+            _sawmill.Error($"Failed to end guild scheduled event {eventId}. Status: {response.StatusCode}");
+        else if (_activeEventId == eventId)
+            _activeEventId = null;
+    }
+
+    private async Task<ScheduledEventResponse?> GetExistingEventAsync(ulong eventId)
+    {
+        var response = await _http.SendAsync(BuildRequest(HttpMethod.Get, $"{GetEventsUrl()}/{eventId}"));
+        if (!response.IsSuccessStatusCode)
+            return null;
+        var ev = await response.Content.ReadFromJsonAsync<ScheduledEventResponse>(JsonOptions);
+        return ev?.Status == 2 ? ev : null;
+    }
+}
+
+public sealed class ScheduledEventCreatePayload
+{
+    [JsonPropertyName("name")] public required string Name { get; init; }
+    [JsonPropertyName("description")] public string? Description { get; init; }
+    [JsonPropertyName("entity_type")] public required int EntityType { get; init; }
+    [JsonPropertyName("entity_metadata")] public required ScheduledEventEntityMetadata EntityMetadata { get; init; }
+    [JsonPropertyName("scheduled_start_time")] public required string ScheduledStartTime { get; init; }
+    [JsonPropertyName("scheduled_end_time")] public required string ScheduledEndTime { get; init; }
+    [JsonPropertyName("privacy_level")] public int PrivacyLevel { get; init; } = 2;
+    [JsonPropertyName("status")] public required int Status { get; init; }
+}
+
+public sealed class ScheduledEventEntityMetadata
+{
+    [JsonPropertyName("location")] public required string Location { get; init; }
+}
+
+public sealed class ScheduledEventPatchPayload
+{
+    [JsonPropertyName("status")] public required int Status { get; init; }
+}
+
+public sealed class ScheduledEventResponse
+{
+    [JsonPropertyName("id")]
+    [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+    public ulong Id { get; init; }
+
+    [JsonPropertyName("status")] public int Status { get; init; }
+    [JsonPropertyName("name")] public string Name { get; init; } = string.Empty;
+}

--- a/Content.Server/_Moffstation/Discord/GuildEvent/DiscordGuildEventManager.cs
+++ b/Content.Server/_Moffstation/Discord/GuildEvent/DiscordGuildEventManager.cs
@@ -50,7 +50,8 @@ public sealed partial class DiscordGuildEventManager : IPostInjectInit
     {
         if (!IsConfigured())
             return;
-        await _lock.WaitAsync();
+
+        using var _ = await _lock.WaitGuardAsync();
         try
         {
             if (_activeEventId != null)
@@ -69,15 +70,11 @@ public sealed partial class DiscordGuildEventManager : IPostInjectInit
         {
             _sawmill.Error($"Error ensuring Discord round event active:\n{e}");
         }
-        finally
-        {
-            _lock.Release();
-        }
     }
 
     public async Task EndActiveEventAsync()
     {
-        await _lock.WaitAsync();
+        using var _ = await _lock.WaitGuardAsync();
         try
         {
             if (_activeEventId == null)
@@ -87,10 +84,6 @@ public sealed partial class DiscordGuildEventManager : IPostInjectInit
         catch (Exception e)
         {
             _sawmill.Error($"Error ending Discord guild scheduled event:\n{e}");
-        }
-        finally
-        {
-            _lock.Release();
         }
     }
 

--- a/Content.Server/_Moffstation/Discord/GuildEvent/DiscordGuildEventManager.cs
+++ b/Content.Server/_Moffstation/Discord/GuildEvent/DiscordGuildEventManager.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -7,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
+using Robust.Shared.Utility;
 
 namespace Content.Server._Moffstation.Discord.GuildEvent;
 
@@ -60,6 +63,11 @@ public sealed partial class DiscordGuildEventManager : IPostInjectInit
                     return;
                 _activeEventId = null;
             }
+
+            // Recover from lost state (e.g. server restart mid-round): claim an existing active event.
+            _activeEventId = await FindActiveEventIdAsync(name);
+            if (_activeEventId != null)
+                return;
 
             await CreateAndActivateEventAsync(name, description, location);
 
@@ -160,6 +168,15 @@ public sealed partial class DiscordGuildEventManager : IPostInjectInit
             return null;
         var ev = await response.Content.ReadFromJsonAsync<ScheduledEventResponse>(JsonOptions);
         return ev?.Status == 2 ? ev : null;
+    }
+
+    private async Task<ulong?> FindActiveEventIdAsync(string name)
+    {
+        var response = await _http.SendAsync(BuildRequest(HttpMethod.Get, GetEventsUrl()));
+        if (!response.IsSuccessStatusCode)
+            return null;
+        var events = await response.Content.ReadFromJsonAsync<List<ScheduledEventResponse>>(JsonOptions);
+        return events?.FirstOrDefault(e => e.Status == 2 && string.Equals(e.Name, name, StringComparison.OrdinalIgnoreCase))?.Id;
     }
 }
 

--- a/Content.Server/_Moffstation/Discord/GuildEvent/DiscordGuildEventSystem.cs
+++ b/Content.Server/_Moffstation/Discord/GuildEvent/DiscordGuildEventSystem.cs
@@ -39,10 +39,7 @@ public sealed partial class DiscordGuildEventSystem : EntitySystem
         if (!_discordEventEnabled)
             return;
 
-        if (args.Paused)
-            EndActiveEvent();
-        else
-            EnsureEventActive();
+        _ = args.Paused ? EndActiveEvent() : EnsureEventActive();
     }
 
     private void OnRunLevelChanged(GameRunLevelChangedEvent ev)
@@ -50,25 +47,20 @@ public sealed partial class DiscordGuildEventSystem : EntitySystem
         if (!_discordEventEnabled)
             return;
 
-        switch (ev.New)
+        _ = ev.New switch
         {
-            case GameRunLevel.InRound:
-            case GameRunLevel.PostRound:
-            case GameRunLevel.PreRoundLobby when !_gameTicker.Paused:
-                EnsureEventActive();
-                break;
-            case GameRunLevel.PreRoundLobby when _gameTicker.Paused:
-                EndActiveEvent();
-                break;
-        }
+            GameRunLevel.InRound or GameRunLevel.PostRound => EnsureEventActive(),
+            GameRunLevel.PreRoundLobby when !_gameTicker.Paused => EnsureEventActive(),
+            _ => EndActiveEvent(),
+        };
     }
 
-    private async void EnsureEventActive()
+    private async Task EnsureEventActive()
     {
         await _eventManager.EnsureEventActiveAsync(_currentEventName, _currentEventDescription, _currentEventLocation);
     }
 
-    private async void EndActiveEvent()
+    private async Task EndActiveEvent()
     {
         await _eventManager.EndActiveEventAsync();
     }

--- a/Content.Server/_Moffstation/Discord/GuildEvent/DiscordGuildEventSystem.cs
+++ b/Content.Server/_Moffstation/Discord/GuildEvent/DiscordGuildEventSystem.cs
@@ -1,0 +1,75 @@
+using Content.Server.GameTicking;
+using Content.Shared._Moffstation.CCVar;
+using Content.Shared.GameTicking;
+using Robust.Shared.Configuration;
+
+namespace Content.Server._Moffstation.Discord.GuildEvent;
+
+public sealed partial class DiscordGuildEventSystem : EntitySystem
+{
+    [Dependency] private IConfigurationManager _cfg = default!;
+    [Dependency] private DiscordGuildEventManager _eventManager = default!;
+    [Dependency] private GameTicker _gameTicker = default!;
+
+    private bool _discordEventEnabled;
+    private string _currentEventName = "";
+    private string _currentEventDescription = "";
+    private string _currentEventLocation = "";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<GameRunLevelChangedEvent>(OnRunLevelChanged);
+        SubscribeLocalEvent<TickerLobbyCountdownEvent>(OnDelayChanged);
+
+        Subs.CVar(_cfg, MoffCCVars.DiscordRoundEventEnabled, value => _discordEventEnabled = value, true);
+        Subs.CVar(_cfg, MoffCCVars.DiscordRoundEventName, value => _currentEventName = value, true);
+        Subs.CVar(_cfg, MoffCCVars.DiscordRoundEventDescription, value => _currentEventDescription = value, true);
+        Subs.CVar(_cfg, MoffCCVars.DiscordRoundEventLocation, value => _currentEventLocation = value, true);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        _eventManager.Shutdown();
+    }
+
+    private void OnDelayChanged(TickerLobbyCountdownEvent args)
+    {
+        if (!_discordEventEnabled)
+            return;
+
+        if (args.Paused)
+            EndActiveEvent();
+        else
+            EnsureEventActive();
+    }
+
+    private void OnRunLevelChanged(GameRunLevelChangedEvent ev)
+    {
+        if (!_discordEventEnabled)
+            return;
+
+        switch (ev.New)
+        {
+            case GameRunLevel.InRound:
+            case GameRunLevel.PostRound:
+            case GameRunLevel.PreRoundLobby when !_gameTicker.Paused:
+                EnsureEventActive();
+                break;
+            case GameRunLevel.PreRoundLobby when _gameTicker.Paused:
+                EndActiveEvent();
+                break;
+        }
+    }
+
+    private async void EnsureEventActive()
+    {
+        await _eventManager.EnsureEventActiveAsync(_currentEventName, _currentEventDescription, _currentEventLocation);
+    }
+
+    private async void EndActiveEvent()
+    {
+        await _eventManager.EndActiveEventAsync();
+    }
+}

--- a/Content.Server/_Moffstation/Discord/GuildEvent/DiscordGuildEventSystem.cs
+++ b/Content.Server/_Moffstation/Discord/GuildEvent/DiscordGuildEventSystem.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Content.Server.GameTicking;
 using Content.Shared._Moffstation.CCVar;
 using Content.Shared.GameTicking;

--- a/Content.Shared/_Moffstation/CCVar/CCVars.Moff.cs
+++ b/Content.Shared/_Moffstation/CCVar/CCVars.Moff.cs
@@ -105,4 +105,29 @@ public sealed class MoffCCVars
     [CVarControl(AdminFlags.Server)]
     public static readonly CVarDef<bool> OocUpstreamPatronColorEnabled =
         CVarDef.Create("moff.ooc_upstream_patron_color_enabled", true, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Whether a discord event should be created and managed as long as the round timer is unpaused
+    /// false by default so the code doesnt try to run on localhost
+    /// </summary>
+    public static readonly CVarDef<bool> DiscordRoundEventEnabled =
+        CVarDef.Create("moff.discord_round_event_enabled", false, CVar.SERVERONLY);
+
+    /// <summary>
+    /// The title of the discord event
+    /// </summary>
+    public static readonly CVarDef<string> DiscordRoundEventName =
+        CVarDef.Create("moff.discord_round_event_name", "Moffstation!", CVar.SERVERONLY | CVar.CONFIDENTIAL);
+
+    /// <summary>
+    /// The description of the discord event (visible when clicked on)
+    /// </summary>
+    public static readonly CVarDef<string> DiscordRoundEventDescription =
+        CVarDef.Create("moff.discord_round_event_description", "Moff is up!\nFair warning: the end time is not accurate.", CVar.SERVERONLY | CVar.CONFIDENTIAL);
+
+    /// <summary>
+    /// The location of the discord event (visible under the title)
+    /// </summary>
+    public static readonly CVarDef<string> DiscordRoundEventLocation =
+        CVarDef.Create("moff.discord_round_event_location", string.Empty, CVar.SERVERONLY);
 }

--- a/Content.Shared/_Moffstation/CCVar/CCVars.Moff.cs
+++ b/Content.Shared/_Moffstation/CCVar/CCVars.Moff.cs
@@ -117,13 +117,13 @@ public sealed class MoffCCVars
     /// The title of the discord event
     /// </summary>
     public static readonly CVarDef<string> DiscordRoundEventName =
-        CVarDef.Create("moff.discord_round_event_name", "Moffstation!", CVar.SERVERONLY | CVar.CONFIDENTIAL);
+        CVarDef.Create("moff.discord_round_event_name", "Moffstation!", CVar.SERVERONLY);
 
     /// <summary>
     /// The description of the discord event (visible when clicked on)
     /// </summary>
     public static readonly CVarDef<string> DiscordRoundEventDescription =
-        CVarDef.Create("moff.discord_round_event_description", "Moff is up!\nFair warning: the end time is not accurate.", CVar.SERVERONLY | CVar.CONFIDENTIAL);
+        CVarDef.Create("moff.discord_round_event_description", "Moff is up!\nFair warning: the end time is not accurate.", CVar.SERVERONLY);
 
     /// <summary>
     /// The location of the discord event (visible under the title)


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
If you saw the `Moffstation!` event flickering today this is why

When the round timer is active or a round is ongoing, the game will create a discord event indicating that Moff is up.
When the timer is paused, it will shut off the event.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Helps people know when we're hosting! Sometimes people might miss the ping, or we might start a session early and people don't know we're still going.
## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
I will detail how I tested here, since its hard to replicate without a whole discord bot

Start server in lobby
no event

start round timer
event pops up
pause timer 
event goes away

start timer
event pops up
enter round
return to lobby
event still there
pause timer
event gone
(also, you cant pause midround)

start timer
shutdown server
event gone
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="677" height="486" alt="image" src="https://github.com/user-attachments/assets/7d8bc7be-2cb2-4ac7-ba7e-4167974b3d21" />
<img width="351" height="166" alt="image" src="https://github.com/user-attachments/assets/e2eea773-6d37-44c4-b40f-2745ec2ab024" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:
- add: Added an automatic discord event for when we have uptime!

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
