### PR TITLE
Objectives in picker get auto-selected after timer runs out

### DIFF
--- a/Content.Server/_Moffstation/Objectives/Systems/AntagRandomObjectivesSystem.cs
+++ b/Content.Server/_Moffstation/Objectives/Systems/AntagRandomObjectivesSystem.cs
@@ -20,7 +20,7 @@ public sealed partial class AntagRandomObjectivesSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<AntagRandomObjectivesComponent, AfterAntagEntitySelectedEvent>(OnAntagSelected);
-        SubscribeAllEvent<ObjectivePickerSelected>(OnObjectivesSelected);
+        SubscribeNetworkEvent<ObjectivePickerSelected>(OnObjectivesSelected);
     }
 
     private void OnAntagSelected(Entity<AntagRandomObjectivesComponent> ent, ref AfterAntagEntitySelectedEvent args)
@@ -61,8 +61,11 @@ public sealed partial class AntagRandomObjectivesSystem : EntitySystem
 
     private void OnObjectivesSelected(ObjectivePickerSelected ev, EntitySessionEventArgs args)
     {
-        var mindId = GetEntity(ev.MindId);
+        ApplySelectedObjectives(GetEntity(ev.MindId), ev.SelectedObjectives);
+    }
 
+    public void ApplySelectedObjectives(EntityUid mindId, HashSet<NetEntity> selectedObjectives)
+    {
         if (!TryComp<MindComponent>(mindId, out var mindComp))
             return;
 
@@ -71,7 +74,7 @@ public sealed partial class AntagRandomObjectivesSystem : EntitySystem
 
         // Verify the objectives are actually in their component
         var objectiveIds = potentialObjectivesComp.ObjectiveOptions.Keys.ToHashSet();
-        foreach (var objective in ev.SelectedObjectives)
+        foreach (var objective in selectedObjectives)
         {
             if (objectiveIds.Contains(objective))
             {

--- a/Content.Server/_Moffstation/Objectives/Systems/AntagRandomObjectivesSystem.cs
+++ b/Content.Server/_Moffstation/Objectives/Systems/AntagRandomObjectivesSystem.cs
@@ -64,7 +64,7 @@ public sealed partial class AntagRandomObjectivesSystem : EntitySystem
         ApplySelectedObjectives(GetEntity(ev.MindId), ev.SelectedObjectives);
     }
 
-    public void ApplySelectedObjectives(EntityUid mindId, HashSet<NetEntity> selectedObjectives)
+    public void ApplySelectedObjectives(EntityUid mindId, IEnumerable<NetEntity> selectedObjectives)
     {
         if (!TryComp<MindComponent>(mindId, out var mindComp))
             return;

--- a/Content.Server/_Moffstation/Objectives/Systems/PotentialObjectivesSystem.cs
+++ b/Content.Server/_Moffstation/Objectives/Systems/PotentialObjectivesSystem.cs
@@ -9,6 +9,7 @@ public sealed partial class PotentialObjectivesSystem : EntitySystem
 {
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private AntagRandomObjectivesSystem _antagObjectives = default!;
 
     public override void Update(float frameTime)
     {
@@ -16,19 +17,14 @@ public sealed partial class PotentialObjectivesSystem : EntitySystem
         while (query.MoveNext(out var uid, out var comp))
         {
             if (_timing.CurTime < comp.AutoSelectionTime)
-                return;
+                continue;
 
             var objectives = comp.ObjectiveOptions.OrderBy(_ => _random.Next())
                 .Take(comp.MaxChoices)
                 .Select(it => it.Key)
                 .ToHashSet();
 
-            var ev = new ObjectivePickerSelected
-            {
-                MindId = GetNetEntity(uid),
-                SelectedObjectives = objectives,
-            };
-            RaiseLocalEvent(ev);
+            _antagObjectives.ApplySelectedObjectives(uid, objectives);
         }
     }
 }

--- a/Content.Shared/_Moffstation/Objectives/PotentialObjectivesComponent.cs
+++ b/Content.Shared/_Moffstation/Objectives/PotentialObjectivesComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class PotentialObjectivesComponent : Component
     /// The delay until the objectives get automatically selected
     /// </summary>
     [DataField, AutoNetworkedField]
-    public TimeSpan AutoSelectionDelay = TimeSpan.FromMinutes(0.1f);
+    public TimeSpan AutoSelectionDelay = TimeSpan.FromMinutes(15);
 
     /// <summary>
     /// The in-game time it get selected

--- a/Content.Shared/_Moffstation/Objectives/PotentialObjectivesComponent.cs
+++ b/Content.Shared/_Moffstation/Objectives/PotentialObjectivesComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class PotentialObjectivesComponent : Component
     /// The delay until the objectives get automatically selected
     /// </summary>
     [DataField, AutoNetworkedField]
-    public TimeSpan AutoSelectionDelay = TimeSpan.FromMinutes(15);
+    public TimeSpan AutoSelectionDelay = TimeSpan.FromMinutes(0.1f);
 
     /// <summary>
     /// The in-game time it get selected


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
See title

closes https://github.com/moff-station/moff-station-14/issues/1238
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix
## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Objectives in picker get auto-selected after timer runs out!

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
