### PR TITLE
[Tweak] Hellportal spawn location logic

### DIFF
--- a/Content.Server/StationEvents/Components/RandomSpawnRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/RandomSpawnRuleComponent.cs
@@ -17,7 +17,19 @@ public sealed partial class RandomSpawnRuleComponent : Component
     [DataField("prototype", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string Prototype = string.Empty;
 
-    // Moffstation - Start - Syndicate dead drop
+    // Moffstation - Start
+    /// <summary>
+    /// Bool to determine if the rule must select the station grid for spawn.
+    /// </summary>
+    [DataField]
+    public bool LargestGrid;
+
+    /// <summary>
+    /// Bool to determine if the rule must select a tile with working atmosphere for spawn.
+    /// </summary>
+    [DataField]
+    public bool SafeAtmosphere;
+
     /// <summary>
     /// The radio message to send when spawning the entity. The entity is used as the sender of the radio message.
     /// </summary>

--- a/Content.Server/StationEvents/Events/RandomSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/RandomSpawnRule.cs
@@ -20,7 +20,7 @@ public sealed partial class RandomSpawnRule : StationEventSystem<RandomSpawnRule
     {
         base.Started(uid, comp, gameRule, args);
 
-        if (TryFindRandomTile(out _, out _, out _, out var coords))
+        if (TryFindRandomTile(out _, out _, out _, out var coords, largestGrid: comp.LargestGrid, safeAtmos: comp.SafeAtmosphere)) //Moff
         {
             Sawmill.Info($"Spawning {comp.Prototype} at {coords}");
             // Moffstation - Syndicate dead drop

--- a/Resources/Prototypes/_Moffstation/GameRules/portal.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/portal.yml
@@ -13,3 +13,5 @@
     minimumPlayers: 30
   - type: RandomSpawnRule
     prototype: HellPortal
+    largestGrid: True
+    safeAtmosphere: True


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Adds largestGrid and safeAtmos parameters to RandomSpawnRule, specifying these parameters as true for the purposes of Hellportal spawning.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A sister PR to https://github.com/moff-station/moff-station-14/pull/1660 - another issue we've observed with Hellportals is simply that, sometimes, they spawn in locations that are otherwise non-impactful. As this PvE event is meant to cause problems for the station similiar to that of our ghostrole midround antags, this requires that the portal itself spawns in a location to actually pose a threat - which it cannot if it's in an easily ignorable location such as the ATS siderooms or on a solar field. This simple change ensures that this portal, while it may not be immediately in the public on spawn, is at least on the station in a location that it can fester, and eventually rise to become the problem it is intended to be.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
Hard to test a negative; how can you prove that it /won't/ spawn on a solar field? I ran the rule probably 50 times or so, and did not observe it once spawn in an invalid location.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
N/A - only changing the spawning logic, not the actual portal itself.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces.
- [X] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- tweak: Hellportals will now always spawn inside of the station.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
