### PR TITLE
DAGD Probability fix

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -10,6 +10,7 @@
     TraitorObjectiveGroupSabotage: 0.5
     TraitorObjectiveGroupOther: 0.5
     DieObjective: 0.002 # Moved here directly, as embedding it in a table messes up the odds
+    EscapeShuttleObjective: 0.01
     # Moffstation - End
 
 - type: weightedRandom

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -5,11 +5,11 @@
     # Moffstation - Start - Reweighing tables for picker. Keep original proto so we can keep up with any upstream changes
     TraitorObjectiveGroupSteal: 0.25
     TraitorObjectiveGroupKill: 1
-    #TraitorObjectiveGroupState: 0.25 # Moff - QUIT FUCKIN UP MY ODDS
+    #TraitorObjectiveGroupState: 0.25 # Moff - QUIT FUCKIN UP MY ODDS (Rolls DAGD too often)
     TraitorObjectiveGroupSocial: 0.5 #Involves helping/harming others without killing them or stealing their stuff
     TraitorObjectiveGroupSabotage: 0.5
     TraitorObjectiveGroupOther: 0.5
-    DieObjective: 0.002 # Moved here directly, as embedding it in a table messes up the odds
+    DieObjective: 0.002 # Moff - Moved here directly, as embedding it in a table messes up the odds
     EscapeShuttleObjective: 0.01
     # Moffstation - End
 

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -5,7 +5,7 @@
     # Moffstation - Start - Reweighing tables for picker. Keep original proto so we can keep up with any upstream changes
     TraitorObjectiveGroupSteal: 0.25
     TraitorObjectiveGroupKill: 1
-    #TraitorObjectiveGroupState: 0.25 #As in, something about your character. Alive, dead, arrested, gained an ability...
+    #TraitorObjectiveGroupState: 0.25 # Moff - QUIT FUCKIN UP MY ODDS
     TraitorObjectiveGroupSocial: 0.5 #Involves helping/harming others without killing them or stealing their stuff
     TraitorObjectiveGroupSabotage: 0.5
     TraitorObjectiveGroupOther: 0.5

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -5,7 +5,7 @@
     # Moffstation - Start - Reweighing tables for picker. Keep original proto so we can keep up with any upstream changes
     TraitorObjectiveGroupSteal: 0.25
     TraitorObjectiveGroupKill: 1
-    TraitorObjectiveGroupState: 0.25 #As in, something about your character. Alive, dead, arrested, gained an ability...
+    #TraitorObjectiveGroupState: 0.25 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 0.5 #Involves helping/harming others without killing them or stealing their stuff
     TraitorObjectiveGroupSabotage: 0.5
     TraitorObjectiveGroupOther: 0.5

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -9,6 +9,7 @@
     TraitorObjectiveGroupSocial: 0.5 #Involves helping/harming others without killing them or stealing their stuff
     TraitorObjectiveGroupSabotage: 0.5
     TraitorObjectiveGroupOther: 0.5
+    DieObjective: 0.002 # Moved here directly, as embedding it in a table messes up the odds
     # Moffstation - End
 
 - type: weightedRandom
@@ -36,12 +37,14 @@
     KillRandomHeadObjective: 0.25
     TeachLessonObjective: 1 # Moffstation - teach lesson objective
 
-- type: weightedRandom
-  id: TraitorObjectiveGroupState
-  weights:
-    EscapeShuttleObjective: 1
-    DieObjective: 0.01 # Moffstation - Objective picker adjustments
+# Moff start - Dont embed this table because it makes DAGD way higher prob than it should be
+#- type: weightedRandom
+#  id: TraitorObjectiveGroupState
+#  weights:
+#    EscapeShuttleObjective: 1
+#    DieObjective: 0.01 # Moffstation - Objective picker adjustments
     #HijackShuttleObjective: 0.02
+# Moff end
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSocial

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -75,7 +75,7 @@
     # Moffstation - Location based objectives
     TrashRoomObjective: 1
     ClaimLocationObjective: 1
-    # Die and escape moved here so that their weights are respected
+    # Despite them not being "social", die and escape moved here so that their weights are respected
     DieObjective: 0.01
     EscapeShuttleObjective: 0.1
     # Moffstation - End

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -9,8 +9,6 @@
     TraitorObjectiveGroupSocial: 0.5 #Involves helping/harming others without killing them or stealing their stuff
     TraitorObjectiveGroupSabotage: 0.5
     TraitorObjectiveGroupOther: 0.5
-    DieObjective: 0.002 # Moff - Moved here directly, as embedding it in a table messes up the odds
-    EscapeShuttleObjective: 0.01
     # Moffstation - End
 
 - type: weightedRandom
@@ -77,6 +75,9 @@
     # Moffstation - Location based objectives
     TrashRoomObjective: 1
     ClaimLocationObjective: 1
+    # Die and escape moved here so that their weights are respected
+    DieObjective: 0.01
+    EscapeShuttleObjective: 0.1
     # Moffstation - End
 
 


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Moves DAGD out of a table and into the base set of traitor objectives.
Removes Escape to CC, most people dont pick it anyway. If you wanna live then live.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
So a bit of code lore on the objective picker

Objectives that are incompatible with eachother can both be present on the objective picker. This is normally not a huge issue. Additionally when an objective is chosen, it is taken out of the available pool of objectives, so people dont get the same thing twice. Additionally, the traitor objective list is made up of groups of different categories, so first it will pick a category, then an objective, then remove it from the category in the future.

All of these things come together for DAGD.

One of the objective categories for traitors is "TraitorObjectiveGroupState" which contains two objectives: Escape to CC and DAGD, the first being common and the second supposed to be exceedingly rare. However, the table itself has an altogether weight of 0.25, which is fairly common. When the table rolls the first time it will most likely pick and take escape to centcomm, but if it gets rolled a second time its ONLY OPTION is DAGD. Meaning that no matter how rare DAGD is within the table, after escape to CC is picked it has a far higher likelyhood of appearing. This makes DAGD far more common than it should be within the objective picker.
## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Fixed DAGD being far more common than it should be
- remove: Removed escape to CC, people dont really pick it in the objective picker. If you wanna live then live!

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
