### PR TITLE
Guard against ES spark throwing throwing in tests

### DIFF
--- a/Content.Shared/_ES/Sparks/ESSparksSystem.cs
+++ b/Content.Shared/_ES/Sparks/ESSparksSystem.cs
@@ -1,6 +1,5 @@
 using Content.Shared._ES.Physics.PreventCollide;
 using Content.Shared._ES.Sparks.Components;
-// using Content.Shared._ES.TileFires; // DeltaV - we don't have tilefires
 using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.Throwing;
@@ -23,6 +22,8 @@ public sealed partial class ESSparksSystem : EntitySystem
     // [Dependency] private readonly ESSharedTileFireSystem _tileFire = default!; // DeltaV - we don't have tilefires
     [Dependency] private ThrowingSystem _throwing = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
+
+    [Dependency] private EntityQuery<TransformComponent> _transformQuery; // Moff
 
     public static readonly EntProtoId DefaultSparks = "ESEffectSparks";
 
@@ -112,6 +113,15 @@ public sealed partial class ESSparksSystem : EntitySystem
         {
             var sparks = Spawn(sparksPrototype, _transform.ToMapCoordinates(coordinates), rotation: angle);
             angle += angleDelta;
+
+            // Moff start - Guard against intermittent test failure where throwing `throw`s :^) because of a lack of
+            // transform component on the sparks. I have no idea how a newly spawned entity can sometimes have a transform and sometimes not.
+            if (!_transformQuery.HasComp(sparks))
+            {
+                Log.Warning($"Skipping throwing sparks for {ToPrettyString(sparks)}, as it lacks a {nameof(TransformComponent)}");
+            }
+            // Moff end
+
             _throwing.TryThrow(sparks, angle.ToVec(), 2f, animated: false);
             _preventCollide.PreventCollide(sparks, ignored);
         }


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
When ES sparks are spawned, they're thrown by the throwing system to make them spark out in random directions.
This uses physics transforms, and somehow the sparks don't always have those, causing the throwing system to `throw`. This just checks if they have a transform before trying to throw them and skips throwing them if they're missing a transform.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #1640

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
devmap
spawn RCD
switch RCD mode
observe sparks still skitter out randomly
maybe RCD some tiles and observe it again

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
n/a not player facing

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
