### PR TITLE
[Tweak] Remove the fireaxe from the infiltrator, replacing it with a sledgehammer spawner.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -53,7 +53,7 @@
     fireStacks: -4
 
 - type: entity
-  id: FireAxeFlaming
+  id: FireAxeFlamingUpstream # Moff
   name: fire axe
   parent: [ BaseSyndicateContraband, FireAxe ]
   description: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle!

--- a/Resources/Prototypes/_Moffstation/Entities/Markers/Spawners/nuclear_operatives.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Markers/Spawners/nuclear_operatives.yml
@@ -1,0 +1,16 @@
+﻿- type: entity
+  parent: MarkerBase
+  id: SpawnPointNukieDemolitionWeapon
+  name: nuclear operative demolition weapon spawner
+  components:
+  - type: EntityTableSpawner
+    offset: 0.2
+    table: !type:AllSelector
+      children:
+      - id: Sledgehammer
+  - type: Sprite
+    sprite: Markers/jobs.rsi
+    layers:
+    - state: green
+    - sprite: Objects/Weapons/Melee/sledgehammer.rsi
+      state: icon

--- a/Resources/Prototypes/_Moffstation/Entities/Markers/Spawners/nuclear_operatives.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Markers/Spawners/nuclear_operatives.yml
@@ -5,9 +5,8 @@
   components:
   - type: EntityTableSpawner
     offset: 0.2
-    table: !type:AllSelector
-      children:
-      - id: Sledgehammer
+    table:
+      id: Sledgehammer
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -952,3 +952,6 @@ BoxHugNitrogen: BoxSurvivalHugNitrogen
 BoxMime: BoxSurvival
 BoxMimeNitrogen: BoxSurvivalNitrogen
 BoxMimeMoth: BoxSurvival
+
+# Moff - 2026-07-25 - Nukie Fireaxe
+FireAxeFlaming: SpawnPointNukieDemolitionWeapon


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Removes the fireaxe from the nuclear operative infiltrator, giving them a sledgehammer as a temporary replacement.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A prelude in preparation for https://github.com/moff-station/moff-station-14/pull/1667 .
One of the major concerns brought up with restoring the fireaxe's ability to pry hull regarded nuclear operatives, as they are given a fireaxe on their main shuttle. This in turn means that a nuclear operative team could space every room they're in with little cost or counterplay, and overall is not a desirable play pattern. Additionally, the fireaxe isn't relevant to nuclear operative themes, which are more identified by the use of esword weaponry, and thus doesn't really have a reason to remain. With this in mind, there was an ask to provide operatives with some demolition-intended replacement, as a vocal few do still enjoy playing off-meta using these large two-handed weapons. As a result, we migrated the nuclear operative fire axe to a spawner, which was currently set to spawn a sledgehammer until we decide the exact direction we want to take it.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
Migrated the original `FireAxeFlaming` to our new `SpawnPointNukieDemolitionWeapon` spawner, which in turn spawns a `Sledgehammer` from its entity table. This is to let us dynamically change this without requiring any upstream grid modifications, as we can always modify this spawnpoint's table as needed.

Additionally, we renamed `FireAxeFlaming` to `FireAxeFlamingUpstream` so that this version of the fireaxe may still exist within our space for future use, likely as a job purchase option for atmos techs later.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

<img width="685" height="389" alt="image" src="https://github.com/user-attachments/assets/af0ab76a-d643-429d-8380-a6e54d29a930" />

_Migrated the Nukie fireaxe to a spawner. Currently spawns a sledge hammer until we finalize a proper replacement._

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces.
- [X] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- tweak: The Infiltrator shuttle now spawns with a sledgehammer instead of a fireaxe. 

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
