### PR TITLE
Replace cursed anchor IDs with less cursed anchor IDs

### DIFF
--- a/Resources/Prototypes/Decals/bricktile_dark.yml
+++ b/Resources/Prototypes/Decals/bricktile_dark.yml
@@ -2,117 +2,117 @@
   id: BrickTileDarkBox
   tags: ["station", "markings"]
   sprite:
-    sprite: &bricktile.rsi _Moffstation/Decals/bricktile.rsi # Moffstation
+    sprite: &bricktile_rsi _Moffstation/Decals/bricktile.rsi # Moffstation
     state: dark_box
 
 - type: decal
   id: BrickTileDarkCornerNe
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_corner_ne
 
 - type: decal
   id: BrickTileDarkCornerSe
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_corner_se
 
 - type: decal
   id: BrickTileDarkCornerNw
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_corner_nw
 
 - type: decal
   id: BrickTileDarkCornerSw
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_corner_sw
 
 - type: decal
   id: BrickTileDarkInnerNe
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_inner_ne
 
 - type: decal
   id: BrickTileDarkInnerSe
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_inner_se
 
 - type: decal
   id: BrickTileDarkInnerNw
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_inner_nw
 
 - type: decal
   id: BrickTileDarkInnerSw
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_inner_sw
 
 - type: decal
   id: BrickTileDarkEndN
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_end_n
 
 - type: decal
   id: BrickTileDarkEndE
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_end_e
 
 - type: decal
   id: BrickTileDarkEndS
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_end_s
 
 - type: decal
   id: BrickTileDarkEndW
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_end_w
 
 - type: decal
   id: BrickTileDarkLineN
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_line_n
 
 - type: decal
   id: BrickTileDarkLineE
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_line_e
 
 - type: decal
   id: BrickTileDarkLineS
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_line_s
 
 - type: decal
   id: BrickTileDarkLineW
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: dark_line_w

--- a/Resources/Prototypes/Decals/bricktile_steel.yml
+++ b/Resources/Prototypes/Decals/bricktile_steel.yml
@@ -2,117 +2,117 @@
   id: BrickTileSteelBox
   tags: ["station", "markings"]
   sprite:
-    sprite: &bricktile.rsi _Moffstation/Decals/bricktile.rsi # Moffstation
+    sprite: &bricktile_rsi _Moffstation/Decals/bricktile.rsi # Moffstation
     state: steel_box
 
 - type: decal
   id: BrickTileSteelCornerNe
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_corner_ne
 
 - type: decal
   id: BrickTileSteelCornerSe
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_corner_se
 
 - type: decal
   id: BrickTileSteelCornerNw
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_corner_nw
 
 - type: decal
   id: BrickTileSteelCornerSw
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_corner_sw
 
 - type: decal
   id: BrickTileSteelInnerNe
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_inner_ne
 
 - type: decal
   id: BrickTileSteelInnerSe
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_inner_se
 
 - type: decal
   id: BrickTileSteelInnerNw
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_inner_nw
 
 - type: decal
   id: BrickTileSteelInnerSw
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_inner_sw
 
 - type: decal
   id: BrickTileSteelEndN
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_end_n
 
 - type: decal
   id: BrickTileSteelEndE
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_end_e
 
 - type: decal
   id: BrickTileSteelEndS
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_end_s
 
 - type: decal
   id: BrickTileSteelEndW
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_end_w
 
 - type: decal
   id: BrickTileSteelLineN
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_line_n
 
 - type: decal
   id: BrickTileSteelLineE
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_line_e
 
 - type: decal
   id: BrickTileSteelLineS
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_line_s
 
 - type: decal
   id: BrickTileSteelLineW
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: steel_line_w

--- a/Resources/Prototypes/Decals/bricktile_white.yml
+++ b/Resources/Prototypes/Decals/bricktile_white.yml
@@ -2,117 +2,117 @@
   id: BrickTileWhiteBox
   tags: ["station", "markings"]
   sprite:
-    sprite: &bricktile.rsi _Moffstation/Decals/bricktile.rsi # Moffstation
+    sprite: &bricktile_rsi _Moffstation/Decals/bricktile.rsi # Moffstation
     state: white_box
 
 - type: decal
   id: BrickTileWhiteCornerNe
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_corner_ne
 
 - type: decal
   id: BrickTileWhiteCornerSe
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_corner_se
 
 - type: decal
   id: BrickTileWhiteCornerNw
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_corner_nw
 
 - type: decal
   id: BrickTileWhiteCornerSw
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_corner_sw
 
 - type: decal
   id: BrickTileWhiteInnerNe
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_inner_ne
 
 - type: decal
   id: BrickTileWhiteInnerSe
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_inner_se
 
 - type: decal
   id: BrickTileWhiteInnerNw
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_inner_nw
 
 - type: decal
   id: BrickTileWhiteInnerSw
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_inner_sw
 
 - type: decal
   id: BrickTileWhiteEndN
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_end_n
 
 - type: decal
   id: BrickTileWhiteEndE
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_end_e
 
 - type: decal
   id: BrickTileWhiteEndS
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_end_s
 
 - type: decal
   id: BrickTileWhiteEndW
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_end_w
 
 - type: decal
   id: BrickTileWhiteLineN
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_line_n
 
 - type: decal
   id: BrickTileWhiteLineE
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_line_e
 
 - type: decal
   id: BrickTileWhiteLineS
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_line_s
 
 - type: decal
   id: BrickTileWhiteLineW
   tags: ["station", "markings"]
   sprite:
-    sprite: *bricktile.rsi # Moffstation
+    sprite: *bricktile_rsi # Moffstation
     state: white_line_w

--- a/Resources/Prototypes/Decals/minitile_dark.yml
+++ b/Resources/Prototypes/Decals/minitile_dark.yml
@@ -2,117 +2,117 @@
   id: MiniTileDarkBox
   tags: ["station", "markings"]
   sprite:
-    sprite: &minitile.rsi _Moffstation/Decals/minitile.rsi # Moffstation
+    sprite: &minitile_rsi _Moffstation/Decals/minitile.rsi # Moffstation
     state: dark_box
 
 - type: decal
   id: MiniTileDarkCornerNe
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_corner_ne
 
 - type: decal
   id: MiniTileDarkCornerSe
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_corner_se
 
 - type: decal
   id: MiniTileDarkCornerNw
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_corner_nw
 
 - type: decal
   id: MiniTileDarkCornerSw
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_corner_sw
 
 - type: decal
   id: MiniTileDarkInnerNe
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_inner_ne
 
 - type: decal
   id: MiniTileDarkInnerSe
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_inner_se
 
 - type: decal
   id: MiniTileDarkInnerNw
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_inner_nw
 
 - type: decal
   id: MiniTileDarkInnerSw
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_inner_sw
 
 - type: decal
   id: MiniTileDarkEndN
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_end_n
 
 - type: decal
   id: MiniTileDarkEndE
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_end_e
 
 - type: decal
   id: MiniTileDarkEndS
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_end_s
 
 - type: decal
   id: MiniTileDarkEndW
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_end_w
 
 - type: decal
   id: MiniTileDarkLineN
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_line_n
 
 - type: decal
   id: MiniTileDarkLineE
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_line_e
 
 - type: decal
   id: MiniTileDarkLineS
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_line_s
 
 - type: decal
   id: MiniTileDarkLineW
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: dark_line_w

--- a/Resources/Prototypes/Decals/minitile_steel.yml
+++ b/Resources/Prototypes/Decals/minitile_steel.yml
@@ -2,117 +2,117 @@
   id: MiniTileSteelBox
   tags: ["station", "markings"]
   sprite:
-    sprite: &minitile.rsi _Moffstation/Decals/minitile.rsi # Moffstation
+    sprite: &minitile_rsi _Moffstation/Decals/minitile.rsi # Moffstation
     state: steel_box
 
 - type: decal
   id: MiniTileSteelCornerNe
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_corner_ne
 
 - type: decal
   id: MiniTileSteelCornerSe
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_corner_se
 
 - type: decal
   id: MiniTileSteelCornerNw
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_corner_nw
 
 - type: decal
   id: MiniTileSteelCornerSw
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_corner_sw
 
 - type: decal
   id: MiniTileSteelInnerNe
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_inner_ne
 
 - type: decal
   id: MiniTileSteelInnerSe
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_inner_se
 
 - type: decal
   id: MiniTileSteelInnerNw
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_inner_nw
 
 - type: decal
   id: MiniTileSteelInnerSw
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_inner_sw
 
 - type: decal
   id: MiniTileSteelEndN
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_end_n
 
 - type: decal
   id: MiniTileSteelEndE
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_end_e
 
 - type: decal
   id: MiniTileSteelEndS
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_end_s
 
 - type: decal
   id: MiniTileSteelEndW
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_end_w
 
 - type: decal
   id: MiniTileSteelLineN
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_line_n
 
 - type: decal
   id: MiniTileSteelLineE
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_line_e
 
 - type: decal
   id: MiniTileSteelLineS
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_line_s
 
 - type: decal
   id: MiniTileSteelLineW
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: steel_line_w

--- a/Resources/Prototypes/Decals/minitile_white.yml
+++ b/Resources/Prototypes/Decals/minitile_white.yml
@@ -2,117 +2,117 @@
   id: MiniTileWhiteBox
   tags: ["station", "markings"]
   sprite:
-    sprite: &minitile.rsi _Moffstation/Decals/minitile.rsi # Moffstation
+    sprite: &minitile_rsi _Moffstation/Decals/minitile.rsi # Moffstation
     state: white_box
 
 - type: decal
   id: MiniTileWhiteCornerNe
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_corner_ne
 
 - type: decal
   id: MiniTileWhiteCornerSe
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_corner_se
 
 - type: decal
   id: MiniTileWhiteCornerNw
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_corner_nw
 
 - type: decal
   id: MiniTileWhiteCornerSw
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_corner_sw
 
 - type: decal
   id: MiniTileWhiteInnerNe
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_inner_ne
 
 - type: decal
   id: MiniTileWhiteInnerSe
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_inner_se
 
 - type: decal
   id: MiniTileWhiteInnerNw
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_inner_nw
 
 - type: decal
   id: MiniTileWhiteInnerSw
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_inner_sw
 
 - type: decal
   id: MiniTileWhiteEndN
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_end_n
 
 - type: decal
   id: MiniTileWhiteEndE
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_end_e
 
 - type: decal
   id: MiniTileWhiteEndS
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_end_s
 
 - type: decal
   id: MiniTileWhiteEndW
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_end_w
 
 - type: decal
   id: MiniTileWhiteLineN
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_line_n
 
 - type: decal
   id: MiniTileWhiteLineE
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_line_e
 
 - type: decal
   id: MiniTileWhiteLineS
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_line_s
 
 - type: decal
   id: MiniTileWhiteLineW
   tags: ["station", "markings"]
   sprite:
-    sprite: *minitile.rsi # Moffstation
+    sprite: *minitile_rsi # Moffstation
     state: white_line_w

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -10,7 +10,7 @@
   description: Regular purple gloves that do not keep you from frying.
   components:
   - type: Sprite
-    sprite: &color.rsi "_Moffstation/Clothing/Hands/Color/color.rsi" # Moffstation
+    sprite: &color_rsi "_Moffstation/Clothing/Hands/Color/color.rsi" # Moffstation
     layers:
     - state: icon
       color: "#9C0DE1"
@@ -23,7 +23,7 @@
       - state: inhand-right
         color: "#9C0DE1"
   - type: Clothing
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     clothingVisuals:
       gloves:
       - state: equipped-HAND
@@ -39,7 +39,7 @@
   description: Regular red gloves that do not keep you from frying.
   components:
   - type: Sprite
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     layers:
     - state: icon
       color: "#940000"
@@ -52,7 +52,7 @@
       - state: inhand-right
         color: "#940000"
   - type: Clothing
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     clothingVisuals:
       gloves:
       - state: equipped-HAND
@@ -68,7 +68,7 @@
   description: Regular blue gloves that do not keep you from frying.
   components:
   - type: Sprite
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     layers:
     - state: icon
       color: "#0089EF"
@@ -81,7 +81,7 @@
       - state: inhand-right
         color: "#0089EF"
   - type: Clothing
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     clothingVisuals:
       gloves:
       - state: equipped-HAND
@@ -97,7 +97,7 @@
   description: Regular teal gloves that do not keep you from frying.
   components:
   - type: Sprite
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     layers:
     - state: icon
       color: "#3CB57C"
@@ -110,7 +110,7 @@
       - state: inhand-right
         color: "#3CB57C"
   - type: Clothing
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     clothingVisuals:
       gloves:
       - state: equipped-HAND
@@ -126,7 +126,7 @@
   description: Regular brown gloves that do not keep you from frying.
   components:
   - type: Sprite
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     layers:
     - state: icon
       color: "#723A02"
@@ -139,7 +139,7 @@
       - state: inhand-right
         color: "#723A02"
   - type: Clothing
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     clothingVisuals:
       gloves:
       - state: equipped-HAND
@@ -155,7 +155,7 @@
   description: Regular grey gloves that do not keep you from frying.
   components:
   - type: Sprite
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     layers:
     - state: icon
       color: "#999999"
@@ -168,7 +168,7 @@
       - state: inhand-right
         color: "#999999"
   - type: Clothing
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     clothingVisuals:
       gloves:
       - state: equipped-HAND
@@ -184,7 +184,7 @@
   description: Regular green gloves that do not keep you from frying.
   components:
   - type: Sprite
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     layers:
     - state: icon
       color: "#5ABF2F"
@@ -197,7 +197,7 @@
       - state: inhand-right
         color: "#5ABF2F"
   - type: Clothing
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     clothingVisuals:
       gloves:
       - state: equipped-HAND
@@ -213,7 +213,7 @@
   description: Regular light brown gloves that do not keep you from frying.
   components:
   - type: Sprite
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     layers:
     - state: icon
       color: "#C09F72"
@@ -226,7 +226,7 @@
       - state: inhand-right
         color: "#C09F72"
   - type: Clothing
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     clothingVisuals:
       gloves:
       - state: equipped-HAND
@@ -242,7 +242,7 @@
   description: Regular orange gloves that do not keep you from frying.
   components:
   - type: Sprite
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     layers:
     - state: icon
       color: "#EF8100"
@@ -255,7 +255,7 @@
       - state: inhand-right
         color: "#EF8100"
   - type: Clothing
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     clothingVisuals:
       gloves:
       - state: equipped-HAND
@@ -271,7 +271,7 @@
   description: Regular white gloves that do not keep you from frying.
   components:
   - type: Sprite
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     layers:
     - state: icon
       color: "#EAE8E8"
@@ -284,7 +284,7 @@
       - state: inhand-right
         color: "#EAE8E8"
   - type: Clothing
-    sprite: *color.rsi # Moffstation
+    sprite: *color_rsi # Moffstation
     clothingVisuals:
       gloves:
       - state: equipped-HAND
@@ -302,7 +302,7 @@
   components:
 # Moffstation -Start
   - type: Sprite
-    sprite: *color.rsi
+    sprite: *color_rsi
     layers:
     - state: icon
       color: "#3f3f3f"
@@ -315,7 +315,7 @@
       - state: inhand-right
         color: "#3f3f3f"
   - type: Clothing
-    sprite: *color.rsi
+    sprite: *color_rsi
     clothingVisuals:
       gloves:
       - state: equipped-HAND

--- a/Resources/Prototypes/Entities/Clothing/Hands/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/specific.yml
@@ -11,7 +11,7 @@
       - Recyclable
   # Moffstation -Start
     - type: Sprite
-      sprite: &color.rsi "_Moffstation/Clothing/Hands/Color/color.rsi"
+      sprite: &color_rsi "_Moffstation/Clothing/Hands/Color/color.rsi"
       layers:
       - state: icon
         color: "#3f3f3f"
@@ -24,7 +24,7 @@
         - state: inhand-right
           color: "#3f3f3f"
     - type: Clothing
-      sprite: *color.rsi
+      sprite: *color_rsi
       clothingVisuals:
         gloves:
         - state: equipped-HAND

--- a/Resources/Prototypes/Entities/Clothing/Shoes/color.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/color.yml
@@ -8,7 +8,7 @@
   description: Stylish black shoes.
   components:
   - type: Sprite
-    sprite: &shoe.rsi _Moffstation/Clothing/Shoes/color.rsi # Moffstation
+    sprite: &shoe_rsi _Moffstation/Clothing/Shoes/color.rsi # Moffstation
     layers:
     - state: icon
       color: "#3f3f3f" #Different from the worn state for contrast reasons.
@@ -24,7 +24,7 @@
         color: "#3f3f3f"
       - state: soles-inhand-right
   - type: Clothing
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     clothingVisuals:
       shoes:
       - state: equipped-FEET
@@ -39,7 +39,7 @@
   description: Don't take them off at your office Christmas party.
   components:
   - type: Sprite
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     layers:
     - state: icon
       color: "#e0dee5" #Moffstation
@@ -53,7 +53,7 @@
       - state: inhand-right
         color: "#e0dee5" #Moffstation
   - type: Clothing
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     clothingVisuals:
       shoes:
       - state: equipped-FEET
@@ -68,7 +68,7 @@
   description: Stylish blue shoes.
   components:
   - type: Sprite
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     layers:
     - state: icon
       color: "#0089EF"
@@ -84,7 +84,7 @@
         color: "#0089EF"
       - state: soles-inhand-right
   - type: Clothing
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     clothingVisuals:
       shoes:
       - state: equipped-FEET
@@ -99,7 +99,7 @@
   description: A pair of brown shoes.
   components:
   - type: Sprite
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     layers:
     - state: icon
       color: "#723A02"
@@ -115,7 +115,7 @@
         color: "#723A02"
       - state: soles-inhand-right
   - type: Clothing
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     clothingVisuals:
       shoes:
       - state: equipped-FEET
@@ -130,7 +130,7 @@
   description: Stylish green shoes.
   components:
   - type: Sprite
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     layers:
     - state: icon
       color: "#5ABF2F"
@@ -146,7 +146,7 @@
         color: "#5ABF2F"
       - state: soles-inhand-right
   - type: Clothing
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     clothingVisuals:
       shoes:
       - state: equipped-FEET
@@ -161,7 +161,7 @@
   description: Stylish orange shoes.
   components:
   - type: Sprite
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     layers:
     - state: icon
       color: "#EF8100"
@@ -177,7 +177,7 @@
         color: "#EF8100"
       - state: soles-inhand-right
   - type: Clothing
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     clothingVisuals:
       shoes:
       - state: equipped-FEET
@@ -192,7 +192,7 @@
   description: Stylish red shoes.
   components:
   - type: Sprite
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     layers:
     - state: icon
       color: "#940000"
@@ -208,7 +208,7 @@
         color: "#940000"
       - state: soles-inhand-right
   - type: Clothing
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     clothingVisuals:
       shoes:
       - state: equipped-FEET
@@ -223,7 +223,7 @@
   description: Stylish yellow shoes.
   components:
   - type: Sprite
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     layers:
     - state: icon
       color: "#EBE216"
@@ -239,7 +239,7 @@
         color: "#EBE216"
       - state: soles-inhand-right
   - type: Clothing
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     clothingVisuals:
       shoes:
       - state: equipped-FEET
@@ -254,7 +254,7 @@
   description: Stylish purple shoes.
   components:
   - type: Sprite
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     layers:
     - state: icon
       color: "#9C0DE1"
@@ -270,7 +270,7 @@
         color: "#9C0DE1"
       - state: soles-inhand-right
   - type: Clothing
-    sprite: *shoe.rsi # Moffstation
+    sprite: *shoe_rsi # Moffstation
     clothingVisuals:
       shoes:
       - state: equipped-FEET

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/color_turtlenecks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/color_turtlenecks.yml
@@ -6,7 +6,7 @@
   description: A generic white turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: &color_turtleneck.rsi "_Moffstation/Clothing/Uniforms/Jumpsuit/color_turtle.rsi" # Moffstation
+    sprite: &color_turtleneck_rsi "_Moffstation/Clothing/Uniforms/Jumpsuit/color_turtle.rsi" # Moffstation
     layers:
     - state: icon
     - state: trousers-icon
@@ -19,7 +19,7 @@
       - state: inhand-right
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -33,7 +33,7 @@
   description: A tasteful grey turtleneck that reminds you of the good old days.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#b3b3b3"
@@ -49,7 +49,7 @@
         color: "#b3b3b3"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -64,7 +64,7 @@
   description: A generic black turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#3f3f3f"
@@ -80,7 +80,7 @@
         color: "#3f3f3f"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -95,7 +95,7 @@
   description: A generic blue turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#52aecc"
@@ -111,7 +111,7 @@
         color: "#52aecc"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -126,7 +126,7 @@
   description: A generic dark blue turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#3285ba"
@@ -142,7 +142,7 @@
         color: "#3285ba"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -157,7 +157,7 @@
   description: A generic teal turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#77f3b7"
@@ -173,7 +173,7 @@
         color: "#77f3b7"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -188,7 +188,7 @@
   description: A generic green turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#9ed63a"
@@ -204,7 +204,7 @@
         color: "#9ed63a"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -219,7 +219,7 @@
   description: A generic dark green turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#79CC26"
@@ -235,7 +235,7 @@
         color: "#79CC26"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -250,7 +250,7 @@
   description: A generic orange turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#ff8c19"
@@ -266,7 +266,7 @@
         color: "#ff8c19"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -281,7 +281,7 @@
   description: A generic pink turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#ffa69b"
@@ -297,7 +297,7 @@
         color: "#ffa69b"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -312,7 +312,7 @@
   description: A generic red turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#eb0c07"
@@ -328,7 +328,7 @@
         color: "#eb0c07"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -343,7 +343,7 @@
   description: A generic yellow turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#ffe14d"
@@ -359,7 +359,7 @@
         color: "#ffe14d"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -374,7 +374,7 @@
   description: A generic light purple turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#9f70cc"
@@ -390,7 +390,7 @@
         color: "#9f70cc"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -405,7 +405,7 @@
   description: A generic light brown turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#c59431"
@@ -421,7 +421,7 @@
         color: "#c59431"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -436,7 +436,7 @@
   description: A generic brown turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#a17229"
@@ -452,7 +452,7 @@
         color: "#a17229"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -467,7 +467,7 @@
   description: A generic maroon turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#cc295f"
@@ -483,7 +483,7 @@
         color: "#cc295f"
       - state: trousers-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/color_turtlenecks_skirt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/color_turtlenecks_skirt.yml
@@ -6,7 +6,7 @@
   description: A generic white turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: &color_turtleneck.rsi "_Moffstation/Clothing/Uniforms/Jumpskirt/color_turtle.rsi" # Moffstation
+    sprite: &color_turtleneck_rsi "_Moffstation/Clothing/Uniforms/Jumpskirt/color_turtle.rsi" # Moffstation
     layers:
     - state: icon
     - state: skirt-icon
@@ -19,7 +19,7 @@
       - state: inhand-right
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -33,7 +33,7 @@
   description: A tasteful grey turtleneck that reminds you of the good old days.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#b3b3b3"
@@ -49,7 +49,7 @@
         color: "#b3b3b3"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -64,7 +64,7 @@
   description: A generic black turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#3f3f3f"
@@ -80,7 +80,7 @@
         color: "#3f3f3f"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -95,7 +95,7 @@
   description: A generic blue turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#52aecc"
@@ -111,7 +111,7 @@
         color: "#52aecc"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -126,7 +126,7 @@
   description: A generic dark blue turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#3285ba"
@@ -142,7 +142,7 @@
         color: "#3285ba"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -157,7 +157,7 @@
   description: A generic teal turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#77f3b7"
@@ -173,7 +173,7 @@
         color: "#77f3b7"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -188,7 +188,7 @@
   description: A generic green turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#9ed63a"
@@ -204,7 +204,7 @@
         color: "#9ed63a"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -219,7 +219,7 @@
   description: A generic dark green turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#79CC26"
@@ -235,7 +235,7 @@
         color: "#79CC26"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -250,7 +250,7 @@
   description: A generic orange turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#ff8c19"
@@ -266,7 +266,7 @@
         color: "#ff8c19"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -281,7 +281,7 @@
   description: A generic pink turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#ffa69b"
@@ -297,7 +297,7 @@
         color: "#ffa69b"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -312,7 +312,7 @@
   description: A generic red turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#eb0c07"
@@ -328,7 +328,7 @@
         color: "#eb0c07"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -343,7 +343,7 @@
   description: A generic yellow turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#ffe14d"
@@ -359,7 +359,7 @@
         color: "#ffe14d"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -374,7 +374,7 @@
   description: A generic light purple turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#9f70cc"
@@ -390,7 +390,7 @@
         color: "#9f70cc"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -405,7 +405,7 @@
   description: A generic light brown turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#c59431"
@@ -421,7 +421,7 @@
         color: "#c59431"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -436,7 +436,7 @@
   description: A generic brown turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#a17229"
@@ -452,7 +452,7 @@
         color: "#a17229"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING
@@ -467,7 +467,7 @@
   description: A generic maroon turtleneck with no rank markings.
   components:
   - type: Sprite
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     layers:
     - state: icon
       color: "#cc295f"
@@ -483,7 +483,7 @@
         color: "#cc295f"
       - state: skirt-inhand-right
   - type: Clothing
-    sprite: *color_turtleneck.rsi # Moffstation
+    sprite: *color_turtleneck_rsi # Moffstation
     clothingVisuals:
       jumpsuit:
       - state: equipped-INNERCLOTHING

--- a/Resources/Prototypes/Entities/Objects/Tools/crowbars.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/crowbars.yml
@@ -31,14 +31,14 @@
     price: 22
   - type: Prying
   - type: Sprite
-    sprite: &crowbar.rsi "_Moffstation/Objects/Tools/crowbar.rsi" # Moffstation
+    sprite: &crowbar_rsi "_Moffstation/Objects/Tools/crowbar.rsi" # Moffstation
   - type: Clothing
-    sprite: *crowbar.rsi # Moffstation
+    sprite: *crowbar_rsi # Moffstation
     quickEquip: false
     slots:
     - Belt
   - type: Item
-    sprite: *crowbar.rsi # Moffstation
+    sprite: *crowbar_rsi # Moffstation
     size: Small
 
 # Standard (grey) Crowbar
@@ -50,7 +50,7 @@
     state: icon
   - type: Item
     storedSprite:
-      sprite: *crowbar.rsi # Moffstation
+      sprite: *crowbar_rsi # Moffstation
       state: storage
 
 # Emergency (red) Crowbar
@@ -70,7 +70,7 @@
   - type: Item
     storedSprite:
       state: red-storage
-      sprite: *crowbar.rsi # Moffstation
+      sprite: *crowbar_rsi # Moffstation
     inhandVisuals:
       left:
       - state: inhand-left
@@ -100,7 +100,7 @@
   - type: Item
     storedSprite:
       state: green-storage
-      sprite: *crowbar.rsi # Moffstation
+      sprite: *crowbar_rsi # Moffstation
     inhandVisuals:
       left:
       - state: inhand-left
@@ -130,7 +130,7 @@
   - type: Item
     storedSprite:
       state: orange-storage
-      sprite: *crowbar.rsi # Moffstation
+      sprite: *crowbar_rsi # Moffstation
     inhandVisuals:
       left:
       - state: inhand-left
@@ -160,7 +160,7 @@
   - type: Item
     storedSprite:
       state: yellow-storage
-      sprite: *crowbar.rsi # Moffstation
+      sprite: *crowbar_rsi # Moffstation
     inhandVisuals:
       left:
       - state: inhand-left

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -8,12 +8,12 @@
     tags:
     - JawsOfLife
   - type: Sprite
-    sprite: &jaws_of_life.rsi "_Moffstation/Objects/Tools/jaws_of_life.rsi" # Moffstation
+    sprite: &jaws_of_life_rsi "_Moffstation/Objects/Tools/jaws_of_life.rsi" # Moffstation
     state: jaws_pry
   - type: Item
     size: Normal
   - type: Clothing
-    sprite: *jaws_of_life.rsi # Moffstation
+    sprite: *jaws_of_life_rsi # Moffstation
     quickEquip: false
     slots:
       - Belt
@@ -32,13 +32,13 @@
     entries:
       - behavior: Prying
         sprite:
-          sprite: *jaws_of_life.rsi # Moffstation
+          sprite: *jaws_of_life_rsi # Moffstation
           state: jaws_pry
         useSound: /Audio/Items/jaws_pry.ogg
         changeSound: /Audio/Items/change_jaws.ogg
       - behavior: Cutting
         sprite:
-          sprite: *jaws_of_life.rsi # Moffstation
+          sprite: *jaws_of_life_rsi # Moffstation
           state: jaws_cutter
         useSound: /Audio/Items/jaws_cut.ogg
         changeSound: /Audio/Items/change_jaws.ogg
@@ -57,7 +57,7 @@
   description: Useful for breaking into secure areas and other nefarious activities.
   components:
   - type: Sprite
-    sprite: *jaws_of_life.rsi # Moffstation
+    sprite: *jaws_of_life_rsi # Moffstation
     state: syn_jaws_pry
   - type: Item
     inhandVisuals:
@@ -73,13 +73,13 @@
     entries:
       - behavior: Prying
         sprite:
-          sprite: *jaws_of_life.rsi # Moffstation
+          sprite: *jaws_of_life_rsi # Moffstation
           state: syn_jaws_pry
         useSound: /Audio/Items/jaws_pry.ogg
         changeSound: /Audio/Items/change_jaws.ogg
       - behavior: Cutting
         sprite:
-          sprite: *jaws_of_life.rsi # Moffstation
+          sprite: *jaws_of_life_rsi # Moffstation
           state: syn_jaws_cutter
         useSound: /Audio/Items/jaws_cut.ogg
         changeSound: /Audio/Items/change_jaws.ogg

--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -5,10 +5,10 @@
   description: A spray painter for painting airlocks, pipes, and other items.
   components:
   - type: Sprite
-    sprite: &spray_painter.rsi "_Moffstation/Objects/Tools/spray_painter.rsi" # Moffstation
+    sprite: &spray_painter_rsi "_Moffstation/Objects/Tools/spray_painter.rsi" # Moffstation
     state: spray_painter
   - type: Item
-    sprite: *spray_painter.rsi # Moffstation
+    sprite: *spray_painter_rsi # Moffstation
   - type: ActivatableUI
     key: enum.SprayPainterUiKey.Key
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Objects/Tools/t-ray.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/t-ray.yml
@@ -5,13 +5,13 @@
   description: A high-tech scanning device that uses Terahertz Radiation to detect subfloor infrastructure.
   components:
   - type: Sprite
-    sprite: &t-ray.rsi "_Moffstation/Objects/Tools/t-ray.rsi" # Moffstation
+    sprite: &t-ray_rsi "_Moffstation/Objects/Tools/t-ray.rsi" # Moffstation
     layers:
     - state: tray-off
       map: ["base"]
   - type: TrayScanner
   - type: Item
-    sprite: *t-ray.rsi # Moffstation
+    sprite: *t-ray_rsi # Moffstation
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -12,7 +12,7 @@
     - PlantSampleTaker
     - Wirecutter
   - type: Sprite
-    sprite: &wirecutters.rsi "_Moffstation/Objects/Tools/wirecutters.rsi" # Moffstation
+    sprite: &wirecutters_rsi "_Moffstation/Objects/Tools/wirecutters.rsi" # Moffstation
     layers:
     - state: cutters
       map: [ "enum.DamageStateVisualLayers.Base" ]
@@ -36,7 +36,7 @@
       - enum.DamageStateVisualLayers.Base:
           cutters: Rainbow
   - type: Item
-    sprite: *wirecutters.rsi # Moffstation
+    sprite: *wirecutters_rsi # Moffstation
     storedRotation: -90
   - type: ToolTileCompatible
   - type: PhysicalComposition
@@ -58,13 +58,13 @@
     tags:
     - Screwdriver
   - type: Sprite
-    sprite: &screwdriver.rsi "_Moffstation/Objects/Tools/screwdriver.rsi" # Moffstation
+    sprite: &screwdriver_rsi "_Moffstation/Objects/Tools/screwdriver.rsi" # Moffstation
     layers:
       - state: screwdriver
         map: [ "enum.DamageStateVisualLayers.Base" ]
       - state: screwdriver-screwybits
   - type: Item
-    sprite: *screwdriver.rsi # Moffstation
+    sprite: *screwdriver_rsi # Moffstation
     storedRotation: -90
   - type: MeleeWeapon
     wideAnimationRotation: -90
@@ -102,12 +102,12 @@
     tags:
     - Wrench
   - type: Sprite
-    sprite: &wrench.rsi _Moffstation/Objects/Tools/wrench.rsi # Moffstation
+    sprite: &wrench_rsi _Moffstation/Objects/Tools/wrench.rsi # Moffstation
     state: icon
   - type: Item
-    sprite: *wrench.rsi # Moffstation
+    sprite: *wrench_rsi # Moffstation
     storedSprite:
-      sprite: *wrench.rsi # Moffstation
+      sprite: *wrench_rsi # Moffstation
       state: storage
   - type: MeleeWeapon
     wideAnimationRotation: -90 # Moffstation
@@ -141,7 +141,7 @@
     sound:
       path: /Audio/Items/multitool_drop.ogg
   - type: Sprite
-    sprite: &multitool.rsi "_Moffstation/Objects/Tools/multitool.rsi" # Moffstation
+    sprite: &multitool_rsi "_Moffstation/Objects/Tools/multitool.rsi" # Moffstation
     layers:
     - state: icon
     - state: green-unlit
@@ -149,7 +149,7 @@
   - type: Item
     size: Small
   - type: Clothing
-    sprite: *multitool.rsi # Moffstation
+    sprite: *multitool_rsi # Moffstation
     quickEquip: false
     slots:
     - Belt
@@ -195,7 +195,7 @@
       sound:
         path: /Audio/Items/multitool_drop.ogg
     - type: Sprite
-      sprite: &network_configurator.rsi "_Moffstation/Objects/Tools/network_configurator.rsi" # Moffstation
+      sprite: &network_configurator_rsi "_Moffstation/Objects/Tools/network_configurator.rsi" # Moffstation
       layers:
         - state: icon
         - state: mode-link
@@ -204,7 +204,7 @@
     - type: Item
       size: Small
     - type: Clothing
-      sprite: *network_configurator.rsi # Moffstation
+      sprite: *network_configurator_rsi # Moffstation
       quickEquip: false
       slots:
         - Belt
@@ -254,10 +254,10 @@
     tags:
     - Powerdrill
   - type: Sprite
-    sprite: &drill.rsi "_Moffstation/Objects/Tools/drill.rsi" # Moffstation
+    sprite: &drill_rsi "_Moffstation/Objects/Tools/drill.rsi" # Moffstation
     state: drill_screw
   - type: Item
-    sprite: *drill.rsi # Moffstation
+    sprite: *drill_rsi # Moffstation
     size: Small
   - type: Tool
     qualities:
@@ -269,7 +269,7 @@
     entries:
       - behavior: Screwing
         sprite:
-          sprite: *drill.rsi # Moffstation
+          sprite: *drill_rsi # Moffstation
           state: drill_screw
         useSound:
           path: /Audio/Items/drill_use.ogg
@@ -277,7 +277,7 @@
           path: /Audio/Items/change_drill.ogg
       - behavior: Anchoring
         sprite:
-          sprite: *drill.rsi # Moffstation
+          sprite: *drill_rsi # Moffstation
           state: drill_bolt
         useSound:
           path: /Audio/Items/drill_use.ogg
@@ -328,12 +328,12 @@
   - type: LimitedCharges
     maxCharges: 30
   - type: Sprite
-    sprite: &rcd.rsi "_Moffstation/Objects/Tools/rcd.rsi" # Moffstation
+    sprite: &rcd_rsi "_Moffstation/Objects/Tools/rcd.rsi" # Moffstation
     state: icon
   - type: Item
     size: Normal
   - type: Clothing
-    sprite: *rcd.rsi # Moffstation
+    sprite: *rcd_rsi # Moffstation
     quickEquip: false
     slots:
     - Belt
@@ -389,10 +389,10 @@
   components:
   - type: RCDAmmo
   - type: Sprite
-    sprite: *rcd.rsi # Moffstation
+    sprite: *rcd_rsi # Moffstation
     state: ammo
   - type: Item
-    sprite: *rcd.rsi # Moffstation
+    sprite: *rcd_rsi # Moffstation
     heldPrefix: ammo
   - type: PhysicalComposition
     materialComposition:

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -21,7 +21,7 @@
           False: { visible: false }
   - type: Item
     size: Small
-    sprite: &welder.rsi "_Moffstation/Objects/Tools/welder.rsi" # Moffstation
+    sprite: &welder_rsi "_Moffstation/Objects/Tools/welder.rsi" # Moffstation
   - type: ItemToggle
     predictable: false
     soundActivate:
@@ -104,7 +104,7 @@
   description: "Melts anything as long as it's fueled, don't forget your eye protection!"
   components:
   - type: Sprite
-    sprite: *welder.rsi # Moffstation
+    sprite: *welder_rsi # Moffstation
 
 - type: entity
   parent: [SolutionWelder, SolutionSmall]
@@ -125,9 +125,9 @@
   description: "An industrial welder with over double the fuel capacity."
   components:
   - type: Sprite
-    sprite: &welder_industrial.rsi "_Moffstation/Objects/Tools/welder_industrial.rsi" #Moffstation
+    sprite: &welder_industrial_rsi "_Moffstation/Objects/Tools/welder_industrial.rsi" #Moffstation
   - type: Item
-    sprite: *welder_industrial.rsi # Moffstation
+    sprite: *welder_industrial_rsi # Moffstation
 
 - type: entity
   parent: [SolutionWelder, SolutionToolNormal]
@@ -148,9 +148,9 @@
   description: "An advanced industrial welder with over double the fuel capacity and hotter flame."
   components:
   - type: Sprite
-    sprite: &welder_industrialadv.rsi "_Moffstation/Objects/Tools/welder_industrialadv.rsi" # Moffstation
+    sprite: &welder_industrialadv_rsi "_Moffstation/Objects/Tools/welder_industrialadv.rsi" # Moffstation
   - type: Item
-    sprite: *welder_industrialadv.rsi # Moffstation
+    sprite: *welder_industrialadv_rsi # Moffstation
   - type: Tool
     speedModifier: 1.3
 
@@ -161,9 +161,9 @@
   description: "An experimental welder capable of self-fuel generation and less harmful to the eyes."
   components:
   - type: Sprite
-    sprite: &welder_experimental.rsi "_Moffstation/Objects/Tools/welder_experimental.rsi" # Moffstation
+    sprite: &welder_experimental_rsi "_Moffstation/Objects/Tools/welder_experimental.rsi" # Moffstation
   - type: Item
-    sprite: *welder_experimental.rsi # Moffstation
+    sprite: *welder_experimental_rsi # Moffstation
   - type: PointLight
     enabled: false
     radius: 1.5
@@ -196,10 +196,10 @@
   description: "A miniature welder used during emergencies."
   components:
   - type: Sprite
-    sprite: &welder_mini.rsi "_Moffstation/Objects/Tools/welder_mini.rsi" # Moffstation
+    sprite: &welder_mini_rsi "_Moffstation/Objects/Tools/welder_mini.rsi" # Moffstation
   - type: Item
     size: Tiny
-    sprite: *welder_mini.rsi # Moffstation
+    sprite: *welder_mini_rsi # Moffstation
   - type: RefillableSolution
     solution: welder
   - type: Tool

--- a/Resources/Prototypes/Entities/Structures/Furniture/carpets.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/carpets.yml
@@ -50,9 +50,9 @@
   suffix: Red
   components:
   - type: Sprite
-    sprite: &red_carpet.rsi "_Moffstation/Structures/Furniture/Carpets/red_carpet.rsi" # Moffstation
+    sprite: &red_carpet_rsi "_Moffstation/Structures/Furniture/Carpets/red_carpet.rsi" # Moffstation
   - type: Icon
-    sprite: *red_carpet.rsi # Moffstation
+    sprite: *red_carpet_rsi # Moffstation
   - type: Destructible
     thresholds:
     - trigger:
@@ -74,9 +74,9 @@
   components:
   - type: Clickable
   - type: Sprite
-    sprite: &black_carpet.rsi "_Moffstation/Structures/Furniture/Carpets/black_carpet.rsi" # Moffstation
+    sprite: &black_carpet_rsi "_Moffstation/Structures/Furniture/Carpets/black_carpet.rsi" # Moffstation
   - type: Icon
-    sprite: *black_carpet.rsi # Moffstation
+    sprite: *black_carpet_rsi # Moffstation
   - type: Destructible
     thresholds:
     - trigger:
@@ -98,9 +98,9 @@
   components:
   - type: Clickable
   - type: Sprite
-    sprite: &pink_carpet.rsi "_Moffstation/Structures/Furniture/Carpets/pink_carpet.rsi" #moffstation
+    sprite: &pink_carpet_rsi "_Moffstation/Structures/Furniture/Carpets/pink_carpet.rsi" #moffstation
   - type: Icon
-    sprite: *pink_carpet.rsi # Moffstation
+    sprite: *pink_carpet_rsi # Moffstation
   - type: Destructible
     thresholds:
     - trigger:
@@ -122,9 +122,9 @@
   components:
   - type: Clickable
   - type: Sprite
-    sprite: &blue_carpet.rsi "_Moffstation/Structures/Furniture/Carpets/blue_carpet.rsi" # Moffstation
+    sprite: &blue_carpet_rsi "_Moffstation/Structures/Furniture/Carpets/blue_carpet.rsi" # Moffstation
   - type: Icon
-    sprite: *blue_carpet.rsi
+    sprite: *blue_carpet_rsi
   - type: Destructible
     thresholds:
     - trigger:
@@ -146,9 +146,9 @@
   components:
   - type: Clickable
   - type: Sprite
-    sprite: &green_carpet.rsi "_Moffstation/Structures/Furniture/Carpets/green_carpet.rsi" # Moffstation
+    sprite: &green_carpet_rsi "_Moffstation/Structures/Furniture/Carpets/green_carpet.rsi" # Moffstation
   - type: Icon
-    sprite: *green_carpet.rsi
+    sprite: *green_carpet_rsi
   - type: Destructible
     thresholds:
     - trigger:
@@ -170,9 +170,9 @@
   components:
   - type: Clickable
   - type: Sprite
-    sprite: &orange_carpet.rsi "_Moffstation/Structures/Furniture/Carpets/orange_carpet.rsi" # Moffstation
+    sprite: &orange_carpet_rsi "_Moffstation/Structures/Furniture/Carpets/orange_carpet.rsi" # Moffstation
   - type: Icon
-    sprite: *orange_carpet.rsi # Moffstation
+    sprite: *orange_carpet_rsi # Moffstation
   - type: Destructible
     thresholds:
     - trigger:
@@ -194,9 +194,9 @@
   components:
   - type: Clickable
   - type: Sprite
-    sprite: &skyblue_carpet.rsi "_Moffstation/Structures/Furniture/Carpets/skyblue_carpet.rsi" # Moffstation
+    sprite: &skyblue_carpet_rsi "_Moffstation/Structures/Furniture/Carpets/skyblue_carpet.rsi" # Moffstation
   - type: Icon
-    sprite: *skyblue_carpet.rsi # Moffstation
+    sprite: *skyblue_carpet_rsi # Moffstation
   - type: Destructible
     thresholds:
     - trigger:
@@ -218,9 +218,9 @@
   components:
   - type: Clickable
   - type: Sprite
-    sprite: &purple_carpet.rsi "_Moffstation/Structures/Furniture/Carpets/purple_carpet.rsi" # Moffstation
+    sprite: &purple_carpet_rsi "_Moffstation/Structures/Furniture/Carpets/purple_carpet.rsi" # Moffstation
   - type: Icon
-    sprite: *purple_carpet.rsi # Moffstation
+    sprite: *purple_carpet_rsi # Moffstation
   - type: Destructible
     thresholds:
     - trigger:
@@ -242,9 +242,9 @@
   components:
   - type: Clickable
   - type: Sprite
-    sprite: &cyan_carpet.rsi "_Moffstation/Structures/Furniture/Carpets/cyan_carpet.rsi" # Moffstation
+    sprite: &cyan_carpet_rsi "_Moffstation/Structures/Furniture/Carpets/cyan_carpet.rsi" # Moffstation
   - type: Icon
-    sprite: *cyan_carpet.rsi # Moffstation
+    sprite: *cyan_carpet_rsi # Moffstation
   - type: Destructible
     thresholds:
     - trigger:
@@ -266,9 +266,9 @@
   components:
   - type: Clickable
   - type: Sprite
-    sprite: &white_carpet.rsi "_Moffstation/Structures/Furniture/Carpets/white_carpet.rsi" # Moffstation
+    sprite: &white_carpet_rsi "_Moffstation/Structures/Furniture/Carpets/white_carpet.rsi" # Moffstation
   - type: Icon
-    sprite: *white_carpet.rsi # Moffstation
+    sprite: *white_carpet_rsi # Moffstation
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/_Moffstation/Body/Species/gray.yml
+++ b/Resources/Prototypes/_Moffstation/Body/Species/gray.yml
@@ -111,134 +111,134 @@
       jumpsuit:
         sizeMaps:
           32:
-            sprite: &displacement.rsi "_Moffstation/Mobs/Species/Gray/displacement.rsi"
+            sprite: &displacement_rsi "_Moffstation/Mobs/Species/Gray/displacement.rsi"
             state: jumpsuit
       head:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: head
       eyes:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: eyes
       gloves:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: hands
       back:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: back
       ears:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: ears
       shoes:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: feet
       neck:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: neck
       mask:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: mask
       outerClothing:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: outerClothing
       suitstorage:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: suitStorage
       belt:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: belt
     femaleDisplacements:
       jumpsuit:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: jumpsuit
       head:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: head
       eyes:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: eyes
       gloves:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: hands
       back:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: back
       ears:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: ears
       shoes:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: feet
       neck:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: neck
       mask:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: mask
       outerClothing:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: outerClothing
       suitstorage:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: suitStorage
       belt:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: belt
   - type: Hands
     leftHandDisplacement:
       sizeMaps:
         32:
-          sprite: *displacement.rsi
+          sprite: *displacement_rsi
           state: inHand
     rightHandDisplacement:
       sizeMaps:
         32:
-          sprite: *displacement.rsi
+          sprite: *displacement_rsi
           state: inHand
   - type: InitialBody
     organs:
@@ -375,7 +375,7 @@
   components:
   - type: VisualOrgan
     data:
-      sprite: &parts.rsi "_Moffstation/Mobs/Species/Gray/parts.rsi"
+      sprite: &parts_rsi "_Moffstation/Mobs/Species/Gray/parts.rsi"
   - type: VisualOrganMarkings
     markingData:
       group: Gray
@@ -386,7 +386,7 @@
   abstract: true
   components:
   - type: Sprite
-    sprite: *parts.rsi
+    sprite: *parts_rsi
 
 - type: entity
   parent: [ OrganBaseTorso, OrganGrayExternal ]

--- a/Resources/Prototypes/_Moffstation/Body/Species/resomi.yml
+++ b/Resources/Prototypes/_Moffstation/Body/Species/resomi.yml
@@ -114,133 +114,133 @@
       jumpsuit:
         sizeMaps:
           32:
-            sprite: &displacement.rsi "_Moffstation/Mobs/Species/Resomi/displacement.rsi"
+            sprite: &displacement_rsi "_Moffstation/Mobs/Species/Resomi/displacement.rsi"
             state: jumpsuit
       head:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: head
       eyes:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: eyes
       gloves:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: hands
       back:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: back
       ears:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: ears
       shoes:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: feet
       neck:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: neck
       mask:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: mask
       outerClothing:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: outerClothing
       suitstorage:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: suitStorage
       belt:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: belt
     femaleDisplacements:
       jumpsuit:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: jumpsuit
       head:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: head
       eyes:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: eyes
       gloves:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: hands
       back:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: back
       ears:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: ears
       shoes:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: feet
       neck:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: neck
       mask:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: mask
       outerClothing:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: outerClothing
       suitstorage:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: suitStorage
       belt:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: belt
       leftHandDisplacement:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: inHand
       rightHandDisplacement:
         sizeMaps:
           32:
-            sprite: *displacement.rsi
+            sprite: *displacement_rsi
             state: inHand
   - type: InitialBody
     organs:

--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/Customization/Markings/gray.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/Customization/Markings/gray.yml
@@ -5,7 +5,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: &head.rsi "_Moffstation/Mobs/Customization/Gray/head.rsi"
+  - sprite: &head_rsi "_Moffstation/Mobs/Customization/Gray/head.rsi"
     state: antennas
 
 - type: marking
@@ -13,7 +13,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: droopyantennas
 
 - type: marking
@@ -21,7 +21,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: bushyeyebrows
 
 - type: marking
@@ -29,7 +29,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: catears
 
 - type: marking
@@ -37,7 +37,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: eyebags
 
 - type: marking
@@ -45,7 +45,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: eyelashes
 
 - type: marking
@@ -53,7 +53,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: fakestache
 
 - type: marking
@@ -61,7 +61,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: floppyears
 
 - type: marking
@@ -69,7 +69,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: gem
 
 - type: marking
@@ -77,7 +77,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: gleepglow
 
 - type: marking
@@ -85,7 +85,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: gleepcheekglow
 
 - type: marking
@@ -93,7 +93,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: largeears
 
 - type: marking
@@ -101,7 +101,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: smalleyebrows
 
 - type: marking
@@ -109,7 +109,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: tinyantennas
 
 - type: marking
@@ -117,7 +117,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: whiskers
 
 - type: marking
@@ -125,7 +125,7 @@
   bodyPart: Head
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *head.rsi
+  - sprite: *head_rsi
     state: wrinkles
 
 # Eye Markings
@@ -142,9 +142,9 @@
         type: !type:SimpleColoring
           color: "#eeefff"
   sprites:
-  - sprite: &eyes.rsi "_Moffstation/Mobs/Customization/Gray/eyes.rsi"
+  - sprite: &eyes_rsi "_Moffstation/Mobs/Customization/Gray/eyes.rsi"
     state: eyes
-  - sprite: *eyes.rsi
+  - sprite: *eyes_rsi
     state: eyes_glimmer
 
 - type: marking
@@ -161,11 +161,11 @@
       tiredeyes_ridge:
         type: !type:SkinColoring
   sprites:
-  - sprite: *eyes.rsi
+  - sprite: *eyes_rsi
     state: tiredeyes
-  - sprite: *eyes.rsi
+  - sprite: *eyes_rsi
     state: tiredeyes_glimmer
-  - sprite: *eyes.rsi
+  - sprite: *eyes_rsi
     state: tiredeyes_ridge
 
 - type: marking
@@ -182,11 +182,11 @@
       angryeyes_ridge:
         type: !type:SkinColoring
   sprites:
-  - sprite: *eyes.rsi
+  - sprite: *eyes_rsi
     state: angryeyes
-  - sprite: *eyes.rsi
+  - sprite: *eyes_rsi
     state: angryeyes_glimmer
-  - sprite: *eyes.rsi
+  - sprite: *eyes_rsi
     state: angryeyes_ridge
 
 - type: marking
@@ -201,9 +201,9 @@
         type: !type:SimpleColoring
           color: "#eeefff"
   sprites:
-  - sprite: *eyes.rsi
+  - sprite: *eyes_rsi
     state: bigeyes
-  - sprite: *eyes.rsi
+  - sprite: *eyes_rsi
     state: bigeyes_glimmer
 
 # Chest Markings
@@ -231,7 +231,7 @@
   bodyPart: LArm
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: &arms.rsi "_Moffstation/Mobs/Customization/Gray/arms.rsi"
+  - sprite: &arms_rsi "_Moffstation/Mobs/Customization/Gray/arms.rsi"
     state: gleepglowlarm
 
 - type: marking
@@ -239,7 +239,7 @@
   bodyPart: LArm
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *arms.rsi
+  - sprite: *arms_rsi
     state: cropcircleslarm
 
 - type: marking
@@ -247,7 +247,7 @@
   bodyPart: RArm
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *arms.rsi
+  - sprite: *arms_rsi
     state: gleepglowrarm
 
 
@@ -256,7 +256,7 @@
   bodyPart: RArm
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *arms.rsi
+  - sprite: *arms_rsi
     state: cropcirclesrarm
 
 # Leg Markings
@@ -266,7 +266,7 @@
   bodyPart: LLeg
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: &legs.rsi "_Moffstation/Mobs/Customization/Gray/legs.rsi"
+  - sprite: &legs_rsi "_Moffstation/Mobs/Customization/Gray/legs.rsi"
     state: gleepglowlleg
 
 - type: marking
@@ -274,7 +274,7 @@
   bodyPart: RLeg
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *legs.rsi
+  - sprite: *legs_rsi
     state: gleepglowrleg
 
 - type: marking
@@ -282,7 +282,7 @@
   bodyPart: LFoot
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *legs.rsi
+  - sprite: *legs_rsi
     state: gleepglowlfoot
 
 - type: marking
@@ -290,7 +290,7 @@
   bodyPart: RFoot
   groupWhitelist: [ Gray ]
   sprites:
-  - sprite: *legs.rsi
+  - sprite: *legs_rsi
     state: gleepglowrfoot
 
 # Gauze Markings
@@ -303,7 +303,7 @@
       type: !type:SimpleColoring
         color: "#FFFFFF"
   sprites:
-  - sprite: &gauze.rsi "_Moffstation/Mobs/Customization/Gray/gauzemarkings.rsi"
+  - sprite: &gauze_rsi "_Moffstation/Mobs/Customization/Gray/gauzemarkings.rsi"
     state: head
 
 - type: marking
@@ -315,7 +315,7 @@
       type: !type:SimpleColoring
         color: "#FFFFFF"
   sprites:
-  - sprite: *gauze.rsi
+  - sprite: *gauze_rsi
     state: chest
 
 - type: marking
@@ -327,7 +327,7 @@
       type: !type:SimpleColoring
         color: "#FFFFFF"
   sprites:
-  - sprite: *gauze.rsi
+  - sprite: *gauze_rsi
     state: stomach
 
 - type: marking
@@ -339,7 +339,7 @@
       type: !type:SimpleColoring
         color: "#FFFFFF"
   sprites:
-  - sprite: *gauze.rsi
+  - sprite: *gauze_rsi
     state: larm
 
 - type: marking
@@ -351,7 +351,7 @@
       type: !type:SimpleColoring
         color: "#FFFFFF"
   sprites:
-  - sprite: *gauze.rsi
+  - sprite: *gauze_rsi
     state: rarm
 
 - type: marking
@@ -363,7 +363,7 @@
       type: !type:SimpleColoring
         color: "#FFFFFF"
   sprites:
-  - sprite: *gauze.rsi
+  - sprite: *gauze_rsi
     state: lhand
 
 - type: marking
@@ -375,7 +375,7 @@
       type: !type:SimpleColoring
         color: "#FFFFFF"
   sprites:
-  - sprite: *gauze.rsi
+  - sprite: *gauze_rsi
     state: rhand
 
 - type: marking
@@ -387,7 +387,7 @@
       type: !type:SimpleColoring
         color: "#FFFFFF"
   sprites:
-  - sprite: *gauze.rsi
+  - sprite: *gauze_rsi
     state: lleg
 
 - type: marking
@@ -399,7 +399,7 @@
       type: !type:SimpleColoring
         color: "#FFFFFF"
   sprites:
-  - sprite: *gauze.rsi
+  - sprite: *gauze_rsi
     state: rleg
 
 - type: marking
@@ -411,7 +411,7 @@
       type: !type:SimpleColoring
         color: "#FFFFFF"
   sprites:
-  - sprite: *gauze.rsi
+  - sprite: *gauze_rsi
     state: lfoot
 
 - type: marking
@@ -423,5 +423,5 @@
       type: !type:SimpleColoring
         color: "#FFFFFF"
   sprites:
-  - sprite: *gauze.rsi
+  - sprite: *gauze_rsi
     state: rfoot

--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Tools/medical_wrench.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Tools/medical_wrench.yml
@@ -5,14 +5,14 @@
   description: 'A common (medical?) tool for assembly and disassembly. Remember: lefty latchy, righty removey.'
   components:
   - type: Sprite
-    sprite: &wrench.rsi "_Moffstation/Objects/Tools/wrench.rsi"
+    sprite: &wrench_rsi "_Moffstation/Objects/Tools/wrench.rsi"
     layers:
     - state: icon
     - state: icon-medical
   - type: Item
-    sprite: *wrench.rsi
+    sprite: *wrench_rsi
     storedSprite:
-      sprite: *wrench.rsi
+      sprite: *wrench_rsi
       state: storage-medical
   - type: MeleeWeapon
     damage:


### PR DESCRIPTION
Regex find and replace a bunch of anchors we added which have `.` or other characters in their identifiers that cause some YAML parsers to choke.

@Davyei , please don't use `.` or `-` in anchors in the future. I didn't know it'd be an issue, so this isn't a reprimand, I'm just letting you know.