### PR TITLE
[Tweak] Hellportals stop spawning entities after 100

### DIFF
--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -249,6 +249,7 @@ namespace Content.IntegrationTests.Tests
                 // Moffstation - Portals spawn more stuff on trigger, self-explanatory
                 "SpawnEntityTableOnTrigger",
                 "AddGameRuleOnTrigger",
+                "Hellportal",
                 // ES fancy timed despawn
                 "ESTimedDespawn",
                 "ESSparkOnTrigger",

--- a/Content.Server/_Moffstation/Hellportal/Components/HellportalComponent.cs
+++ b/Content.Server/_Moffstation/Hellportal/Components/HellportalComponent.cs
@@ -1,23 +1,41 @@
 ﻿using Content.Shared.EntityTable.EntitySelectors;
 using Robust.Shared.Audio;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server._Moffstation.Hellportal.Components;
 
-[RegisterComponent]
+[RegisterComponent, AutoGenerateComponentPause]
 public sealed partial class HellportalComponent : Component
 {
+    /// <summary>
+    /// List of entities that can spawn from this portal.
+    /// TODO: create an AdvancedSpawnTable and BossSpawnTable for ramping progression
+    /// </summary>
     [DataField(required: true)]
     public EntityTableSelector BasicSpawnTable;
 
-    [DataField]
-    public float Accumulator = 0f;
+    /// <summary>
+    /// When the next spawn wave will trigger.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan NextSpawn = TimeSpan.Zero;
 
+    /// <summary>
+    /// Cooldown duration between hellportal spawn waves, in seconds.
+    /// </summary>
     [DataField]
-    public float SpawnCooldown = 30f;
+    public TimeSpan SpawnCooldown = TimeSpan.FromSeconds(30f);
 
+    /// <summary>
+    /// If the number of existing hellportal-spawned entities exceed this number,
+    /// the hellportal will not spawn any further entities.
+    /// </summary>
     [DataField]
     public int MaxSpawns = 100;
 
+    /// <summary>
+    /// Determines the sound to play on spawn trigger, if not null.
+    /// </summary>
     [DataField]
     public SoundSpecifier? Sound;
 

--- a/Content.Server/_Moffstation/Hellportal/Components/HellportalComponent.cs
+++ b/Content.Server/_Moffstation/Hellportal/Components/HellportalComponent.cs
@@ -18,6 +18,7 @@ public sealed partial class HellportalComponent : Component
     /// When the next spawn wave will trigger.
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoPausedField]
     public TimeSpan NextSpawn = TimeSpan.Zero;
 
     /// <summary>

--- a/Content.Server/_Moffstation/Hellportal/Components/HellportalComponent.cs
+++ b/Content.Server/_Moffstation/Hellportal/Components/HellportalComponent.cs
@@ -1,0 +1,24 @@
+﻿using Content.Shared.EntityTable.EntitySelectors;
+using Robust.Shared.Audio;
+
+namespace Content.Server._Moffstation.Hellportal.Components;
+
+[RegisterComponent]
+public sealed partial class HellportalComponent : Component
+{
+    [DataField(required: true)]
+    public EntityTableSelector BasicSpawnTable;
+
+    [DataField]
+    public float Accumulator = 0f;
+
+    [DataField]
+    public float SpawnCooldown = 30f;
+
+    [DataField]
+    public int MaxSpawns = 100;
+
+    [DataField]
+    public SoundSpecifier? Sound;
+
+}

--- a/Content.Server/_Moffstation/Hellportal/Components/HellportalMobComponent.cs
+++ b/Content.Server/_Moffstation/Hellportal/Components/HellportalMobComponent.cs
@@ -1,0 +1,5 @@
+﻿
+namespace Content.Server._Moffstation.Hellportal.Components;
+
+[RegisterComponent]
+public sealed partial class HellportalMobComponent : Component;

--- a/Content.Server/_Moffstation/Hellportal/HellportalSystem.cs
+++ b/Content.Server/_Moffstation/Hellportal/HellportalSystem.cs
@@ -2,6 +2,7 @@
 using Content.Server._Moffstation.Hellportal.Components;
 using Content.Shared.EntityTable;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Timing;
 
 namespace Content.Server._Moffstation.Hellportal;
 
@@ -9,13 +10,7 @@ public sealed partial class HellportalSystem : EntitySystem
 {
     [Dependency] private EntityTableSystem _entityTable = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-        SubscribeLocalEvent < HellportalComponent, AnchorStateChangedEvent>(OnAnchorChange);
-
-    }
+    [Dependency] private IGameTiming _time = default!;
 
     public override void Update(float frameTime)
     {
@@ -26,30 +21,26 @@ public sealed partial class HellportalSystem : EntitySystem
 
         while (query.MoveNext(out var uid, out var comp, out var xform))
         {
-            comp.Accumulator += frameTime;
-            var spawns = _entityTable.GetSpawns(comp.BasicSpawnTable);
+            if (_time.CurTime < comp.NextSpawn)
+                continue;
 
-            if (comp.Accumulator > comp.SpawnCooldown)
-            {
-                comp.Accumulator -= comp.SpawnCooldown;
+            comp.NextSpawn = _time.CurTime + comp.SpawnCooldown;
 
-                if (totalCount < comp.MaxSpawns)
-                {
-                    _audio.PlayPvs(comp.Sound, xform.Coordinates);
-                    foreach (var proto in spawns)
-                    {
-                        Spawn(proto, xform.Coordinates);
-                    }
-                }
-            }
+            if (totalCount >= comp.MaxSpawns)
+                continue;
+
+            _audio.PlayPvs(comp.Sound, xform.Coordinates);
+            foreach (var proto in _entityTable.GetSpawns(comp.BasicSpawnTable))
+                Spawn(proto, xform.Coordinates);
         }
     }
 
-    private void OnAnchorChange(EntityUid uid, HellportalComponent component, ref AnchorStateChangedEvent args)
+    [SubscribeLocalEvent]
+    private void OnAnchorChange(Entity<HellportalComponent> entity, ref AnchorStateChangedEvent args)
     {
         if (!args.Anchored)
         {
-            QueueDel(uid);
+            QueueDel(entity);
         }
     }
 }

--- a/Content.Server/_Moffstation/Hellportal/HellportalSystem.cs
+++ b/Content.Server/_Moffstation/Hellportal/HellportalSystem.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq;
+using Content.Server._Moffstation.Hellportal.Components;
+using Content.Shared.EntityTable;
+using Robust.Shared.Audio.Systems;
+
+namespace Content.Server._Moffstation.Hellportal;
+
+public sealed partial class HellportalSystem : EntitySystem
+{
+    [Dependency] private EntityTableSystem _entityTable = default!;
+    [Dependency] private SharedAudioSystem _audio = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent < HellportalComponent, AnchorStateChangedEvent>(OnAnchorChange);
+
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<HellportalComponent, TransformComponent>();
+        var totalCount = EntityQuery<HellportalMobComponent>().Count();
+
+        while (query.MoveNext(out var uid, out var comp, out var xform))
+        {
+            comp.Accumulator += frameTime;
+            var spawns = _entityTable.GetSpawns(comp.BasicSpawnTable);
+
+            if (comp.Accumulator > comp.SpawnCooldown)
+            {
+                comp.Accumulator -= comp.SpawnCooldown;
+
+                if (totalCount < comp.MaxSpawns)
+                {
+                    _audio.PlayPvs(comp.Sound, xform.Coordinates);
+                    foreach (var proto in spawns)
+                    {
+                        Spawn(proto, xform.Coordinates);
+                    }
+                }
+            }
+        }
+    }
+
+    private void OnAnchorChange(EntityUid uid, HellportalComponent component, ref AnchorStateChangedEvent args)
+    {
+        if (!args.Anchored)
+        {
+            QueueDel(uid);
+        }
+    }
+}

--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/NPCs/portalmobs.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/NPCs/portalmobs.yml
@@ -1,30 +1,45 @@
 - type: entity
-  parent: [ BaseSmasherHostile, MobFleshLover ]
+  abstract: true
+  parent: BaseSmasherHostile
+  id: BaseHellportalMob
+  components:
+  - type: HellportalMob
+  - type: TriggerOnMobstateChange
+    mobState:
+    - Dead
+  - type: GibOnTrigger
+    deleteItems: true
+  - type: SpawnOnTrigger
+    proto: Ash # TODO: custom demons, add demonic essence
+    predicted: true
+
+- type: entity
+  parent: [ BaseHellportalMob, MobFleshLover ]
   id: MobFleshLoverSmasher
   categories: [ HideSpawnMenu ]
 
 - type: entity
-  parent: [ BaseSmasherHostile, MobFleshGolem ]
+  parent: [ BaseHellportalMob, MobFleshGolem ]
   id: MobFleshGolemSmasher
   categories: [ HideSpawnMenu ]
 
 - type: entity
-  parent: [ BaseSmasherHostile, MobFleshClamp ]
+  parent: [ BaseHellportalMob, MobFleshClamp ]
   id: MobFleshClampSmasher
   categories: [ HideSpawnMenu ]
 
 - type: entity
-  parent: [ BaseSmasherHostile, MobFleshJared ]
+  parent: [ BaseHellportalMob, MobFleshJared ]
   id: MobFleshJaredSmasher
   categories: [ HideSpawnMenu ]
 
 - type: entity
-  parent: [ BaseSmasherHostile, MobAbomination ]
+  parent: [ BaseHellportalMob, MobAbomination ]
   id: MobAbominationSmasher
   categories: [ HideSpawnMenu ]
 
 - type: entity
-  parent: [ BaseSmasherHostile, MobCorgiNarsi ]
+  parent: [ BaseHellportalMob, MobCorgiNarsi ]
   id: MobHellhound
   name: hellhound
   categories: [ HideSpawnMenu ]
@@ -35,6 +50,11 @@
     - SimpleHostile
 
 - type: entity
-  parent: [ BaseSmasherHostile, MobHellspawn ]
+  parent: [ BaseHellportalMob, MobGoliath ]
+  id: MobHellGoliath
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  parent: [ BaseHellportalMob, MobHellspawn ]
   id: MobHellspawnSmasher
   name: hellspawn

--- a/Resources/Prototypes/_Moffstation/Entities/Structures/Specific/portal.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Structures/Specific/portal.yml
@@ -1,3 +1,4 @@
+# Base
 - type: entity
   id: BaseHostilePortal
   abstract: true
@@ -40,6 +41,12 @@
   - type: EmitSoundOnSpawn
     sound:
       path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg
+
+- type: entity
+  parent: BaseHostilePortal
+  id: BaseHostilePortalTriggered
+  abstract: true
+  components:
   - type: TriggerOnSpawn
   - type: RepeatingTrigger
     delay: 30
@@ -49,7 +56,7 @@
     sound:
       collection: RadiationPulse
 
-
+# Hellportal
 - type: entity
   parent: BaseHostilePortal
   id: HellPortal
@@ -58,11 +65,10 @@
   components:
   - type: WarpPoint
     location: Hell Portal
-  - type: SpawnEntityTableOnTrigger
-    useMapCoords: true
-    table: !type:AllSelector
+  - type: Hellportal
+    basicSpawnTable: !type:AllSelector
       children:
-      - !type:GroupSelector # The base foot soliders that spawn every time
+      - !type:GroupSelector
         rolls: !type:RangeNumberSelector
           range: 3, 5
         children:
@@ -71,10 +77,12 @@
         - id: MobFleshClampSmasher
         - id: MobFleshJaredSmasher
         - id: MobAbominationSmasher
-      - !type:GroupSelector # The base foot soliders that spawn every time
+      - !type:GroupSelector
         prob: 0.3
         children:
         - id: MobHellhound
-        - id: MobGoliath
+        - id: MobHellGoliath
         - id: MobHellspawnSmasher
           weight: 0.05
+    sound:
+      collection: RadiationPulse


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Created a unique system for Hellportals for their spawn logic, tracking how many existing 'demons' currently exist and halting spawns after 100.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Hellportals are a fun maintstay feature that Moffstation has developed, and intend to expand further upon. With this in mind however, one of the major issues encountered with these hell portals is that - in the event these portals spawn somewhere inaccessible, over time the total number of entities will begin to tax the server itself, leading to excessive lag. This pull request looks to fix this by tagging spawned entities with a new dummy component for headcount purposes, and acidifies them on death. furthermore, once a headcount of 100 is exceeded, the portal will stop spawning until the count drops below this threshhold.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
Theft of dragon and trigger code.

Removed the old trigger system, though taking bits of the original system as required, and created a new system for Hellportals explicitly. This new system then runs an entityquery for our HellportalMob component, which has been attached to our 'demons' as a component.

With this new system created as well, this opens up further planned developments such as spreading influence, having the portal affect the environment around itself, so keep an eye out for that.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
N/A - beyond hellmobs now acidifying, much of the Hellportal from the player perspective is still the same.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces.
- [X] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl: CasaleBalthazar, Centronias, Nyxilath

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Hellportal mobs now return back to their plane of origin on death, acidifying on death.
- tweak: Hellportals now will halt reinforcements when demonic forces exceed 100 strong.