### PR TITLE
[Fix] Exclude MoffC4InstantExplosion from our CI test

### DIFF
--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -260,6 +260,7 @@ namespace Content.IntegrationTests.Tests
             var excludedIds = new[]
             {
                 "MaterialHideSharkminnowTrimmed",
+                "MoffC4InstantExplosion",
             };
             // Moff end
 


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
adds `MoffC4InstantExplosion` to `excludedIds` within `SpawnAndDeleteEntityCountTest()`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's a bit difficult to delete something that explodes instantly, isn't it?

<img width="474" height="125" alt="image" src="https://github.com/user-attachments/assets/6f57dec1-3c5e-4658-bd4f-83d98d76f7ec" />

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
run CI.
run CI.
run CI.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->