### PR TITLE
Change necronomicon to be chaplain only

### DIFF
--- a/Resources/Prototypes/_Moffstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Moffstation/Catalog/uplink_catalog.yml
@@ -104,9 +104,6 @@
   - !type:BuyerJobCondition
     whitelist:
     - Chaplain
-    - Librarian
-    - Lawyer
-    - Psychologist
 
 # Other
 - type: listing


### PR DESCRIPTION
## About the PR
These jobs shouldn't have the necronomicon

## Why / Balance
The necronomicon can only be used by chaplains, and the changes made in #1056 made without properly testing them or knowing how bibles work mechanically. The only job bibles work for is chaplain, and if you don't have the chaplain component they burn you.
<img width="378" height="307" alt="image" src="https://github.com/user-attachments/assets/d21f3a52-004b-4c2f-a7b0-25240eb01424" />

## Test Plan / Technical Details
Spawn in release as non chaplain, no necronomicon in uplink.
Technicals of BibleSystem:
So BibleSystem checks if you are a chaplain, which is a component applied on spawn, and if you do not have this component, it burns the fuck out of you and makes features of the bible like healing or familiars not work for you. This would mean, you have spent your TC on something completely useless to you mechanically and actively wants to kill you for not being a chaplain as well

## Media
<img width="516" height="511" alt="image" src="https://github.com/user-attachments/assets/bfa3b056-8a13-4bca-b6ec-66d7341b68bd" />

## Requirements
- [X] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces.
- [X] I have thoroughly tested my changes in-game to ensure they function properly.

## Changelog
:cl:
- remove: Removed necronomicon from nonchaplain jobs uplinks

