### PR TITLE
Added a page about topicals to the guidebook

### DIFF
--- a/Resources/Locale/en-US/_Moffstation/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Moffstation/guidebook/guides.ftl
@@ -10,3 +10,5 @@ moff-eor-rules = End of Round rules
 moff-crew-rules = Crew rules
 moff-antag-rules = Antag rules
 moff-prisoner-rules = Prisoner rules
+
+moff-guide-entry-topicals = Topicals

--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -116,6 +116,9 @@ guide-entry-biological = Biological
 guide-entry-botanical = Botanical
 guide-entry-special = Special
 guide-entry-others = Others
+# Moffstation - guidebook topicals:
+guide-entry-topicals = Topicals
+# Moffstation - end
 
 guide-entry-pizza-recipes = Pizzas
 guide-entry-savory-recipes = Savory Foods

--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -116,9 +116,6 @@ guide-entry-biological = Biological
 guide-entry-botanical = Botanical
 guide-entry-special = Special
 guide-entry-others = Others
-# Moffstation - guidebook topicals:
-guide-entry-topicals = Topicals
-# Moffstation - end
 
 guide-entry-pizza-recipes = Pizzas
 guide-entry-savory-recipes = Savory Foods

--- a/Resources/Prototypes/Guidebook/medical.yml
+++ b/Resources/Prototypes/Guidebook/medical.yml
@@ -33,6 +33,7 @@
   # TODO GUIDEBOOK Maybe allow duplicate entries?
   - Botanicals
   - AdvancedBrute
+  - Topicals # Moffstation - guidebook topicals
 
 - type: guideEntry
   id: Medicine
@@ -50,3 +51,10 @@
   id: AdvancedBrute
   name: guide-entry-brute
   text: "/ServerInfo/Guidebook/Medical/AdvancedBrute.xml"
+
+# Moffstation - guidebook topicals - start
+- type: guideEntry
+  id: Topicals
+  name: guide-entry-topicals
+  text: "/ServerInfo/_Moffstation/Guidebook/Medical/Topicals.xml"
+# Moffstation - guidebook topicals - end

--- a/Resources/Prototypes/Guidebook/medical.yml
+++ b/Resources/Prototypes/Guidebook/medical.yml
@@ -33,7 +33,7 @@
   # TODO GUIDEBOOK Maybe allow duplicate entries?
   - Botanicals
   - AdvancedBrute
-  - Topicals # Moffstation - guidebook topicals
+  - MoffTopicals # Moffstation - guidebook topicals
 
 - type: guideEntry
   id: Medicine
@@ -51,10 +51,3 @@
   id: AdvancedBrute
   name: guide-entry-brute
   text: "/ServerInfo/Guidebook/Medical/AdvancedBrute.xml"
-
-# Moffstation - guidebook topicals - start
-- type: guideEntry
-  id: Topicals
-  name: guide-entry-topicals
-  text: "/ServerInfo/_Moffstation/Guidebook/Medical/Topicals.xml"
-# Moffstation - guidebook topicals - end

--- a/Resources/Prototypes/_Moffstation/Guidebook/medical.yml
+++ b/Resources/Prototypes/_Moffstation/Guidebook/medical.yml
@@ -1,0 +1,4 @@
+- type: guideEntry
+  id: MoffTopicals
+  name: moff-guide-entry-topicals
+  text: "/ServerInfo/_Moffstation/Guidebook/Medical/Topicals.xml"

--- a/Resources/ServerInfo/_Moffstation/Guidebook/Medical/Topicals.xml
+++ b/Resources/ServerInfo/_Moffstation/Guidebook/Medical/Topicals.xml
@@ -1,0 +1,64 @@
+<Document>
+
+  # Basic Topicals
+  Basic topicals are made in the techfab, or in the case of Gauze can also be crafted by hand.
+
+  ## Brutepack
+  <Box HorizontalAlignment="Left">
+    <GuideEntityEmbed Entity="Brutepack" Caption="" Margin="0 -5 0 0"/>
+    <Box Orientation="Vertical">
+      - 0.25 steel & 0.25 plastic
+      - Heals [color=green]5 Blunt, Piercing and Slash[/color]
+    </Box>
+  </Box>
+
+  ## Ointment
+  <Box HorizontalAlignment="Left">
+    <GuideEntityEmbed Entity="Ointment" Caption="" Margin="0 -5 0 0"/>
+    <Box Orientation="Vertical">
+      - 0.25 glass & 0.25 plastic
+      - Heals [color=green]5 Heat, Cold, and Shock and 1.5 Caustic[/color]
+    </Box>
+  </Box>
+
+  ## Gauze
+  <Box HorizontalAlignment="Left">
+    <GuideEntityEmbed Entity="Gauze" Caption="" Margin="0 -5 0 0"/>
+    <Box Orientation="Vertical">
+      - 1 cloth, or 2 when made by hand
+      - Heals [color=green]10 Piercing, 5 Slash and stops bleeding[/color]
+    </Box>
+  </Box>
+
+  ## Bloodpack
+  <Box HorizontalAlignment="Left">
+    <GuideEntityEmbed Entity="Bloodpack" Caption="" Margin="0 -5 0 0"/>
+    <Box Orientation="Vertical">
+      - Cannot be crafted
+      - Heals [color=green]0.5 bloodloss and restores ~5% blood volume[/color]
+    </Box>
+  </Box>
+
+  ## Tourniquet
+  <Box HorizontalAlignment="Left">
+    <GuideEntityEmbed Entity="Tourniquet" Caption="" Margin="0 -5 0 0"/>
+    <Box Orientation="Vertical">
+      - Cannot be crafted
+      - Does [color=red]5 Blunt and 5 Asphyxiation damage[/color]
+      - [color=green]Stops bleeding. Much faster to apply than Gauze.[/color]
+    </Box>
+  </Box>
+
+  # Advanced Topicals
+  Advanced topicals must be made in the microwave.
+
+  <GuideMicrowaveEmbed Recipe="RecipeMedicatedSuture"/>
+  - Heals [color=green]10 Blunt, Piercing, Slash and stops bleeding[/color]
+  <GuideMicrowaveEmbed Recipe="RecipeRegenerativeMesh"/>
+  - Heals [color=green]10 Heat, Cold, Shock and Caustic[/color]
+  <GuideMicrowaveEmbed Recipe="RecipePoulticePack"/>
+  - Heals the same as Brutepacks
+  <GuideMicrowaveEmbed Recipe="RecipeAloeCream"/>
+  - Heals the same as Ointment
+
+</Document>


### PR DESCRIPTION
## About the PR
I created a page containing information such as the recipes and effects of topicals, because for some reason we didn't have one.

## Why / Balance
Useful reference. Nobody wants to go to google or github to check the recipes while playing a round.

## Technical details
Only _slightly_ cursed xaml.

## Test plan
- Open game
- Open guidebook page
- :eye: :eye:

## Media
<img width="590" height="1136" alt="2026-06-27_15-24_1" src="https://github.com/user-attachments/assets/88ca2e2c-f1fe-4073-940f-613cfa89ec47" />
<img width="587" height="909" alt="2026-06-27_15-25" src="https://github.com/user-attachments/assets/84a4ee5a-fa2d-4e3e-ab0c-d4ed5c49ef18" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none (probably)

## Changelog
- add: The guidebook now has a page detailing topical medications.