### PR TITLE
Change going to lobby discord notif

### DIFF
--- a/Resources/Locale/en-US/discord/round-notifications.ftl
+++ b/Resources/Locale/en-US/discord/round-notifications.ftl
@@ -1,4 +1,5 @@
-﻿discord-round-notifications-new = A new round is starting!
+﻿# Moff - Change the new round starting text
+#discord-round-notifications-new = The round is now in lobby!
 discord-round-notifications-started = Round #{$id} on map "{$map}" started.
 discord-round-notifications-end = Round #{$id} has ended. It lasted for {$hours} hours, {$minutes} minutes, and {$seconds} seconds.
 discord-round-notifications-end-ping = <@&{$roleId}>, a new round will start soon!


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
When the round restarts, the discord message will now read `The round is now in lobby!` instead of `A new round is starting!`
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This has been bugging me but also confusing a few people.
## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
probably dont need a CL for this

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
