### PR TITLE
Fix #1636; sparkless welder for CI usage

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/TileAtmosphereTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/TileAtmosphereTest.cs
@@ -98,7 +98,7 @@ public abstract class TileAtmosphereTest : AtmosTest
 
         await Server.WaitAssertion(() =>
         {
-            var welder = SEntMan.SpawnEntity("Welder", source.ToCoordinates());
+            var welder = SEntMan.SpawnEntity("WelderNoSparks", source.ToCoordinates()); // Moffstation - Normal welder with sparks can fail the test
             Assert.That(ItemToggleSys.TryActivate(welder));
         });
 

--- a/Resources/Prototypes/_Moffstation/Entities/Debugging/debug_sweps.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Debugging/debug_sweps.yml
@@ -10,3 +10,13 @@
         Blunt: 200
         Asphyxiation: 200
         Shock: 200
+
+- type: entity
+  parent: Welder
+  id: WelderNoSparks
+  categories: [ Debug ]
+  name: welding tool
+  suffix: Debug, no sparks
+  components:
+  - type: ESSparkOnItemToggle
+    count: 0

--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Tools/welders.yml
@@ -1,0 +1,8 @@
+- type: entity
+  parent: Welder
+  id: WelderNoSparks
+  name: welding tool
+  suffix: Debug, no sparks
+  components:
+  - type: ESSparkOnItemToggle
+    count: 0

--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Tools/welders.yml
@@ -1,9 +1,0 @@
-- type: entity
-  parent: Welder
-  id: WelderNoSparks
-  categories: [ Debug ]
-  name: welding tool
-  suffix: Debug, no sparks
-  components:
-  - type: ESSparkOnItemToggle
-    count: 0

--- a/Resources/Prototypes/_Moffstation/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Objects/Tools/welders.yml
@@ -1,6 +1,7 @@
 - type: entity
   parent: Welder
   id: WelderNoSparks
+  categories: [ Debug ]
   name: welding tool
   suffix: Debug, no sparks
   components:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Add sparkless debug welder, use it in the atmos fire test

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #1636

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
I used `git bisect` with a script that ran the failing test a bazillion times and tracked down the issue to #1571 . Looking at the test, I see it uses a welder to ignite gas, so my assumption is that the sparks are causing the gas to ignite in a way that's different from upstream, causing the slight deviation in values that it's asserting against.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
n/a

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
