### PR TITLE
Remove nanochat from mime PDAs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -468,7 +468,6 @@
         children:
         - id: CrewManifestCartridge
         - id: NewsReaderCartridge
-        - id: NanoChatCartridge # CD
         - id: SOSCartridge # Imp
   - type: PermanentStatusEffects # for random sentience event
     statusEffects:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
They were added in error as a merge issue

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
spawn pdas
check pdas

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Mime and Mime alternative PDAs no longer incorrectly have Nanochat installed.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
