### PR TITLE
[Fix] Secret doors are now more secret

### DIFF
--- a/Content.Client/_ST/Interaction/StellarInteractionParticleSystem.cs
+++ b/Content.Client/_ST/Interaction/StellarInteractionParticleSystem.cs
@@ -2,8 +2,10 @@
 //
 // SPDX-License-Identifier: MIT
 
+using System.Linq;
 using System.Numerics;
 using Content.Client._Moffstation.Interaction;
+using Content.Shared._Moffstation.Interaction;
 using Content.Shared._ST.Interaction;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
@@ -38,11 +40,15 @@ public sealed partial class StellarInteractionParticleSystem : EntitySystem
         var used = GetEntity(ev.Used);
         var target = GetEntity(ev.Target);
 
-
         if (!Exists(performer) || !Exists(target))
             return;
 
-        // Moffstation - start - Add in cooldown
+        // Moff Start - Add in cooldown, secret doors remain secret
+        if (TryComp<HideInteractionParticleComponent>(target, out var hide))
+        {
+            return;
+        }
+
         if (TryComp<InteractionParticleTrackerComponent>(performer, out var tracker))
         {
             if (_timing.CurTime < tracker.ExpireTime)

--- a/Content.Shared/_Moffstation/Interaction/HideInteractionParticle.cs
+++ b/Content.Shared/_Moffstation/Interaction/HideInteractionParticle.cs
@@ -1,0 +1,7 @@
+﻿namespace Content.Shared._Moffstation.Interaction;
+
+/// <summary>
+/// Component added to entity prototypes to hide client-side interaction animations.
+/// </summary>
+[RegisterComponent]
+public sealed partial class HideInteractionParticleComponent : Component;

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -75,6 +75,7 @@
     containers:
       battery-container: !type:Container
   - type: BlockWeather
+  - type: HideInteractionParticle # Moff
 
 - type: entity
   id: BaseSecretDoorAssembly


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Secret doors now will no longer display interaction particles.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In PR https://github.com/moff-station/moff-station-14/pull/1489 , new effects were added to interactions, highlighting when players touched windows, doors, among many other mundane tasks. However, there was no exclusion clause set for secret doors - resulting in a defect letting players know what walls were doors by 'interacting' with them, and seeing if the animation played. This pull request fixes this issue, by creating a generic component that can be applied to entities, and adding a check to the client for this component on the target.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
a little bit of C#.
Spawn in an environment - add a secret door. Test the interaction with a normal door, and then compare it to the secret door.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

https://github.com/user-attachments/assets/6313c1a6-9eec-4e6d-9c80-d74c62a19767


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces.
- [X] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Secret doors no longer reveal their secret by way of interaction particle effects.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
