### PR TITLE
Ai shell action sprites fixed

### DIFF
--- a/Resources/Prototypes/_CD/Actions/station_ai.yml
+++ b/Resources/Prototypes/_CD/Actions/station_ai.yml
@@ -12,7 +12,8 @@
     event: !type:ToggleAiShellControllerUiEvent
   - type: Sprite
     sprite: _Moffstation/Interface/Actions/actions_ai.rsi
-    state: actions_entershell
+    layers:
+    - state: actions_entershell
 
 - type: entity
   parent: BaseMentalAction
@@ -27,4 +28,5 @@
     event: !type:StopAiShellControlEvent
   - type: Sprite
     sprite: Interface/Actions/actions_ai.rsi
-    state: ai_core
+    layers:
+    - state: ai_core


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
fixes the sprites for the enter and exit shell action

## Why / Balance
Upstream merge broke them, this fixes them

## Test Plan / Technical Details
check actions, see sprites

## Media
im lazy

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Fixed the ai shell action sprites

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
