### PR TITLE
Fix Hephaestus AI sprites

### DIFF
--- a/Resources/Prototypes/_Moffstation/AppearanceCustomization/station_ai.yml
+++ b/Resources/Prototypes/_Moffstation/AppearanceCustomization/station_ai.yml
@@ -132,17 +132,17 @@
       sprite: _Moffstation/Mobs/Silicon/StationAi/station_ai.rsi
       state: ai_helios
     Dead: *defaultdead
-    
+
 - type: stationAiCustomization
   parent: StationAiIconBase
   id: StationAiIconAiHephaestus
   name: station-ai-icon-hephaestus
   layerData:
     Occupied:
-      sprite: _Moffstation\Mobs\Silicon\StationAi\hephaestus_ai.rsi
+      sprite: &hephaestus_rsi _Moffstation/Mobs/Silicon/StationAi/hephaestus_ai.rsi
       state: ai_hephaestus
     Dead:
-      sprite: _Moffstation\Mobs\Silicon\StationAi\hephaestus_ai.rsi
+      sprite: *hephaestus_rsi
       state: ai_hephaestus_purged
 
 - type: stationAiCustomization


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title
Related to #1691

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
devmap
ai takeover
check customization menu
pick customization

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="741" height="512" alt="image" src="https://github.com/user-attachments/assets/9ee139ff-e826-4105-82b1-4285054268ea" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: The Hephaestus AI core customization no longer has an ERROR sprite.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
