### PR TITLE
[tweak] Less obvious bomb deliveries and mail spesos information

### DIFF
--- a/Content.Shared/Delivery/DeliveryModifierSystem.cs
+++ b/Content.Shared/Delivery/DeliveryModifierSystem.cs
@@ -160,7 +160,7 @@ public sealed partial class DeliveryModifierSystem : EntitySystem
             args.PushMarkup(Loc.GetString("moff-delivery-bomb-primed-examine", ("type", trueName)));
         //else
         //    args.PushMarkup(Loc.GetString("delivery-bomb-examine", ("type", trueName)));
-        //// Moffstation - End
+        // Moffstation - End
     }
 
     private void OnGetExplosiveMultiplier(Entity<DeliveryBombComponent> ent, ref GetDeliveryMultiplierEvent args)

--- a/Content.Shared/Delivery/DeliveryModifierSystem.cs
+++ b/Content.Shared/Delivery/DeliveryModifierSystem.cs
@@ -154,10 +154,13 @@ public sealed partial class DeliveryModifierSystem : EntitySystem
 
         var isPrimed = HasComp<PrimedDeliveryBombComponent>(ent);
 
+        //// Moffstation - Start - Less obvious bomb mail
         if (isPrimed)
-            args.PushMarkup(Loc.GetString("delivery-bomb-primed-examine", ("type", trueName)));
-        else
-            args.PushMarkup(Loc.GetString("delivery-bomb-examine", ("type", trueName)));
+            // args.PushMarkup(Loc.GetString("delivery-bomb-primed-examine", ("type", trueName)));
+            args.PushMarkup(Loc.GetString("moff-delivery-bomb-primed-examine", ("type", trueName)));
+        //else
+        //    args.PushMarkup(Loc.GetString("delivery-bomb-examine", ("type", trueName)));
+        //// Moffstation - End
     }
 
     private void OnGetExplosiveMultiplier(Entity<DeliveryBombComponent> ent, ref GetDeliveryMultiplierEvent args)

--- a/Content.Shared/Delivery/DeliveryModifierSystem.cs
+++ b/Content.Shared/Delivery/DeliveryModifierSystem.cs
@@ -154,7 +154,7 @@ public sealed partial class DeliveryModifierSystem : EntitySystem
 
         var isPrimed = HasComp<PrimedDeliveryBombComponent>(ent);
 
-        //// Moffstation - Start - Less obvious bomb mail
+        // Moffstation - Start - Less obvious bomb mail
         if (isPrimed)
             // args.PushMarkup(Loc.GetString("delivery-bomb-primed-examine", ("type", trueName)));
             args.PushMarkup(Loc.GetString("moff-delivery-bomb-primed-examine", ("type", trueName)));

--- a/Content.Shared/Delivery/SharedDeliverySystem.cs
+++ b/Content.Shared/Delivery/SharedDeliverySystem.cs
@@ -69,7 +69,7 @@ public abstract partial class SharedDeliverySystem : EntitySystem
             var multiplier = GetDeliveryMultiplier(ent);
             var totalSpesos = Math.Round(ent.Comp.BaseSpesoReward * multiplier);
 
-            args.PushMarkup(Loc.GetString("delivery-earnings-examine", ("spesos", totalSpesos)), -1);
+            // args.PushMarkup(Loc.GetString("delivery-earnings-examine", ("spesos", totalSpesos)), -1); // Moffstation - Mail changes
         }
     }
 

--- a/Resources/Locale/en-US/_Moffstation/delivery/delivery-component.ftl
+++ b/Resources/Locale/en-US/_Moffstation/delivery/delivery-component.ftl
@@ -1,0 +1,1 @@
+﻿moff-delivery-bomb-primed-examine = [color=purple]Is this supposed to be ticking?[/color]

--- a/Resources/Prototypes/Entities/Objects/Deliveries/deliveries.yml
+++ b/Resources/Prototypes/Entities/Objects/Deliveries/deliveries.yml
@@ -217,8 +217,8 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: DeliveryBomb
-    explosionChance: 0
-    explosionChanceRetryIncrease: 0.05
+    explosionChance: 0 # Moff - Less obvious bomb mail
+    explosionChanceRetryIncrease: 0.05 # Moff - Less obvious bomb mail
   - type: AmbientSound
     enabled: false
     range: 8

--- a/Resources/Prototypes/Entities/Objects/Deliveries/deliveries.yml
+++ b/Resources/Prototypes/Entities/Objects/Deliveries/deliveries.yml
@@ -79,13 +79,15 @@
     - state: broken
       map: [ "enum.DeliveryVisualLayers.Breakage" ]
       visible: false
-    - state: bomb
-      map: [ "enum.DeliveryVisualLayers.Bomb" ]
-      visible: false
-    - state: bomb_unshaded
-      map: [ "enum.DeliveryVisualLayers.BombPrimed" ]
-      shader: unshaded
-      visible: false
+    # Moffstation - Start - Less obvious bomb mail
+    #- state: bomb
+    #  map: [ "enum.DeliveryVisualLayers.Bomb" ]
+    #  visible: false
+    #- state: bomb_unshaded
+    #  map: [ "enum.DeliveryVisualLayers.BombPrimed" ]
+    #  shader: unshaded
+    #  visible: false
+    # Moffstation - End
     - state: trash
       map: [ "enum.DeliveryVisualLayers.Trash" ]
       visible: false

--- a/Resources/Prototypes/Entities/Objects/Deliveries/deliveries.yml
+++ b/Resources/Prototypes/Entities/Objects/Deliveries/deliveries.yml
@@ -217,6 +217,8 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: DeliveryBomb
+    explosionChance: 0
+    explosionChanceRetryIncrease: 0.05
   - type: AmbientSound
     enabled: false
     range: 8

--- a/Resources/Prototypes/Entities/Objects/Deliveries/deliveries.yml
+++ b/Resources/Prototypes/Entities/Objects/Deliveries/deliveries.yml
@@ -136,13 +136,15 @@
     - state: broken
       map: [ "enum.DeliveryVisualLayers.Breakage" ]
       visible: false
-    - state: bomb
-      map: [ "enum.DeliveryVisualLayers.Bomb" ]
-      visible: false
-    - state: bomb_unshaded
-      map: [ "enum.DeliveryVisualLayers.BombPrimed" ]
-      shader: unshaded
-      visible: false
+    # Moffstation - Start - Less obvious bomb mail
+    #- state: bomb
+    #  map: [ "enum.DeliveryVisualLayers.Bomb" ]
+    #  visible: false
+    #- state: bomb_unshaded
+    #  map: [ "enum.DeliveryVisualLayers.BombPrimed" ]
+    #  shader: unshaded
+    #  visible: false
+    # Moffstation - End
   - type: Item
     storedRotation: 90
   - type: Delivery


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline
See the Harmony contributing guidelines for an example on what we want: https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Makes bomb letters less obvious, and additionally removes the flag stating how many spesos each letter will deliver for.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bomb letters in their current implementation are too obvious, even if rare, leading to players cheesing their intention by having recipients open their letters and toss the letter directly into space - mitigating any risk for all of the economic benefit. To correct this, we have first removed the visuals and pre-open examine flavor text, to hide the fact that the letter is in fact a bomb letter. Once activated, the bomb letter will still give an audio tick, hinting at the trap, as well as a new examine flavor text to highlight this for players without audio.

Additionally, the information showcasing the number of spesos was removed. This is mostly to prevent folks from seeing the increased value of the bomb mail to know preemptively leading to the same original problem - but also it really doesn't add anything meaningful for the player experience to begin with.

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Commented out a few lines of C# and yml, while adding a new ftl file for our flavor text.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
May be worth setting `id: DeliveryModifierBomb` to `1` from `0.02`, for the sake of ensuring letters spawn as bomb mail.
Spawn letter.
Inspect letter.
Open letter.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

<img width="485" height="243" alt="image" src="https://github.com/user-attachments/assets/08490079-9bf6-426c-905a-bb7be725e769" />

_Normal letter..?_

<img width="486" height="196" alt="image" src="https://github.com/user-attachments/assets/78521d1f-50fb-43a7-a5e1-4056e11a7349" />

_Tick tock._

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Upstream Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) as well as the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces, and/or followed proper guidelines for modifying upstream files.
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- Changelog changes go here, below the :cl:-->
:cl:


<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Bomb letters are now visually identical to their non-bomb counterparts.
- remove: Mail no longer states their direct spesos value on each unit. 