### PR TITLE
Add toggleable replicator night vision

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/Mobs/replicator.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/Mobs/replicator.yml
@@ -187,3 +187,18 @@
   - type: MovementIgnoreGravity
   - type: SyncSprite
   - type: ComplexInteraction
+  - type: NightVision
+    action: ActionReplicatorNightVision
+    lightingColor: "#FFEBB0AA"
+
+- type: entity
+  parent: ActionToggleNightVision
+  id: ActionReplicatorNightVision
+  name: Toggle Night Vision
+  description: Turns night vision on/off.
+  components:
+  - type: Action
+    itemIconStyle: BigAction
+    icon:
+      sprite: Interface/Actions/changeling2.rsi # I regret to reuse this, but it is what it is.
+      state: nv_on


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
They need it since they tend to destroy lights around themselves and suffer in darkness otherwise.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
`self spawn:on MobReplicatorT1`
Control
See nightvision
Toggle on/off

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
smol

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- add: Replicators now have toggleable night vision.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
