### PR TITLE
[Bugfix] Repremand Avali players for taking too many survival boxes

### DIFF
--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -124,6 +124,7 @@
   loadouts:
   - LoadoutSpeciesEVANitrogen
   - LoadoutSpeciesEVAOxygen
+  - LoadoutSpeciesEVAOxygenAvali # Moffstation
 
 # vox get a nitrogen tank, other species get nothing
 - type: loadoutGroup
@@ -140,6 +141,7 @@
   loadouts:
   - LoadoutSpeciesPocketDoubleNitrogen
   - LoadoutSpeciesPocketDoubleOxygen
+  - LoadoutSpeciesPocketDoubleOxygenAvali # Moffstation
 
 # Command
 - type: loadoutGroup

--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -20,7 +20,6 @@
     - Reptilian
     - Vulpkanin
     # Moffstation - Begin
-    - Avali
     - Gray
     - Resomi
     - Thaven

--- a/Resources/Prototypes/_Moffstation/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/_Moffstation/Loadouts/Miscellaneous/survival.yml
@@ -24,6 +24,23 @@
     - Vox
     - Vulpkanin
 
+# EVA Tanks
+- type: loadout
+  id: LoadoutSpeciesEVAOxygenAvali
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: EffectSpeciesAvali
+  equipment:
+    suitstorage: OxygenTankFilled
+
+- type: loadout
+  id: LoadoutSpeciesPocketDoubleOxygenAvali
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: EffectSpeciesAvali
+  equipment:
+    pocket1: DoubleEmergencyOxygenTankFilled
+
 # Drink Bottles
 - type: loadout
   id: LoadoutSpeciesBottleAmmonia


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Fixed the loadout bug where crew Avali would spawn with an ammonia and a water survival box.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix of my own fault.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Removed Avali from OxygenBreather loadout group.
Created new isolated oxygen tank loadout referencing existing Avali loadoutgroup species specifier.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Load into round with an Avali.
Open bag.
Doublecheck Ninja and LoneOp spawn for air tanks.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- fix: Avali now spawn with the correct number of survival boxes.
- fix: Nuclear Operative Avali now spawn with a double emergency oxygen tank in their pockets.