### PR TITLE
Readd command job weights for display

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -17,7 +17,10 @@
     - !type:DepartmentTimeRequirement
       department: Cargo
       time: 10h
-#  weight: 10 # Moff - no job weights
+  # Moff start - no job weights
+#  weight: 10
+  displayWeight: 10
+  # Moff end
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -23,7 +23,10 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 4h
-#  weight: 20 # Moff - no job weights
+  # Moff start - no job weights
+#  weight: 20
+  displayWeight: 20
+  # Moff end
   startingGear: CaptainGear
   icon: "JobIconCaptain"
   joinNotifyCrew: true

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -23,7 +23,10 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 2.5h
-#  weight: 20 # Moff - no job weights
+  # Moff start - no job weights
+#  weight: 20
+  displayWeight: 20
+  # Moff end
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -17,7 +17,10 @@
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 10h
-#  weight: 10 # Moff - no job weights
+  # Moff start - no job weights
+#  weight: 10
+  displayWeight: 10
+  # Moff end
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -19,7 +19,10 @@
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 10h
-#  weight: 10 # Moff - no job weights
+  # Moff start - no job weights
+#  weight: 10
+  displayWeight: 10
+  # Moff end
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -13,7 +13,10 @@
   - !type:RoleTimeRequirement
     role: JobBorg
     time: 5h
-#  weight: 10 # Moff - no job weights
+  # Moff start - no job weights
+#  weight: 10
+  displayWeight: 10
+  # Moff end
   icon: JobIconStationAi
   supervisors: job-supervisors-rd
   jobEntity: StationAiBrain

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -14,7 +14,10 @@
   - !type:DepartmentTimeRequirement
     department: Science
     time: 10h
-#  weight: 10 # Moff - no job weights
+  # Moff start - no job weights
+#  weight: 10
+  displayWeight: 10
+  # Moff end
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -20,7 +20,10 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 10h
-#  weight: 10 # Moff - no job weights
+  # Moff start - no job weights
+#  weight: 10
+  displayWeight: 10
+  # Moff end
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -14,7 +14,10 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 10h
-#  weight: 5 # Moff - no job weights
+  # Moff start - no job weights
+#  weight: 5
+  displayWeight: 5
+  # Moff end
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Fix https://discord.com/channels/1322447119252062260/1531435274142224476/1531435274142224476
Weights are used, implicitly, to order jobs. Removing weights removed the ordering. So we just need to readd weights in the form of `displayWeight`, which is for display only.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix good

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
connect multiple clients to the server
`forcemap amber`
take a command job and a job in the same department
verify command job sorts above the rest of the department on the manifest

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="351" height="154" alt="image" src="https://github.com/user-attachments/assets/78768037-0652-4fa8-8e19-f42cbf43daea" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Jobs on the manifest once again sort with department heads above their reports.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
