### PR TITLE
Map Patching to include Bounds with Prototype Selection

### DIFF
--- a/Content.Shared/_Harmony/EntitySelector/EntitySelector.cs
+++ b/Content.Shared/_Harmony/EntitySelector/EntitySelector.cs
@@ -11,13 +11,15 @@ public abstract partial class EntitySelector
 
     [DataField]
     public List<EntitySelector> SubSelectors = new();
-
+    
+    // Moffstation - Start - Add bounds for prototype selectors.
     /// <summary>
     /// Optional grid-local area that an entity must be inside to match this selector.
     /// When null, this selector can match entities anywhere on the grid.
     /// </summary>
     [DataField]
     public Box2? Bounds;
+    // Moffstation - End
 
     /// <summary>
     /// One-time initialization of an entity selector.
@@ -48,6 +50,7 @@ public abstract partial class EntitySelector
         if (!Initialized)
             Initialize();
 
+        // Moffstation - Start - Add bounds for prototype selectors.
         // If bounds were configured for this selector, require the entity to have a transform so we can
         // compare its current grid-local position against those bounds.
         if (Bounds != null)
@@ -60,6 +63,7 @@ public abstract partial class EntitySelector
             if (!Bounds.Value.Contains(transform.LocalPosition))
                 return false;
         }
+        // Moffstation - End
 
         if (SubSelectors.Count == 0)
             return true;

--- a/Content.Shared/_Harmony/EntitySelector/EntitySelector.cs
+++ b/Content.Shared/_Harmony/EntitySelector/EntitySelector.cs
@@ -13,6 +13,13 @@ public abstract partial class EntitySelector
     public List<EntitySelector> SubSelectors = new();
 
     /// <summary>
+    /// Optional grid-local area that an entity must be inside to match this selector.
+    /// When null, this selector can match entities anywhere on the grid.
+    /// </summary>
+    [DataField]
+    public Box2? Bounds;
+
+    /// <summary>
     /// One-time initialization of an entity selector.
     /// Recursively initializes all sub-selectors.
     /// </summary>
@@ -40,6 +47,19 @@ public abstract partial class EntitySelector
     {
         if (!Initialized)
             Initialize();
+
+        // If bounds were configured for this selector, require the entity to have a transform so we can
+        // compare its current grid-local position against those bounds.
+        if (Bounds != null)
+        {
+            if (!EntityManager.TryGetComponent<TransformComponent>(entity, out var transform))
+                return false;
+
+            // Map modifications iterate over entities parented to the target grid, so LocalPosition is the
+            // position within that grid. Only entities inside the configured bounds are eligible to match.
+            if (!Bounds.Value.Contains(transform.LocalPosition))
+                return false;
+        }
 
         if (SubSelectors.Count == 0)
             return true;


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Huge thanks to Zero. Such a simple fix which makes this so much easier.

I was working through Map Patching for the Clothing Stains PR. With the goal of adding Washing Machines to all maps. The issue is in order to make the Laundry equipment fit, you need to remove some entities, and the removal of entities via mapModifications is really unrobust.

Basically when specifying a prototype to be removed, there is no way to specify a specific instance of that prototype. You have to remove all instances of that prototype.
Which then requires you to add all of the unintended deletions of that prototype back in through map patching.

For instance, on map Dove. If you were to remove one instance of the Mirror prototype, you would have to add all the Mirrors back resulting in this code...
```
  removals:
  - !type:EntityPrototypeSelector
    prototype: Mirror
  additions:
  # Add back removed Mirrors
  - prototype: Mirror
    position: -17.5, 8.5
    rotation: 90
  - prototype: Mirror
    position: 3.5, 19.5
    rotation: 90
  - prototype: Mirror
    position: 31.5, 13.5
    rotation: 270
  - prototype: Mirror
    position: -1.5, -27.5
    rotation: 270
  - prototype: Mirror
    position: -1.5, -27.5
    rotation: 270
  - prototype: Mirror
    position: 35.5, -25.5
    rotation: 270
  - prototype: Mirror
    position: -19.5, 38.5
    rotation: 0
  - prototype: Mirror
    position: -17.5, 38.5
    rotation: 0
  - prototype: Mirror
    position: -21.5, 18.5
    rotation: 180
  - prototype: Mirror
    position: -20.5, 18.5
    rotation: 180
  - prototype: Mirror
    position: -19.5, 18.5
    rotation: 180
  - prototype: Mirror
    position: -10.5, 49.5
    rotation: 0
  - prototype: Mirror
    position: 81.5, -5.5
    rotation: 0
  - prototype: Mirror
    position: 81.5, -9.5
    rotation: 0
  - prototype: Mirror
    position: 1.5, 20.5
    rotation: 270
```
It gets ridiculous if there are alot of a specific prototype on the Map.

The changes  in this PR you to specify transform bounds to more precisely select a specific prototype you want to remove.
To achieve the same result, of removing a single Mirror prototype, we can now just do...

```
removals:
- !type:EntityPrototypeSelector
prototype: Mirror
bounds: "-18,10,-17,11"
```

Adding bounds saves so much fucking time, and holy shit. Thank you Zero for sending me the change.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->


## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Adds the ability to specify bounds for the Harmony EntityPrototypeSelector used in Map Patching.

```
bounds: "LEFT, BOTTOM, RIGHT, TOP"
```

Failure to correctly format the bounds will cause the bounds to fail. Previous versions of RT allowed for negative bounds, but any version later than 280.0.0 must be formatted as Left, Bottom, Right, Top or prototype removal will fail to load.
See #1651, where an additional check was added to alert of degenerate bounds.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Add the following code...

```
- type: mapModification
  id: AddThronglers
  additions:
  - prototype: Throngler
    position: 28.5, 9.5
  - prototype: Throngler
    position: 29.5, 9.5
  - prototype: Throngler
    position: 30.5, 9.5

- type: mapModification
  id: Remove
  removals:
  - !type:EntityPrototypeSelector
    prototype: Throngler

- type: mapModification
  id: RemoveBounds
  removals:
  - !type:EntityPrototypeSelector
    prototype: Throngler
    bounds: "29,9,30,10"
```


Load into Dev environment
Run the following console command...
`applymapmodification AddThronglers [autofill Dev grid #]`

This should spawn three Thronglers just south of spawn.


Run the following console command...
`applymapmodification Remove [autofill Dev grid #]`

This should remove all Thronglers on the Dev map regardless of their position.


Run the following console command...
`applymapmodification AddThronglers [autofill Dev grid #]`
This should spawn three Thronglers again.
Run the following console command...
`applymapmodification RemoveBounds[autofill Dev grid #]`

This should remove the middle Throngler.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:

no player facing change, but holy shit thanks Zero
<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
