### PR TITLE
Fix displacement map bug when a marking has multiple layers

### DIFF
--- a/Content.Client/Body/VisualBodySystem.cs
+++ b/Content.Client/Body/VisualBodySystem.cs
@@ -232,7 +232,7 @@ public sealed partial class VisualBodySystem : SharedVisualBodySystem
                         (target, target.Comp),
                         // Similar logic as above, but this makes the displacement layer go below the
                         // original sprite. So it should be all the displacements, then all the sprite layers on top
-                        index + i + 1,
+                        index + i + numDisplacements + 1, // Moff - Markings with multiple layers on species with displacement maps. Without this, the displacement maps are applied to the wrong layer.
                         layerId,
                         out _
                     );


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix: https://discord.com/channels/1322447119252062260/1532240212258848778

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
Tech: the issue was that https://redirect.github.com/space-wizards/space-station-14/pull/44111 seems to have used a sprite displacement map function incorrectly, thinking that an `index` parameter was the index at which the displacement map would be inserted when actually it's the index of the layer to which the displacement map will be applied. This incorrect index meant that displacement maps simply weren't being applied to layers beyond the first on markings with multiple layers.

client+server
`golobby`
make dorf
add cat ears
observe they look okay

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="185" height="331" alt="image" src="https://github.com/user-attachments/assets/d3fd6645-b3a3-426e-8ea4-45708354d770" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Certain markings with multiple sprite layers no longer fail to apply species' displacement maps to layers beyond the first. For example, Dwarves no longer have floating cat-ear insides above their heads.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
