### PR TITLE
Flash protection disables innate night vision again

### DIFF
--- a/Content.Shared/_Moffstation/Overlays/NightVisionDisabledByFlashImmunityComponent.cs
+++ b/Content.Shared/_Moffstation/Overlays/NightVisionDisabledByFlashImmunityComponent.cs
@@ -1,0 +1,9 @@
+﻿using Content.Shared.Flash.Components;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Moffstation.Overlays;
+
+/// This marker component causes entities with both <see cref="Content.Shared.Overlays.NightVisionComponent"/> and
+/// <see cref="FlashImmunityComponent">flash immunity</see> to have its night vision disabled.
+[RegisterComponent, NetworkedComponent]
+public sealed partial class NightVisionDisabledByFlashImmunityComponent : Component;

--- a/Content.Shared/_Moffstation/Overlays/NightVisionDisabledByFlashImmunitySystem.cs
+++ b/Content.Shared/_Moffstation/Overlays/NightVisionDisabledByFlashImmunitySystem.cs
@@ -1,0 +1,19 @@
+﻿using Content.Shared.Flash;
+using Content.Shared.NightVision;
+
+namespace Content.Shared._Moffstation.Overlays;
+
+/// This system implements the behavior of <see cref="NightVisionDisabledByFlashImmunityComponent"/>.
+public sealed partial class NightVisionDisabledByFlashImmunitySystem : EntitySystem
+{
+    [Dependency] private SharedNightVisionSystem _nightVision = default!;
+
+    [SubscribeLocalEvent]
+    private void OnFlashImmunityChanged(
+        Entity<NightVisionDisabledByFlashImmunityComponent> ent,
+        ref FlashImmunityChangedEvent args
+    )
+    {
+        _nightVision.SetEnabled(ent.Owner, !args.FlashImmune);
+    }
+}

--- a/Resources/Prototypes/_Moffstation/Body/Species/resomi.yml
+++ b/Resources/Prototypes/_Moffstation/Body/Species/resomi.yml
@@ -401,6 +401,7 @@
         - MobLayer
   - type: FlashModifier
     modifier: 2
+  - type: NightVisionDisabledByFlashImmunity
 
 
 - type: entity


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix of regression after switching to upstream night vision
Fixes #1661

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
Devmap
Spawn + control resomi
Turn off lights
Observe night vision working
Put on welding mash
Observe night vision not working
Take off welding mask
Observe night vision working again

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="1920" height="1044" alt="image" src="https://github.com/user-attachments/assets/767073ad-d3ad-4c7e-939f-6bfd6437381c" />

<img width="1920" height="1044" alt="image" src="https://github.com/user-attachments/assets/905b7a7f-aeaf-4d98-8378-322cb8e6651d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Resomis' night vision is once again disabled while they are immune to flashes.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
