### PR TITLE
[Feature] Additional Telepad cosmetics

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Telepad.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Telepad.cs
@@ -108,6 +108,7 @@ public sealed partial class CargoSystem
             if (FulfillOrder(currentOrder, currentOrder.Account, xform.Coordinates, comp.PrinterOutput))
             {
                 _audio.PlayPvs(_audio.ResolveSound(comp.TeleportSound), uid, AudioParams.Default.WithVolume(-8f));
+                Spawn(comp.TelepadFlash, xform.Coordinates); // Moff - Thematic Telepads
 
                 if (_station.GetOwningStation(uid) is { } station)
                     UpdateOrders(station);

--- a/Content.Shared/Cargo/Components/SharedCargoTelepadComponent.cs
+++ b/Content.Shared/Cargo/Components/SharedCargoTelepadComponent.cs
@@ -41,4 +41,13 @@ public sealed partial class CargoTelepadComponent : Component
 
     [DataField("receiverPort", customTypeSerializer: typeof(PrototypeIdSerializer<SinkPortPrototype>)), ViewVariables(VVAccess.ReadWrite)]
     public string ReceiverPort = "OrderReceiver";
+
+
+    // Moff Start - Thematic Telepads
+    /// <summary>
+    ///     Flash-effect that is created with each package delivered via telepad teleportation.
+    /// </summary>
+    [DataField]
+    public EntProtoId TelepadFlash = "AdminInstantEffectBluespace";
+    // Moff End
 }

--- a/Content.Shared/Cargo/Components/SharedCargoTelepadComponent.cs
+++ b/Content.Shared/Cargo/Components/SharedCargoTelepadComponent.cs
@@ -48,6 +48,6 @@ public sealed partial class CargoTelepadComponent : Component
     ///     Flash-effect that is created with each package delivered via telepad teleportation.
     /// </summary>
     [DataField]
-    public EntProtoId TelepadFlash = "AdminInstantEffectBluespace";
+    public EntProtoId? TelepadFlash = "AdminInstantEffectBluespace";
     // Moff End
 }


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Cargo Telepads now create a bluespace flash effect when they're used.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Telepads thematically teleport transport goods across time and space faster than light - or in SS14 terms, use bluespace.

This feature was something I ended up developing on the side of my other pull request https://github.com/moff-station/moff-station-14/pull/1621 , but seemed both easy enough to split off while also being uniquely distinct and impactful, it would be worth splitting into its own dedicated pull request.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->

Creates an entity reference within the component for the telepad, and spawn this entity every time an order is fulfilled.

Attach a telepad to a cargo request computer, and teleport any item in.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

https://github.com/user-attachments/assets/4dac924a-f3cf-495a-99b6-53f910a641c6


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- add: Telepads now apply a bluespace effect when they teleport goods.