### PR TITLE
Gungame second wind

### DIFF
--- a/Content.Server/_Moffstation/GameTicking/Rules/GunGameRuleSystem.cs
+++ b/Content.Server/_Moffstation/GameTicking/Rules/GunGameRuleSystem.cs
@@ -9,6 +9,7 @@ using Content.Server.Mind;
 using Content.Server.Power.Components;
 using Content.Server.RoundEnd;
 using Content.Server.Station.Systems;
+using Content.Shared.Administration.Systems;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.GameTicking;
 using Content.Shared.GameTicking.Components;
@@ -47,6 +48,7 @@ public sealed partial class GunGameRuleSystem : GameRuleSystem<GunGameRuleCompon
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private ItemSlotsSystem _itemSlots = default!;
+    [Dependency] private RejuvenateSystem _rejuvenate = default!;
 
     public override void Initialize()
     {
@@ -130,6 +132,11 @@ public sealed partial class GunGameRuleSystem : GameRuleSystem<GunGameRuleCompon
             killerInfo.Kills = 0;
             ProgressPlayerReward(killerInfo, gunGame);
             RefreshPlayerLoadout(killerInfo, gunGame);
+
+            // Rejuvenate the killer
+            if (_player.TryGetSessionById(killer.PlayerId, out var session)
+                && session.AttachedEntity is { } killerUid)
+                _rejuvenate.PerformRejuvenate(killerUid);
         }
     }
 


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
You now get rejuvinated in gungame when you get a kill
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I think its more fun when you're able to recover after killing someone, rather than being an easy kill for the next person you come across.

Those who have will have more in abundance. But those who do not have, even what little they have will be taken away from them.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- add: You now rejuvenate after getting a kill in gungame!

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
