### PR TITLE
Borgs are informed of changes to their laws again

### DIFF
--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -84,7 +84,7 @@ public sealed partial class SiliconLawSystem : SharedSiliconLawSystem
 
         var msg = Loc.GetString("laws-update-notify");
         var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", msg));
-        UpdateLawVersion(ent.Owner);
+        // UpdateLawVersion(ent.Owner); // Moff - Updated when laws are pushed from the provider to the lawbound
         _chatManager.ChatMessageToOne(ChatChannel.Server, msg, wrappedMessage, default, false, actor.PlayerSession.Channel, colorOverride: Color.Red);
 
         if (cue != null && _mind.TryGetMind(ent, out var mindId, out _))
@@ -152,17 +152,19 @@ public sealed partial class SiliconLawSystem : SharedSiliconLawSystem
         }
     }
 
-    /// <summary>
-    /// Updates the version on a target SiliconLawBoundComponent. This is used in the law UI as flair to show the
-    /// number of updates a silicon player's laws has had
-    /// </summary>
-    private void UpdateLawVersion(Entity<SiliconLawBoundComponent?> target)
-    {
-        if (!Resolve(target, ref target.Comp))
-            return;
-
-        target.Comp.Version++;
-    }
+    // Moff start - Laws are tracked on bound SiliconLawProvider
+    // /// <summary>
+    // /// Updates the version on a target SiliconLawBoundComponent. This is used in the law UI as flair to show the
+    // /// number of updates a silicon player's laws has had
+    // /// </summary>
+    // private void UpdateLawVersion(Entity<SiliconLawBoundComponent?> target)
+    // {
+    //     if (!Resolve(target, ref target.Comp))
+    //         return;
+    //
+    //     target.Comp.Version++;
+    // }
+    // Moff end
 
     /// <summary>
     /// Given a list of laws, sets all unobfuscated laws' identifier in order from highest to lowest priority.

--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -73,7 +73,7 @@ public sealed partial class SiliconLawSystem : SharedSiliconLawSystem
         UpdateSiliconRoles(owner, args.Mind);
     }
 
-    public override void NotifyLawsChanged(Entity<SiliconLawProviderComponent> ent, SoundSpecifier? cue = null)
+    public override void NotifyLawsChanged(Entity<SiliconLawBoundComponent> ent, SoundSpecifier? cue = null) // Moff - Borg laws on brain, not chassis
     {
         base.NotifyLawsChanged(ent, cue);
 
@@ -115,15 +115,19 @@ public sealed partial class SiliconLawSystem : SharedSiliconLawSystem
     /// </summary>
     public void SetLaws(List<SiliconLaw> newLaws, EntityUid target, SoundSpecifier? cue = null)
     {
-        if (!TryComp<SiliconLawProviderComponent>(target, out var component))
-            return;
+        // Moff start - Borg laws on brain, not chassis
+        SetProviderLaws(target, newLaws, false, cue);
 
-        if (component.Lawset == null)
-            component.Lawset = new SiliconLawset();
-
-        component.Lawset.Laws = newLaws;
-        RankLaws(component.Lawset.Laws);
-        NotifyLawsChanged((target,component), cue);
+        // if (!TryComp<SiliconLawProviderComponent>(target, out var component))
+        //     return;
+        //
+        // if (component.Lawset == null)
+        //     component.Lawset = new SiliconLawset();
+        //
+        // component.Lawset.Laws = newLaws;
+        // RankLaws(component.Lawset.Laws);
+        // NotifyLawsChanged((target,component), cue);
+        // Moff end
     }
 
     protected override void OnUpdaterInsert(Entity<SiliconLawUpdaterComponent> ent, ref EntInsertedIntoContainerMessage args)

--- a/Content.Shared/Silicons/Laws/Components/SiliconLawBoundComponent.cs
+++ b/Content.Shared/Silicons/Laws/Components/SiliconLawBoundComponent.cs
@@ -41,7 +41,7 @@ public sealed partial class SiliconLawBoundComponent : Component
     /// <summary>
     /// Version to display on the law panel. Increments whenever the laws are changed
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField] // Moff - Reimplement versioning on law providers. This is networked from the remote law provider.
     public int Version = 1;
 
     // Prevent cheat clients from seeing the laws of other players.

--- a/Content.Shared/Silicons/Laws/Components/SiliconLawProviderComponent.cs
+++ b/Content.Shared/Silicons/Laws/Components/SiliconLawProviderComponent.cs
@@ -25,6 +25,10 @@ public sealed partial class SiliconLawProviderComponent : Component
     [DataField, AutoNetworkedField]
     public SiliconLawset Lawset = new ();
 
+    // Moff start - implement lawset version on law provider
+    [DataField, AutoNetworkedField] public int Version = 1;
+    // Moff end
+
     /// <summary>
     /// The sound that plays for the Silicon player
     /// when the law change is processed for the provider.

--- a/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.API.cs
+++ b/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.API.cs
@@ -188,6 +188,11 @@ public abstract partial class SharedSiliconLawSystem
         cue ??= ent.Comp.LawUploadSound;
 
         ent.Comp.Lawset.Laws = newLaws;
+        // Moff start - implement lawset versioning on law providers
+        ent.Comp.Version += 1;
+        Dirty(ent);
+        // Moff end
+
         _adminLogger.Add(LogType.Action, LogImpact.Medium, $"The provider laws {ent} have been set to {ent.Comp.Lawset.LoggingString() ?? "Empty"}.");
         SyncToLawBound(ent, silent ? null : cue);
     }
@@ -212,6 +217,7 @@ public abstract partial class SharedSiliconLawSystem
         }
 
         ent.Comp.Lawset = provider.Lawset.Clone();
+        ent.Comp.Version = provider.Version; // Moff - implement lawset versioning on law providers
 
         if (TryComp<ShowCrewIconsComponent>(ent, out var crewIcons))
         {

--- a/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.API.cs
+++ b/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.API.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Moffstation.Extensions;
 using Content.Shared.Database;
 using Content.Shared.Overlays;
 using Content.Shared.Roles.Components;
@@ -313,15 +314,17 @@ public abstract partial class SharedSiliconLawSystem
 
         foreach (var lawboundEnt in iteratedEntities)
         {
-            if (!TryComp<SiliconLawBoundComponent>(lawboundEnt, out var lawboundComp))
+            // Moff start - Lawbound query
+            if (_siliconLawBoundQuery.ResolveOrNull(lawboundEnt, logMissing: false) is not {} lawbound)
             {
-                UnlinkFromProvider((lawboundEnt, lawboundComp));
+                UnlinkFromProvider(lawboundEnt);
                 continue;
             }
 
-            lawboundComp.LawsetProvider = ent.Owner;
-            UpdateLaws((lawboundEnt, lawboundComp));
-            NotifyLawsChanged((ent, ent.Comp), cue);
+            lawbound.Comp.LawsetProvider = ent.Owner;
+            UpdateLaws(lawbound.Owner);
+            NotifyLawsChanged(lawbound, cue);
+            // Moff end
         }
 
         Dirty(ent);
@@ -332,7 +335,7 @@ public abstract partial class SharedSiliconLawSystem
     /// </summary>
     /// <param name="uid">The entity to notify.</param>
     /// <param name="cue">The sound to play. Will play no sound if null.</param>
-    public virtual void NotifyLawsChanged(Entity<SiliconLawProviderComponent> ent, SoundSpecifier? cue = null)
+    public virtual void NotifyLawsChanged(Entity<SiliconLawBoundComponent> ent, SoundSpecifier? cue = null) // Moff - Borg laws on brain, not chassis
     {
 
     }

--- a/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
+++ b/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
@@ -30,6 +30,8 @@ public abstract partial class SharedSiliconLawSystem : EntitySystem
     [Dependency] private SharedUserInterfaceSystem _userInterface = default!;
     [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
+
+    [Dependency] private readonly EntityQuery<SiliconLawBoundComponent> _siliconLawBoundQuery;
     // Moffstation - End
 
     /// <summary>

--- a/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
+++ b/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
@@ -31,7 +31,7 @@ public abstract partial class SharedSiliconLawSystem : EntitySystem
     [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
 
-    [Dependency] private readonly EntityQuery<SiliconLawBoundComponent> _siliconLawBoundQuery;
+    [Dependency] private EntityQuery<SiliconLawBoundComponent> _siliconLawBoundQuery;
     // Moffstation - End
 
     /// <summary>


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Fix bug where borgs wouldn't get notifications when their laws were changed, meaning ion storms etc. were silent.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
I mangled it in a recent merge since we have unguarded "early test merge" of laws on brains rather than on chassis.
Basically, there was one place where it would do a fan-out of "notify all lawbounds attached to a modified brain", but I accidentally made it "fan-out" into the brain each time.

Test:
devmap
`> cvar role_timers false` (actual Cvar name different, I forget)
spawn chassis, microreactor, posi brain
activate brain
unlock chassis, open chassis, insert microreactor, and brain
take brain
`addgamerule IonStorm` (actual even name different, I forget)
Repeat above until you hear the `beep beep beep beep beep` and get the chat log message saying your laws were changed

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="376" height="318" alt="image" src="https://github.com/user-attachments/assets/037266d0-dd05-4b0a-a2c7-1a500718ceeb" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Lawbound silicons once again get an audio and chat cue when their laws are changed.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
