### PR TITLE
Fix two loc issues, one by changing the moproach event's implementation

### DIFF
--- a/Resources/Locale/en-US/discord/round-notifications.ftl
+++ b/Resources/Locale/en-US/discord/round-notifications.ftl
@@ -1,5 +1,5 @@
 ﻿# Moff - Change the new round starting text
-#discord-round-notifications-new = The round is now in lobby!
+discord-round-notifications-new = The round is now in lobby!
 discord-round-notifications-started = Round #{$id} on map "{$map}" started.
 discord-round-notifications-end = Round #{$id} has ended. It lasted for {$hours} hours, {$minutes} minutes, and {$seconds} seconds.
 discord-round-notifications-end-ping = <@&{$roleId}>, a new round will start soon!

--- a/Resources/Prototypes/_Starlight/GameRules/pests.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/pests.yml
@@ -4,7 +4,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    startAnnouncement: station-event-vent-creatures-start-announcement
+    startAnnouncement: station-event-vent-creatures-start-announcement-no-time
     startAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 6

--- a/Resources/Prototypes/_Starlight/GameRules/pests.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/pests.yml
@@ -4,12 +4,14 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    startAnnouncement: station-event-vent-creatures-start-announcement-no-time
+    startAnnouncement: station-event-vent-creatures-start-horde-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 6
     duration: 30 # Moffstation - used as delay
-  - type: VentCrittersRule
-    entries:
-    - id: MobMoproachHat
-      prob: 0.03
+  # Moff start - Swap to vent horde rule
+  - type: VentHordeRule
+    table:
+      id: MobMoproachHat
+      rolls: 5, 10
+  # Moff end


### PR DESCRIPTION
# Draft because I haven't tested it yet

<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bad loc bad

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
Manually tested the event on the devmap. I can't test the discord hook.

I swapped the moproach event because the loc was being annoying because we don't have a place to get the `time`/`location` for the event on the old vent critter rule. So just swapping to vent horde is easier. 🤷 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [ ] I have properly sectioned my changes into fork namespaces.
- [ ] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
n/a, imo, nothing is changed enough to warrant it.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
