### PR TITLE
AFK Playtime fix

### DIFF
--- a/Content.IntegrationTests/Tests/Afk/AfkSystemTest.cs
+++ b/Content.IntegrationTests/Tests/Afk/AfkSystemTest.cs
@@ -154,7 +154,7 @@ public sealed class AfkSystemTest : GameTest
 
             Assert.Multiple(() =>
             {
-                Assert.That(_afkManager.IsAfk(session), Is.True);
+                Assert.That(_afkManager.IsAfk(session), Is.False); // Moff - should be false
                 Assert.That(_afkConfirm.HasConfirmation(session), Is.False);
             });
         });

--- a/Content.Server/Afk/AfkManager.cs
+++ b/Content.Server/Afk/AfkManager.cs
@@ -93,6 +93,11 @@ namespace Content.Server.Afk
 
         public bool IsAfk(ICommonSession player)
         {
+            // Moff start - A timer of 0 disables AFK entirely, don't report anyone as AFK
+            if (_afkTime <= TimeSpan.Zero)
+                return false;
+            // Moff end
+
             if (!_lastActionTimes.TryGetValue(player, out var time))
             {
                 // Some weird edge case like disconnected clients. Just say true I guess.
@@ -103,6 +108,11 @@ namespace Content.Server.Afk
 
             if (_adminManager.IsAdmin(player))
             {
+                // Moff start - Admin AFK timer disabled
+                if (_adminAfkTime <= TimeSpan.Zero)
+                    return false;
+                // Moff end
+
                 timeOut = _adminAfkTime;
             }
             else


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
After we turned off AFK, it marks everyone as AFK automatically, making it so that they dont get more playtime
Admins have been having to manually add playtime, this should fix it.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
buge
## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Players now get playtime for playing again!

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
