### PR TITLE
Made high-heeled boots available in the dramadrobe.

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -24,7 +24,7 @@
     # Moffstation - Begin - vocal synth outfits
     BoxPerformer: 1
     BoxPerformerRed: 1
-    BoxPerformerYellow: 1 
+    BoxPerformerYellow: 1
     # Moffstation - End
     ClothingMaskJoy: 2
     ClothingHeadHatCardborg: 2
@@ -83,6 +83,7 @@
     ToyFigurineMusician: 1
     ClothingShoesBling: 1
     ClothingShoesBootsCowboyFancy: 1
+    ClothingShoesHighheelBoots: 2 # Moff - Adds high-heeled boots to DramaDrobe
     ClothingOuterDogi: 1
     ClothingOuterSuitCarp: 1
     ClothingMaskBlushingClown: 1


### PR DESCRIPTION

## About the PR
Added them to the hacked section of the dramadrobe!

## Why / Balance
Right now they're only maintenance loot... Which kinda sucks because they're very cool. 

## Test Plan / Technical Details

Went into the dev environment
Hacked the dramadrobe
It's there

## Media

<img width="950" height="586" alt="Screenshot 2026-07-22 154904" src="https://github.com/user-attachments/assets/a45982ce-24c7-4de0-ab90-29f5bd6e27a8" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces.
- [X] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- tweak: Made high-heeled boots available in the hacked dramadrobe


