### PR TITLE
Antag pop adjustments

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -235,7 +235,7 @@
   parent: [BaseGameRule, BaseRoundstartAntagRule]
   components:
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 30 # Moff - Highpop Gamemode
     # Moffstation - Begin - Delay revs so that everyone spawning at the arrivals terminal doesn't end the round
     delay:
       min: 300
@@ -300,7 +300,7 @@
   parent: [ BaseGameRule, BaseRoundstartAntagRule]
   components:
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 20 # Moff - Midpop Gamemode
     delay:
       min: 600
       max: 900
@@ -345,7 +345,7 @@
   id: Xenoborgs
   components:
   - type: GameRule
-    minPlayers: 30
+    minPlayers: 30 # Moff - Highpop Gamemode
 
 # This rule makes the chosen players unable to get other antag rules, as a way to prevent metagaming job rolls.
 # Put this before antags assigned to station jobs, but after non-job antags (NukeOps/Wiz).

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -3,7 +3,7 @@
   id: Conspirators
   components:
   - type: GameRule
-    minPlayers: 28 # minimum of 4 conspirators
+    minPlayers: 20 # Moff - Midpop Gamemode
     # Moffstation - Start - Delay so they don't get selected on arrivals
     delay:
       min: 240

--- a/Resources/Prototypes/_Moffstation/GameRules/pirates.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/pirates.yml
@@ -21,7 +21,7 @@
   - type: LoadMapRule
     gridPath: /Maps/_Moffstation/Shuttles/shuttle-sp-scurvydog.yml
   - type: GameRule
-    minPlayers: 25
+    minPlayers: 20 # Midpop gamemode
   - type: AntagSelection
     selectionTime: PrePlayerSpawn
     antags:

--- a/Resources/Prototypes/_Moffstation/GameRules/wizard_duel.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/wizard_duel.yml
@@ -7,7 +7,7 @@
   - type: RuleGrids
   - type: AntagLoadProfileRule
   - type: GameRule
-    minPlayers: 35
+    minPlayers: 30 # Highpop gamemode
   - type: AntagObjectives
     objectives:
     - WizardDuelistMeetObjective

--- a/Resources/Prototypes/_Moffstation/secret_weights.yml
+++ b/Resources/Prototypes/_Moffstation/secret_weights.yml
@@ -1,18 +1,18 @@
 # Rather than just having these total out to 1, instead we are making the base "0.1"
-# Make
+# Change their values to reflect how common you want them compared to the rest
 - type: weightedRandom
   id: Secret
   weights:
-    # Deadpop gamemodes (0 Ready)
-    Survival: 0.05
-    # Lowpop gamemodes (5 Ready)
+    # Deadpop gamemodes - 0 Ready
+    Survival: 0.03
+    # Lowpop gamemodes - 5 Ready
     Traitor: 0.10
-    # Midpop gamemodes (20 Ready)
+    # Midpop gamemodes - 20 Ready
     Nukeops: 0.10
     Conspiracy: 0.10
     Pirates: 0.10
     Zombie: 0.10
-    # Highpop Gamemodes (30 Ready)
-    Revolutionary: 0.05
-    Xenoborgs: 0.09
-    WizardDuel: 0.03
+    # Highpop Gamemodes - 30 Ready
+    Revolutionary: 0.10
+    Xenoborgs: 0.05
+    WizardDuel: 0.10

--- a/Resources/Prototypes/_Moffstation/secret_weights.yml
+++ b/Resources/Prototypes/_Moffstation/secret_weights.yml
@@ -1,12 +1,18 @@
+# Rather than just having these total out to 1, instead we are making the base "0.1"
+# Make
 - type: weightedRandom
   id: Secret
   weights:
-    Traitor: 0.33
-    Nukeops: 0.20
+    # Deadpop gamemodes (0 Ready)
+    Survival: 0.05
+    # Lowpop gamemodes (5 Ready)
+    Traitor: 0.10
+    # Midpop gamemodes (20 Ready)
+    Nukeops: 0.10
     Conspiracy: 0.10
     Pirates: 0.10
-    Xenoborgs: 0.09
-    Zombie: 0.05
+    Zombie: 0.10
+    # Highpop Gamemodes (30 Ready)
     Revolutionary: 0.05
-    Survival: 0.05
+    Xenoborgs: 0.09
     WizardDuel: 0.03


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Standardizes gamemodes compared to ready count. 


Alot of gamemodes would previously get barred against a high player count, while this isnt nessessarily a problem on its own, the most common gamemode even when the other ones become availible is still traitors.

With this PR, gamemodes are divided into 4 categories for the most part with equal weight:
- Deadpop gamemodes - 0 Ready
Survival: 0.03
- Lowpop gamemodes - 5 Ready
Traitor: 0.10
- Midpop gamemodes - 20 Ready
Nukeops: 0.10
Conspiracy: 0.10
Pirates: 0.10
Zombie: 0.10
- Highpop Gamemodes - 30 Ready
Revolutionary: 0.10
Xenoborgs: 0.05
WizardDuel: 0.10
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The amount of rounds with a high enough pop to play some of the other game modes is more limited, so I think we should allow it to be higher variety when we reach those points. Even if it wasnt, there isnt too much reason to make some gamemodes super common and others super rare.
## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
its shrimple yaml
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- tweak: Standardized gamemode player counts

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
