### PR TITLE
[Fix] Clumsy as a trait doesn't make you feel like a clown.

### DIFF
--- a/Content.Shared/Clumsy/ClumsyComponent.cs
+++ b/Content.Shared/Clumsy/ClumsyComponent.cs
@@ -19,6 +19,14 @@ public sealed partial class ClumsyComponent : Component
     [DataField]
     public SoundSpecifier ClumsySound = new SoundPathSpecifier("/Audio/Items/bikehorn.ogg");
 
+    // Moffstation - Start - Clumsy as a trait
+    /// <summary>
+    ///     If clumsy should play a comedic sound effect when clumsy interactions fail.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool ClumsySoundEnabled = true;
+    // Moffstation - End
+
     /// <summary>
     ///     Default chance to fail a clumsy interaction.
     ///     If a system needs to use something else, add a new variable in the component, do not modify this percentage.

--- a/Content.Shared/Clumsy/ClumsyComponent.cs
+++ b/Content.Shared/Clumsy/ClumsyComponent.cs
@@ -16,16 +16,8 @@ public sealed partial class ClumsyComponent : Component
     /// <summary>
     ///     Sound to play when clumsy interactions fail.
     /// </summary>
-    [DataField]
-    public SoundSpecifier ClumsySound = new SoundPathSpecifier("/Audio/Items/bikehorn.ogg");
-
-    // Moffstation - Start - Clumsy as a trait
-    /// <summary>
-    ///     If clumsy should play a comedic sound effect when clumsy interactions fail.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public bool ClumsySoundEnabled = true;
-    // Moffstation - End
+    [DataField, AutoNetworkedField] // Moffstation - Clumsy as a trait
+    public SoundSpecifier? ClumsySound = new SoundPathSpecifier("/Audio/Items/bikehorn.ogg"); // Moffstation - Clumsy as a trait
 
     /// <summary>
     ///     Default chance to fail a clumsy interaction.

--- a/Content.Shared/Clumsy/ClumsySystem.cs
+++ b/Content.Shared/Clumsy/ClumsySystem.cs
@@ -53,7 +53,8 @@ public sealed partial class ClumsySystem : EntitySystem
 
         args.TargetGettingInjected = args.EntityUsingInjector;
         args.OverrideMessage = Loc.GetString(ent.Comp.HypoFailedMessage);
-        _audio.PlayPredicted(ent.Comp.ClumsySound, ent, args.EntityUsingInjector);
+        if(ent.Comp.ClumsySoundEnabled) // Moffstation - Clumsy as a trait
+            _audio.PlayPredicted(ent.Comp.ClumsySound, ent, args.EntityUsingInjector); // Moffstation - Clumsy as a trait
     }
 
     private void BeforeDefibrillatorZapsEvent(Entity<ClumsyComponent> ent, ref SelfBeforeDefibrillatorZapsEvent args)
@@ -68,7 +69,8 @@ public sealed partial class ClumsySystem : EntitySystem
             return;
 
         args.DefibTarget = args.EntityUsingDefib;
-        _audio.PlayPvs(ent.Comp.ClumsySound, ent);
+        if(ent.Comp.ClumsySoundEnabled) // Moffstation - Clumsy as a trait
+            _audio.PlayPvs(ent.Comp.ClumsySound, ent); // Moffstation - Clumsy as a trait
 
     }
 
@@ -97,7 +99,8 @@ public sealed partial class ClumsySystem : EntitySystem
         var othersMessage = Loc.GetString(ent.Comp.CatchingFailedMessageOthers, ("item", ent.Owner), ("catcher", Identity.Entity(ent.Owner, EntityManager)));
         _popup.PopupEntity(selfMessage, ent.Owner, ent.Owner);
         _popup.PopupEntity(othersMessage, ent.Owner, Filter.PvsExcept(ent.Owner), true);
-        _audio.PlayPvs(ent.Comp.ClumsySound, ent);
+        if(ent.Comp.ClumsySoundEnabled) // Moffstation - Clumsy as a trait
+            _audio.PlayPvs(ent.Comp.ClumsySound, ent); // Moffstation - Clumsy as a trait
     }
 
     private void BeforeGunShotEvent(Entity<ClumsyComponent> ent, ref SelfBeforeGunShotEvent args)
@@ -121,7 +124,8 @@ public sealed partial class ClumsySystem : EntitySystem
 
         // Apply salt to the wound ("Honk!") (No idea what this comment means)
         _audio.PlayPvs(ent.Comp.GunShootFailSound, ent);
-        _audio.PlayPvs(ent.Comp.ClumsySound, ent);
+        if(ent.Comp.ClumsySoundEnabled) // Moffstation - Clumsy as a trait
+            _audio.PlayPvs(ent.Comp.ClumsySound, ent); // Moffstation - Clumsy as a trait
 
         _popup.PopupEntity(Loc.GetString(ent.Comp.GunFailedMessage), ent, ent);
         args.Cancel();
@@ -139,7 +143,8 @@ public sealed partial class ClumsySystem : EntitySystem
 
         HitHeadClumsy(ent, args.BeingClimbedOn);
 
-        _audio.PlayPredicted(ent.Comp.ClumsySound, ent, ent);
+        if (ent.Comp.ClumsySoundEnabled) // Moffstation - Clumsy as a trait
+            _audio.PlayPredicted(ent.Comp.ClumsySound, ent, ent); // Moffstation - Clumsy as a trait
 
         _audio.PlayPredicted(ent.Comp.TableBonkSound, ent, ent);
 

--- a/Content.Shared/Clumsy/ClumsySystem.cs
+++ b/Content.Shared/Clumsy/ClumsySystem.cs
@@ -53,8 +53,7 @@ public sealed partial class ClumsySystem : EntitySystem
 
         args.TargetGettingInjected = args.EntityUsingInjector;
         args.OverrideMessage = Loc.GetString(ent.Comp.HypoFailedMessage);
-        if(ent.Comp.ClumsySoundEnabled) // Moffstation - Clumsy as a trait
-            _audio.PlayPredicted(ent.Comp.ClumsySound, ent, args.EntityUsingInjector); // Moffstation - Clumsy as a trait
+        _audio.PlayPredicted(ent.Comp.ClumsySound, ent, args.EntityUsingInjector); // Moffstation - Clumsy as a trait
     }
 
     private void BeforeDefibrillatorZapsEvent(Entity<ClumsyComponent> ent, ref SelfBeforeDefibrillatorZapsEvent args)
@@ -69,8 +68,7 @@ public sealed partial class ClumsySystem : EntitySystem
             return;
 
         args.DefibTarget = args.EntityUsingDefib;
-        if(ent.Comp.ClumsySoundEnabled) // Moffstation - Clumsy as a trait
-            _audio.PlayPvs(ent.Comp.ClumsySound, ent); // Moffstation - Clumsy as a trait
+        _audio.PlayPvs(ent.Comp.ClumsySound, ent); // Moffstation - Clumsy as a trait
 
     }
 
@@ -99,8 +97,7 @@ public sealed partial class ClumsySystem : EntitySystem
         var othersMessage = Loc.GetString(ent.Comp.CatchingFailedMessageOthers, ("item", ent.Owner), ("catcher", Identity.Entity(ent.Owner, EntityManager)));
         _popup.PopupEntity(selfMessage, ent.Owner, ent.Owner);
         _popup.PopupEntity(othersMessage, ent.Owner, Filter.PvsExcept(ent.Owner), true);
-        if(ent.Comp.ClumsySoundEnabled) // Moffstation - Clumsy as a trait
-            _audio.PlayPvs(ent.Comp.ClumsySound, ent); // Moffstation - Clumsy as a trait
+        _audio.PlayPvs(ent.Comp.ClumsySound, ent); // Moffstation - Clumsy as a trait
     }
 
     private void BeforeGunShotEvent(Entity<ClumsyComponent> ent, ref SelfBeforeGunShotEvent args)
@@ -124,8 +121,7 @@ public sealed partial class ClumsySystem : EntitySystem
 
         // Apply salt to the wound ("Honk!") (No idea what this comment means)
         _audio.PlayPvs(ent.Comp.GunShootFailSound, ent);
-        if(ent.Comp.ClumsySoundEnabled) // Moffstation - Clumsy as a trait
-            _audio.PlayPvs(ent.Comp.ClumsySound, ent); // Moffstation - Clumsy as a trait
+        _audio.PlayPvs(ent.Comp.ClumsySound, ent); // Moffstation - Clumsy as a trait
 
         _popup.PopupEntity(Loc.GetString(ent.Comp.GunFailedMessage), ent, ent);
         args.Cancel();
@@ -143,8 +139,7 @@ public sealed partial class ClumsySystem : EntitySystem
 
         HitHeadClumsy(ent, args.BeingClimbedOn);
 
-        if (ent.Comp.ClumsySoundEnabled) // Moffstation - Clumsy as a trait
-            _audio.PlayPredicted(ent.Comp.ClumsySound, ent, ent); // Moffstation - Clumsy as a trait
+        _audio.PlayPredicted(ent.Comp.ClumsySound, ent, ent); // Moffstation - Clumsy as a trait
 
         _audio.PlayPredicted(ent.Comp.TableBonkSound, ent, ent);
 

--- a/Content.Shared/Clumsy/ClumsySystem.cs
+++ b/Content.Shared/Clumsy/ClumsySystem.cs
@@ -53,7 +53,7 @@ public sealed partial class ClumsySystem : EntitySystem
 
         args.TargetGettingInjected = args.EntityUsingInjector;
         args.OverrideMessage = Loc.GetString(ent.Comp.HypoFailedMessage);
-        _audio.PlayPredicted(ent.Comp.ClumsySound, ent, args.EntityUsingInjector); // Moffstation - Clumsy as a trait
+        _audio.PlayPredicted(ent.Comp.ClumsySound, ent, args.EntityUsingInjector);
     }
 
     private void BeforeDefibrillatorZapsEvent(Entity<ClumsyComponent> ent, ref SelfBeforeDefibrillatorZapsEvent args)
@@ -68,7 +68,7 @@ public sealed partial class ClumsySystem : EntitySystem
             return;
 
         args.DefibTarget = args.EntityUsingDefib;
-        _audio.PlayPvs(ent.Comp.ClumsySound, ent); // Moffstation - Clumsy as a trait
+        _audio.PlayPvs(ent.Comp.ClumsySound, ent);
 
     }
 
@@ -97,7 +97,7 @@ public sealed partial class ClumsySystem : EntitySystem
         var othersMessage = Loc.GetString(ent.Comp.CatchingFailedMessageOthers, ("item", ent.Owner), ("catcher", Identity.Entity(ent.Owner, EntityManager)));
         _popup.PopupEntity(selfMessage, ent.Owner, ent.Owner);
         _popup.PopupEntity(othersMessage, ent.Owner, Filter.PvsExcept(ent.Owner), true);
-        _audio.PlayPvs(ent.Comp.ClumsySound, ent); // Moffstation - Clumsy as a trait
+        _audio.PlayPvs(ent.Comp.ClumsySound, ent);
     }
 
     private void BeforeGunShotEvent(Entity<ClumsyComponent> ent, ref SelfBeforeGunShotEvent args)
@@ -121,7 +121,7 @@ public sealed partial class ClumsySystem : EntitySystem
 
         // Apply salt to the wound ("Honk!") (No idea what this comment means)
         _audio.PlayPvs(ent.Comp.GunShootFailSound, ent);
-        _audio.PlayPvs(ent.Comp.ClumsySound, ent); // Moffstation - Clumsy as a trait
+        _audio.PlayPvs(ent.Comp.ClumsySound, ent);
 
         _popup.PopupEntity(Loc.GetString(ent.Comp.GunFailedMessage), ent, ent);
         args.Cancel();
@@ -139,7 +139,7 @@ public sealed partial class ClumsySystem : EntitySystem
 
         HitHeadClumsy(ent, args.BeingClimbedOn);
 
-        _audio.PlayPredicted(ent.Comp.ClumsySound, ent, ent); // Moffstation - Clumsy as a trait
+        _audio.PlayPredicted(ent.Comp.ClumsySound, ent, ent);
 
         _audio.PlayPredicted(ent.Comp.TableBonkSound, ent, ent);
 

--- a/Resources/Prototypes/_Moffstation/Traits/medical.yml
+++ b/Resources/Prototypes/_Moffstation/Traits/medical.yml
@@ -86,7 +86,7 @@
   - !type:AddCompsEffect
     components:
     - type: Clumsy
-      clumsySoundEnabled: false
+      clumsySound: null
 
 - type: trait
   id: Snoring

--- a/Resources/Prototypes/_Moffstation/Traits/medical.yml
+++ b/Resources/Prototypes/_Moffstation/Traits/medical.yml
@@ -86,6 +86,7 @@
   - !type:AddCompsEffect
     components:
     - type: Clumsy
+      clumsySoundEnabled: false
 
 - type: trait
   id: Snoring


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Clumsy as a trait will no longer play the clown horn sfx.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
While the clown horn sfx is comedic for clowns - for other more serious characters, it was brought up that it was a bit demeaning for characters meant to represent true disabilities. This pull request does not remove the horn sfx for clowns or alternate sounds for monkeys and kobolds, but removes this slapstick element for the trait variant.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Makes clumsy's sound specifier nullable and autonetworked, so 'null' sfx may be assigned. 

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
- Spawn in with a character that possesses clumsy.
- Jump onto a table until clumsy triggers.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl: Centronias, Nyxilath


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- fix: Clumsy as a character trait will no longer play a bikehorn sfx