### PR TITLE
Thavens get all their moods again

### DIFF
--- a/Content.Server/_MACRO/StrangeMoods/StrangeMoodsSystem.cs
+++ b/Content.Server/_MACRO/StrangeMoods/StrangeMoodsSystem.cs
@@ -46,11 +46,9 @@ public sealed partial class StrangeMoodsSystem : SharedStrangeMoodsSystem
 
     private void OnStrangeMoodsInit(Entity<StrangeMoodsComponent> ent, ref MapInitEvent args)
     {
-        var mood = ent.Comp.StrangeMood;
-
         if (_proto.TryIndex(ent.Comp.StrangeMoodPrototype, out var moodProto))
         {
-            mood = DeepCopy(moodProto);
+            ent.Comp.StrangeMood = DeepCopy(moodProto);
 
             // Add any required components
             if (moodProto.Components is { } components)
@@ -60,14 +58,16 @@ public sealed partial class StrangeMoodsSystem : SharedStrangeMoodsSystem
         }
 
         RefreshMoods(ent);
-        SetSharedMood(ent, mood.SharedMoodPrototype);
+        SetSharedMood(ent, ent.Comp.StrangeMood.SharedMoodPrototype);
 
         // Add action to bar
-        ent.Comp.Action ??= _actions.AddAction(ent.Owner, mood.ActionViewMoods);
+        ent.Comp.Action ??= _actions.AddAction(ent.Owner, ent.Comp.StrangeMood.ActionViewMoods);
         if (TryComp<UserInterfaceComponent>(ent, out var ui))
+        {
             _bui.SetUi((ent, ui),
                 StrangeMoodsUiKey.Key,
                 new InterfaceData("StrangeMoodsBoundUserInterface", requireInputValidation: false));
+        }
     }
 
     private void OnStrangeMoodsShutdown(Entity<StrangeMoodsComponent> ent, ref ComponentShutdown args)


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
TItle

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
Spawn McEars
Check moods

Issue was due to changes in a merge. I got got by a `ref` keyword which previously meant changes were applied to a component's state whereas after the bad merge, I'd put the unique moods into a local var that just went out of scope.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
smol

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Thavens once again get all of their moods.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
