### PR TITLE
Replicators get back up when they're repaired

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/Mobs/replicator.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/Mobs/replicator.yml
@@ -103,6 +103,7 @@
     thresholds:
       0: Alive
       100: Dead
+    allowRevives: true
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
Literally just one bool on `mobThresholds` which causes the mob to go from dead to alive when they cross back over the threshold. This is why borgs can get back up when they're repaired and humans can't.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
smol

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Replicators now properly return to a controllable healthy state when repaired from being disabled on the ground.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
