### PR TITLE
Light/APC Overload Event.

### DIFF
--- a/Content.Server/_Moffstation/GameTicking/Rules/Components/LightOverloadRuleComponent.cs
+++ b/Content.Server/_Moffstation/GameTicking/Rules/Components/LightOverloadRuleComponent.cs
@@ -1,0 +1,41 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Moffstation.GameTicking.Rules.Components;
+
+/// <summary>
+/// This is used for...
+/// </summary>
+[RegisterComponent]
+public sealed partial class LightOverloadRuleComponent : Component
+{
+    // The radius around the APC to search for lights to explode.
+    // This is needed because there isn't an easy way to determine which APC a light is connected to.
+    [DataField]
+    public float Radius = 8.0f;
+
+    // The type of sparks prototype to spawn on the lights when they explode.
+    [DataField]
+    public EntProtoId SparksPrototype = "ESEffectSparks";
+
+    // The probability of sparks spawning at the light when it goes out.
+    [DataField]
+    public float SparksProbability = 0.5f;
+
+    // The probability that a light within the radius blows up.
+    [DataField]
+    public float LightOverloadProbability = 0.8f;
+
+    // The maximum delay before a light explodes.
+    [DataField]
+    public TimeSpan MaxDelay =  TimeSpan.FromSeconds(5.0);
+
+    // The probability that a light becomes a blinking light.
+    [DataField]
+    public float LightBlinkingProbability = 0.2f;
+
+    // The amount of time a light will remain blinking.
+    [DataField]
+    public TimeSpan BlinkTime =  TimeSpan.FromSeconds(30.0);
+
+
+}

--- a/Content.Server/_Moffstation/GameTicking/Rules/Components/LightOverloadRuleComponent.cs
+++ b/Content.Server/_Moffstation/GameTicking/Rules/Components/LightOverloadRuleComponent.cs
@@ -3,7 +3,8 @@ using Robust.Shared.Prototypes;
 namespace Content.Server._Moffstation.GameTicking.Rules.Components;
 
 /// <summary>
-/// This is used for...
+/// This component is for round event rules which selects an APC and explodes lights in a radius around it.
+/// <seealso cref="LightOverloadRuleSystem"/>
 /// </summary>
 [RegisterComponent]
 public sealed partial class LightOverloadRuleComponent : Component
@@ -37,5 +38,11 @@ public sealed partial class LightOverloadRuleComponent : Component
     [DataField]
     public TimeSpan BlinkTime =  TimeSpan.FromSeconds(30.0);
 
+    // The announcement to make when this rule triggers.
+    [DataField]
+    public string Announcement = "light-overload-announcement";
 
+    // The color to use when making the announcement
+    [DataField]
+    public Color AnnouncementColor = Color.Yellow;
 }

--- a/Content.Server/_Moffstation/GameTicking/Rules/Components/LightOverloadRuleComponent.cs
+++ b/Content.Server/_Moffstation/GameTicking/Rules/Components/LightOverloadRuleComponent.cs
@@ -27,7 +27,7 @@ public sealed partial class LightOverloadRuleComponent : Component
 
     // The maximum delay before a light explodes.
     [DataField]
-    public TimeSpan MaxDelay =  TimeSpan.FromSeconds(5.0);
+    public TimeSpan MaxDelay = TimeSpan.FromSeconds(5.0);
 
     // The probability that a light becomes a blinking light.
     [DataField]

--- a/Content.Server/_Moffstation/GameTicking/Rules/Components/LightOverloadRuleComponent.cs
+++ b/Content.Server/_Moffstation/GameTicking/Rules/Components/LightOverloadRuleComponent.cs
@@ -36,7 +36,7 @@ public sealed partial class LightOverloadRuleComponent : Component
 
     // The amount of time a light will remain blinking.
     [DataField]
-    public TimeSpan BlinkTime =  TimeSpan.FromSeconds(30.0);
+    public TimeSpan BlinkTime = TimeSpan.FromSeconds(30.0);
 
     // The announcement to make when this rule triggers.
     [DataField]

--- a/Content.Server/_Moffstation/GameTicking/Rules/Components/LightOverloadRuleComponent.cs
+++ b/Content.Server/_Moffstation/GameTicking/Rules/Components/LightOverloadRuleComponent.cs
@@ -40,7 +40,7 @@ public sealed partial class LightOverloadRuleComponent : Component
 
     // The announcement to make when this rule triggers.
     [DataField]
-    public string Announcement = "light-overload-announcement";
+    public LocId Announcement = "light-overload-announcement";
 
     // The color to use when making the announcement
     [DataField]

--- a/Content.Server/_Moffstation/GameTicking/Rules/LightOverloadRuleSystem.cs
+++ b/Content.Server/_Moffstation/GameTicking/Rules/LightOverloadRuleSystem.cs
@@ -1,0 +1,79 @@
+using Content.Server._Moffstation.GameTicking.Rules.Components;
+using Content.Server._Moffstation.Power.Components;
+using Content.Server.Chat.Systems;
+using Content.Server.GameTicking.Rules;
+using Content.Server.Light.EntitySystems;
+using Content.Server.Pinpointer;
+using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
+using Content.Server.Radio.EntitySystems;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Light.Components;
+using Content.Shared.Station.Components;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Server._Moffstation.GameTicking.Rules;
+
+/// <summary>
+/// This rule selects a random APC on the station and breaks lights connected to it, with accompanying sparks and sounds.
+/// </summary>
+public sealed partial class LightOverloadRuleSystem : GameRuleSystem<LightOverloadRuleComponent>
+{
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private ApcSystem _apcSystem = default!;
+    [Dependency] private EntityLookupSystem _entityLookup = default!;
+    [Dependency] private IGameTiming _gameTime = default!;
+    [Dependency] private NavMapSystem _navMap = default!;
+    [Dependency] private ChatSystem _chatSystem = default!;
+
+    protected override void Started(EntityUid entity, LightOverloadRuleComponent component, GameRuleComponent ruleData, GameRuleStartedEvent args)
+    {
+        base.Started(entity, component, ruleData, args);
+
+        if (!TryGetRandomStation(out var chosenStation))
+            return;
+
+        var stationApcs = new List<Entity<ApcComponent, TransformComponent>>();
+        var query = EntityQueryEnumerator<ApcComponent, TransformComponent>();
+        while (query.MoveNext(out var apcUid, out var apc, out var xform))
+        {
+            if (apc.MainBreakerEnabled && CompOrNull<StationMemberComponent>(xform.GridUid)?.Station == chosenStation)
+            {
+                stationApcs.Add((apcUid, apc, xform));
+            }
+        }
+
+        var selectedApc = stationApcs[_random.Next(stationApcs.Count)];
+        _apcSystem.ApcToggleBreaker(selectedApc);
+        var apcCoords = selectedApc.Comp2.Coordinates;
+        Spawn(component.SparksPrototype, apcCoords);
+
+        var message = Loc.GetString("light-overload-announcement",
+            ("location", FormattedMessage.RemoveMarkupOrThrow(
+                _navMap.GetNearestBeaconString((selectedApc, selectedApc.Comp2)))));
+
+        _chatSystem.DispatchStationAnnouncement(chosenStation.Value, message, playDefaultSound: true, colorOverride: Color.Yellow);
+
+        foreach (var light in _entityLookup.GetEntitiesInRange<PoweredLightComponent>(
+                     apcCoords,
+                     component.Radius))
+        {
+            if (_random.Prob(component.LightOverloadProbability))
+            {
+                var explodeTimer = EnsureComp<LightExplodeTimerComponent>(light);
+                explodeTimer.ExplodeTimer = _random.NextFloat((float) component.MaxDelay.TotalSeconds);
+                explodeTimer.SparksPrototype = component.SparksPrototype;
+                explodeTimer.SparksProbability = component.SparksProbability;
+            }
+
+            if (_random.Prob(component.LightBlinkingProbability))
+            {
+                var blinking = EnsureComp<BlinkingPoweredLightComponent>(light);
+                blinking.StopBlinkingTime = _gameTime.CurTime + component.BlinkTime;
+            }
+        }
+    }
+}

--- a/Content.Server/_Moffstation/GameTicking/Rules/LightOverloadRuleSystem.cs
+++ b/Content.Server/_Moffstation/GameTicking/Rules/LightOverloadRuleSystem.cs
@@ -29,9 +29,9 @@ public sealed partial class LightOverloadRuleSystem : GameRuleSystem<LightOverlo
     [Dependency] private NavMapSystem _navMap = default!;
     [Dependency] private ChatSystem _chatSystem = default!;
 
-    protected override void Started(EntityUid entity, LightOverloadRuleComponent component, GameRuleComponent ruleData, GameRuleStartedEvent args)
+    protected override void Started(EntityUid entity, LightOverloadRuleComponent overloadComp, GameRuleComponent ruleData, GameRuleStartedEvent args)
     {
-        base.Started(entity, component, ruleData, args);
+        base.Started(entity, overloadComp, ruleData, args);
 
         if (!TryGetRandomStation(out var chosenStation))
             return;
@@ -49,30 +49,33 @@ public sealed partial class LightOverloadRuleSystem : GameRuleSystem<LightOverlo
         var selectedApc = stationApcs[_random.Next(stationApcs.Count)];
         _apcSystem.ApcToggleBreaker(selectedApc);
         var apcCoords = selectedApc.Comp2.Coordinates;
-        Spawn(component.SparksPrototype, apcCoords);
+        Spawn(overloadComp.SparksPrototype, apcCoords);
 
-        var message = Loc.GetString("light-overload-announcement",
+        var message = Loc.GetString(overloadComp.Announcement,
             ("location", FormattedMessage.RemoveMarkupOrThrow(
                 _navMap.GetNearestBeaconString((selectedApc, selectedApc.Comp2)))));
 
-        _chatSystem.DispatchStationAnnouncement(chosenStation.Value, message, playDefaultSound: true, colorOverride: Color.Yellow);
+        _chatSystem.DispatchStationAnnouncement(chosenStation.Value, message, playDefaultSound: true, colorOverride: overloadComp.AnnouncementColor);
 
         foreach (var light in _entityLookup.GetEntitiesInRange<PoweredLightComponent>(
                      apcCoords,
-                     component.Radius))
+                     overloadComp.Radius))
         {
-            if (_random.Prob(component.LightOverloadProbability))
+            if (_random.Prob(overloadComp.LightOverloadProbability))
             {
                 var explodeTimer = EnsureComp<LightExplodeTimerComponent>(light);
-                explodeTimer.ExplodeTimer = _random.NextFloat((float) component.MaxDelay.TotalSeconds);
-                explodeTimer.SparksPrototype = component.SparksPrototype;
-                explodeTimer.SparksProbability = component.SparksProbability;
+                explodeTimer.ExplodeTimer = _random.NextFloat((float) overloadComp.MaxDelay.TotalSeconds);
+                explodeTimer.SparksPrototype = overloadComp.SparksPrototype;
+                explodeTimer.SparksProbability = overloadComp.SparksProbability;
             }
 
-            if (_random.Prob(component.LightBlinkingProbability))
+            // We have both of these probabilities get rolled on all the lights so
+            // sometimes there is a light that starts blinking then explodes.
+            // For the flavor.
+            if (_random.Prob(overloadComp.LightBlinkingProbability))
             {
                 var blinking = EnsureComp<BlinkingPoweredLightComponent>(light);
-                blinking.StopBlinkingTime = _gameTime.CurTime + component.BlinkTime;
+                blinking.StopBlinkingTime = _gameTime.CurTime + overloadComp.BlinkTime;
             }
         }
     }

--- a/Content.Server/_Moffstation/Power/Components/LightExplodeTimerComponent.cs
+++ b/Content.Server/_Moffstation/Power/Components/LightExplodeTimerComponent.cs
@@ -4,7 +4,7 @@ namespace Content.Server._Moffstation.Power.Components;
 
 /// <summary>
 /// This component gets added to a light during a light overload event causing it to explode.
-/// See LightOverloadRuleSystem for more information.
+/// See <see cref="LightOverloadRuleSystem"/> for more information.
 /// </summary>
 [RegisterComponent]
 public sealed partial class LightExplodeTimerComponent : Component
@@ -13,12 +13,12 @@ public sealed partial class LightExplodeTimerComponent : Component
     public float ExplodeTimer = 0.0f;
 
     // The probability of sparks spawning at the light when it goes out.
-    // This is set by the LightOverloadRuleSystem.
+    // This is set by the <see cref="LightOverloadRuleSystem"/>.
     [DataField]
     public float SparksProbability = 0.5f;
 
     // The type of sparks prototype to spawn on the lights when they explode.
-    // This is set by the LightOverloadRuleSystem.
+    // This is set by the <see cref="LightOverloadRuleSystem"/>.
     [DataField]
     public EntProtoId SparksPrototype = "ESEffectSparks";
 }

--- a/Content.Server/_Moffstation/Power/Components/LightExplodeTimerComponent.cs
+++ b/Content.Server/_Moffstation/Power/Components/LightExplodeTimerComponent.cs
@@ -1,0 +1,24 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Moffstation.Power.Components;
+
+/// <summary>
+/// This component gets added to a light during a light overload event causing it to explode.
+/// See LightOverloadRuleSystem for more information.
+/// </summary>
+[RegisterComponent]
+public sealed partial class LightExplodeTimerComponent : Component
+{
+    [DataField]
+    public float ExplodeTimer = 0.0f;
+
+    // The probability of sparks spawning at the light when it goes out.
+    // This is set by the LightOverloadRuleSystem.
+    [DataField]
+    public float SparksProbability = 0.5f;
+
+    // The type of sparks prototype to spawn on the lights when they explode.
+    // This is set by the LightOverloadRuleSystem.
+    [DataField]
+    public EntProtoId SparksPrototype = "ESEffectSparks";
+}

--- a/Content.Server/_Moffstation/Power/EntitySystems/LightExplodeTimerSystem.cs
+++ b/Content.Server/_Moffstation/Power/EntitySystems/LightExplodeTimerSystem.cs
@@ -6,17 +6,14 @@ using Robust.Shared.Random;
 namespace Content.Server._Moffstation.Power.EntitySystems;
 
 /// <summary>
-/// This handles...
+/// This handles updating the <see cref="LightExplodeTimerComponents"/> when they're applied to lights.
+/// Usually this component gets added to lights via the <see cref="LightOverloadRuleSystem"/> but
+/// this does also work if an admin simply adds the component themselves via toolshed.
 /// </summary>
 public sealed partial class LightExplodeTimerSystem : EntitySystem
 {
     [Dependency] private PoweredLightSystem _poweredLight = default!;
     [Dependency] private IRobustRandom _random = default!;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-    }
 
     public override void Update(float frameTime)
     {
@@ -29,7 +26,7 @@ public sealed partial class LightExplodeTimerSystem : EntitySystem
             if (explodeTimer.ExplodeTimer > 0.0f)
                 continue;
 
-            _poweredLight.TryDestroyBulb(lightUid);
+            _poweredLight.TryDestroyBulb(lightUid, light);
 
             if (!_random.Prob(explodeTimer.SparksProbability))
                 Spawn(explodeTimer.SparksPrototype, xform.Coordinates);

--- a/Content.Server/_Moffstation/Power/EntitySystems/LightExplodeTimerSystem.cs
+++ b/Content.Server/_Moffstation/Power/EntitySystems/LightExplodeTimerSystem.cs
@@ -1,0 +1,40 @@
+using Content.Server._Moffstation.Power.Components;
+using Content.Server.Light.EntitySystems;
+using Content.Shared.Light.Components;
+using Robust.Shared.Random;
+
+namespace Content.Server._Moffstation.Power.EntitySystems;
+
+/// <summary>
+/// This handles...
+/// </summary>
+public sealed partial class LightExplodeTimerSystem : EntitySystem
+{
+    [Dependency] private PoweredLightSystem _poweredLight = default!;
+    [Dependency] private IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<LightExplodeTimerComponent, PoweredLightComponent, TransformComponent>();
+        while (query.MoveNext(out var lightUid, out var explodeTimer, out var light, out var xform))
+        {
+            explodeTimer.ExplodeTimer -= frameTime;
+            if (explodeTimer.ExplodeTimer > 0.0f)
+                continue;
+
+            _poweredLight.TryDestroyBulb(lightUid);
+
+            if (!_random.Prob(explodeTimer.SparksProbability))
+                Spawn(explodeTimer.SparksPrototype, xform.Coordinates);
+
+            RemComp(lightUid, explodeTimer);
+        }
+    }
+}

--- a/Content.Server/_Moffstation/Power/EntitySystems/LightExplodeTimerSystem.cs
+++ b/Content.Server/_Moffstation/Power/EntitySystems/LightExplodeTimerSystem.cs
@@ -28,7 +28,7 @@ public sealed partial class LightExplodeTimerSystem : EntitySystem
 
             _poweredLight.TryDestroyBulb(lightUid, light);
 
-            if (!_random.Prob(explodeTimer.SparksProbability))
+            if (_random.Prob(explodeTimer.SparksProbability))
                 Spawn(explodeTimer.SparksPrototype, xform.Coordinates);
 
             RemComp(lightUid, explodeTimer);

--- a/Resources/Locale/en-US/_Moffstation/station-events/light-overload.ftl
+++ b/Resources/Locale/en-US/_Moffstation/station-events/light-overload.ftl
@@ -1,1 +1,1 @@
-light-overload-announcement = Attention. An anomalous power surge has been detected {$location}. Please watch for broken lights and power outages.
+light-overload-announcement = Attention. An anomalous power surge has been detected {$location}. Please watch for sparks and broken lights.

--- a/Resources/Locale/en-US/_Moffstation/station-events/light-overload.ftl
+++ b/Resources/Locale/en-US/_Moffstation/station-events/light-overload.ftl
@@ -1,0 +1,1 @@
+light-overload-announcement = Attention. An anomalous power surge has been detected {$location}. Please watch for broken lights and power outages.

--- a/Resources/Locale/en-US/_Moffstation/station-events/light-overload.ftl
+++ b/Resources/Locale/en-US/_Moffstation/station-events/light-overload.ftl
@@ -1,1 +1,1 @@
-light-overload-announcement = Attention. An anomalous power surge has been detected {$location}. Please watch for sparks and broken lights.
+light-overload-announcement = Attention. An anomalous power surge has tripped the breaker in an APC {$location}. Please watch for sparks and broken lights.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -26,7 +26,6 @@
     #- id: SpiderSpawnHorde # Moffstation - Move to pests table
     - id: VentClog
 
-
 - type: entityTable
   id: BasicAntagEventsTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -13,6 +13,8 @@
     - id: GreytideVirus
     - id: IonStorm # its calm like 90% of the time smh
     - id: KudzuGrowth
+    - id: LightOverloadRule # Moffstation - New events
+    - id: LightOverloadRuleBlinking # Moffstation - New events
     - id: MassHallucinations
     - id: MouseMigration
     - id: PowerGridCheck
@@ -23,6 +25,7 @@
     #- id: SpiderClownSpawnHorde # Moffstation - Move to pests table
     #- id: SpiderSpawnHorde # Moffstation - Move to pests table
     - id: VentClog
+
 
 - type: entityTable
   id: BasicAntagEventsTable

--- a/Resources/Prototypes/_Moffstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/events.yml
@@ -87,3 +87,12 @@
   - type: LightOverloadRule
   - type: DynamicRuleCost
     cost: 5
+
+- type: entity
+  parent: LightOverloadRule
+  id: LightOverloadRuleBlinking
+  components:
+  - type: LightOverloadRule
+    radius: 12.0
+    lightOverloadProbability: 0.1
+    lightBlinkingProbability: 0.4

--- a/Resources/Prototypes/_Moffstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/events.yml
@@ -73,3 +73,17 @@
       proto: SyndieVentSoldier
   - type: DynamicRuleCost
     cost: 25
+
+# Lights go boom
+- type: entity
+  parent: BaseStationEventShortDelay
+  id: LightOverloadRule
+  components:
+  - type: StationEvent
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    earliestStart: 10
+    weight: 4
+  - type: LightOverloadRule
+  - type: DynamicRuleCost
+    cost: 5

--- a/Resources/Prototypes/_Moffstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/events.yml
@@ -83,7 +83,7 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     earliestStart: 10
-    weight: 4
+    weight: 6
   - type: LightOverloadRule
   - type: DynamicRuleCost
     cost: 5


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->

Ever wish lights could just go out on their own? Tired of things working too well? Are you an antag looking for some convenient darkness? Well I have the thing for you! This event randomly chooses an APC on the station and breaks most of the lights around it, while also shutting it off. 

Some of the lights around the APC will also become all blinky, which just adds further annoyance and really helps set the tone of the station. The only way lights become blinky normally is via a start-of-round variation which I'm not a huge fan of since I think they add a lot of atmosphere. 

Janitors can also benefit from this new event, since now they'll have plenty more lights to fix, and can use this event as an excuse to get into some departments easier. 

I was inspired by https://github.com/EphemeralSpace/ephemeral-space/pull/1439 which does a similar thing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

See above.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->

Added a new rule system and component which handles most of this process. Also added a timer component and accompanying system which staggers out the lights exploding, so they don't all go out at once.

If you're wondering why I didn't figure out which lights are actually connected to an APC instead of using the radius around it, well that's because there's no way to really do that easily right now. Cables don't keep track of what provider they're attached to, just what power flows through them. 

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Start a round, preferably on a small map like Reach.
Add the `LightOverloadRule`
Watch as a random APC is selected and the lights around it start exploding.

## Media

https://github.com/user-attachments/assets/fc524de8-9e31-4ca6-a1cc-f34f5962e84b


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

None, other than the lights that are gonna be breaking.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl: Southbridge
- add: There is now a new event which causes lights around an APC to shatter and degrade.

