### PR TITLE
Fix tier 2 replicator damage states

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/Mobs/tier-2.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/Mobs/tier-2.yml
@@ -25,10 +25,6 @@
     sortedHands:
     - Right
     - Left
-  - type: DamageStateVisuals
-    states:
-      Dead:
-        Base: dead_level2
 
 # Tier 2: Deconstructors. These guys are a little bit tougher, and have tools to take things apart, but they don't have the ability to enter combat mode.
 - type: entity
@@ -53,6 +49,8 @@
     states:
       Alive:
         Base: alive_level2
+      Dead:
+        Base: dead_level2
   - type: Loadout
     prototypes:
     - StartingGearReplicatorTools
@@ -81,6 +79,8 @@
     states:
       Alive:
         Base: alive_level2alt
+      Dead:
+        Base: dead_level2
   - type: Loadout
     prototypes:
     - StartingGearReplicatorT2Alt


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
Fixed the tier 2 damage states for replicators, inheritance was acting fucky.

## Why / Balance
so you can actually know they're dead now!

## Test Plan / Technical Details
omega yamlchuddery. bad practice i'm sure but like. if the inheritance isnt gonna work what can you do, it's also only 2 prototypes anyway, i doubt we'll be expanding that much on tier 2 replicators.

- addgamerule ReplicatorSpawn
- take a replicator and put down a nest
- stuff it with bullshit until you can hit tier 2
- evolve, aghost and blast the thing to smithereens with a fireaxe or something
- smile because you can tell when you've disabled it

## Media
<img width="405" height="279" alt="image" src="https://github.com/user-attachments/assets/367f3db6-a98b-4f9f-be3c-bb8e61e41d01" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Tier 2 replicators (deconstructors and defenders) now have a visually damaged state when they're disabled.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
