### PR TITLE
[Tweak] Artifact console adjustments (LOOK I FINALLY IMPLEMENTED LOCALIZATION INTO OUR EFFECTS!)

### DIFF
--- a/Content.Client/Xenoarchaeology/Ui/AnalysisConsoleMenu.xaml.cs
+++ b/Content.Client/Xenoarchaeology/Ui/AnalysisConsoleMenu.xaml.cs
@@ -200,7 +200,7 @@ public sealed partial class AnalysisConsoleMenu : FancyWindow
         var hasInfo = _xenoArtifact.HasUnlockedPredecessor(artifact.Value, node.Value);
 
         // Moff Start - dynamic description
-        if (lockedState >= 1 || !_ent.HasComponent<XAELocalizedDescriptionComponent>(node.Value)) // If our node has been activated or lacks our custom localization string, reveal the default description
+        if (lockedState >= 1 || !_ent.TryGetComponent<XAELocalizedDescriptionComponent>(node.Value, out var localizedDesc)) // If our node has been activated or lacks our custom localization string, reveal the default description
         {
             // Show node durability value
             DurabilityValueLabel.SetMarkup(Loc.GetString("analysis-console-info-durability-value",
@@ -221,7 +221,7 @@ public sealed partial class AnalysisConsoleMenu : FancyWindow
             // Show vague effect hint
             EffectValueLabel.SetMarkup(Loc.GetString("analysis-console-info-effect-value",
                 ("state", hasInfo),
-                ("info", Loc.GetString(_ent.GetComponentOrNull<XAELocalizedDescriptionComponent>(node.Value)?.Description ?? string.Empty))));
+                ("info", Loc.GetString(localizedDesc.Description))));
         }
         // Moff End
 

--- a/Content.Client/Xenoarchaeology/Ui/AnalysisConsoleMenu.xaml.cs
+++ b/Content.Client/Xenoarchaeology/Ui/AnalysisConsoleMenu.xaml.cs
@@ -4,6 +4,7 @@ using Content.Client.Resources;
 using Content.Client.UserInterface.Controls;
 using Content.Client.Xenoarchaeology.Artifact;
 using Content.Client.Xenoarchaeology.Equipment;
+using Content.Shared._Moffstation.Xenoarchaeology.Artifact.XAE.Components;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 using Content.Shared.Xenoarchaeology.Equipment.Components;
 using Robust.Client.Audio;
@@ -202,9 +203,20 @@ public sealed partial class AnalysisConsoleMenu : FancyWindow
 
         var hasInfo = _xenoArtifact.HasUnlockedPredecessor(artifact.Value, node.Value);
 
-        EffectValueLabel.SetMarkup(Loc.GetString("analysis-console-info-effect-value",
-            ("state", hasInfo),
-            ("info", _ent.GetComponentOrNull<MetaDataComponent>(node.Value)?.EntityDescription ?? string.Empty)));
+        // Moff Start - dynamic description
+        if (lockedState >= 1)
+        {
+            EffectValueLabel.SetMarkup(Loc.GetString("analysis-console-info-effect-value",
+                ("state", hasInfo),
+                ("info", _ent.GetComponentOrNull<MetaDataComponent>(node.Value)?.EntityDescription ?? string.Empty)));
+        }
+        else
+        {
+            EffectValueLabel.SetMarkup(Loc.GetString("analysis-console-info-effect-value",
+                ("state", hasInfo),
+                ("info", Loc.GetString(_ent.GetComponentOrNull<XAELocalizedDescriptionComponent>(node.Value)?.Description ?? string.Empty))));
+        }
+        // Moff End
 
         var predecessorNodes = _xenoArtifact.GetPredecessorNodes(artifact.Value.Owner, node.Value);
         if (!hasInfo)

--- a/Content.Client/Xenoarchaeology/Ui/AnalysisConsoleMenu.xaml.cs
+++ b/Content.Client/Xenoarchaeology/Ui/AnalysisConsoleMenu.xaml.cs
@@ -196,22 +196,29 @@ public sealed partial class AnalysisConsoleMenu : FancyWindow
             >= 0.50f => Color.Yellow,
             _ => Color.Red
         };
-        DurabilityValueLabel.SetMarkup(Loc.GetString("analysis-console-info-durability-value",
-            ("color", color),
-            ("current", node.Value.Comp.Durability),
-            ("max", node.Value.Comp.MaxDurability)));
 
         var hasInfo = _xenoArtifact.HasUnlockedPredecessor(artifact.Value, node.Value);
 
         // Moff Start - dynamic description
-        if (lockedState >= 1)
+        if (lockedState >= 1 || !_ent.HasComponent<XAELocalizedDescriptionComponent>(node.Value)) // If our node has been activated or lacks our custom localization string, reveal the default description
         {
+            // Show node durability value
+            DurabilityValueLabel.SetMarkup(Loc.GetString("analysis-console-info-durability-value",
+                ("color", color),
+                ("current", node.Value.Comp.Durability),
+                ("max", node.Value.Comp.MaxDurability)));
+
+            // Show detailed description
             EffectValueLabel.SetMarkup(Loc.GetString("analysis-console-info-effect-value",
                 ("state", hasInfo),
                 ("info", _ent.GetComponentOrNull<MetaDataComponent>(node.Value)?.EntityDescription ?? string.Empty)));
         }
-        else
+        else // If our node has not been activated and possesses a localization string, use this secret hint instead
         {
+            // hide node durability value - No metagaming!
+            DurabilityValueLabel.SetMarkup(Loc.GetString("moff-analysis-console-info-durability-unknown"));
+
+            // Show vague effect hint
             EffectValueLabel.SetMarkup(Loc.GetString("analysis-console-info-effect-value",
                 ("state", hasInfo),
                 ("info", Loc.GetString(_ent.GetComponentOrNull<XAELocalizedDescriptionComponent>(node.Value)?.Description ?? string.Empty))));

--- a/Content.Shared/_Moffstation/Xenoarchaeology/Artifact/XAE/Components/XAELocalizedDescription.cs
+++ b/Content.Shared/_Moffstation/Xenoarchaeology/Artifact/XAE/Components/XAELocalizedDescription.cs
@@ -7,5 +7,5 @@
 public sealed partial class XAELocalizedDescriptionComponent : Component
 {
     [DataField(required: true)]
-    public string Description;
+    public LocId Description;
 }

--- a/Content.Shared/_Moffstation/Xenoarchaeology/Artifact/XAE/Components/XAELocalizedDescription.cs
+++ b/Content.Shared/_Moffstation/Xenoarchaeology/Artifact/XAE/Components/XAELocalizedDescription.cs
@@ -1,0 +1,11 @@
+﻿namespace Content.Shared._Moffstation.Xenoarchaeology.Artifact.XAE.Components;
+
+/// <summary>
+/// Replaces the default description with a localized string.
+/// </summary>
+[RegisterComponent]
+public sealed partial class XAELocalizedDescriptionComponent : Component
+{
+    [DataField(required: true)]
+    public string Description;
+}

--- a/Resources/Locale/en-US/_Moffstation/xenoarcheology/artifact-analyzer.ftl
+++ b/Resources/Locale/en-US/_Moffstation/xenoarcheology/artifact-analyzer.ftl
@@ -1,0 +1,1 @@
+﻿moff-analysis-console-info-durability-unknown = [font="Monospace" size=11][color=Red]Unknown[/color][/font]

--- a/Resources/Locale/en-US/_Moffstation/xenoarcheology/artifact-hints.ftl
+++ b/Resources/Locale/en-US/_Moffstation/xenoarcheology/artifact-hints.ftl
@@ -1,6 +1,7 @@
 ﻿## See upstream guidelines for xenoarcheology hints and triggers; reuse what you can, and effects should be more vague than triggers.
 
 ## Effects
+moff-artifact-effect-hint-debug = Test Good!
 
 ## Triggers
 xenoarch-trigger-tip-cleaner = Cleaning solution

--- a/Resources/Locale/en-US/_Moffstation/xenoarcheology/artifact-hints.ftl
+++ b/Resources/Locale/en-US/_Moffstation/xenoarcheology/artifact-hints.ftl
@@ -1,10 +1,8 @@
 ﻿## See upstream guidelines for xenoarcheology hints and triggers; reuse what you can, and effects should be more vague than triggers.
 
 ## Effects
-moff-artifact-effect-hint-debug = Test Good!
+moff-artifact-effect-hint-energy = Energy manipulation
+moff-artifact-effect-hint-entity-translocation = Entity translocation
+moff-artifact-effect-hint-handheld-utility = Handheld utility augmentation
 
 ## Triggers
-xenoarch-trigger-tip-cleaner = Cleaning solution
-xenoarch-trigger-tip-antidepressants = Antidepressants
-xenoarch-trigger-tip-lube = Lubrication
-xenoarch-trigger-tip-narcotics = Illegal stimulants

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -1,5 +1,5 @@
 - type: entityTable
-  id: XenoArtifactEffectsDefaultTable
+  id: XenoArtifactEffectsDefaultTableDebug
   table: !type:GroupSelector
     children:
     # hijacks use key, prevents from using artifact, sadly
@@ -151,6 +151,13 @@
     - id: XenoArtifactDrill
       weight: 1
 
+- type: entityTable
+  id: XenoArtifactEffectsDefaultTable
+  table: !type:GroupSelector
+    children:
+    - id: XenoArtifactPhasing
+      weight: 10
+
 - type: entity
   id: BaseXenoArtifactEffect
   name: effect
@@ -259,6 +266,8 @@
   description: Metaphysical displacement # Moffstation - Obfuscate xenoarcheology
   components:
   - type: XAERemoveCollision
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-debug
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -1,5 +1,5 @@
 - type: entityTable
-  id: XenoArtifactEffectsDefaultTableDebug
+  id: XenoArtifactEffectsDefaultTable
   table: !type:GroupSelector
     children:
     # hijacks use key, prevents from using artifact, sadly
@@ -15,8 +15,10 @@
       weight: 2
     - id: XenoArtifactWandering
       weight: 4
-    - id: XenoArtifactSpeedUp
-      weight: 4
+    # Moff Start - Moving to handheld-only table
+    # - id: XenoArtifactSpeedUp
+    #   weight: 4
+    # Moff End
     - id: XenoArtifactGhost
       weight: 2
     - id: XenoArtifactEffectBadFeeling
@@ -69,10 +71,8 @@
       weight: 4
     - id: XenoArtifactFaunaSpawn
       weight: 10
-    # Moffstation - Start - Revert artifact mob change
-#    - id: XenoArtifactHostileFaunaSpawn
-#      weight: 10
-    # Moffstation - End
+    - id: XenoArtifactHostileFaunaSpawn
+      weight: 10
     - id: XenoArtifactCashSpawn
       weight: 10
     - id: XenoArtifactShatterWindows
@@ -133,10 +133,10 @@
       weight: 4
     - id: XenoArtifactEffectCreationGasCarbonDioxide
       weight: 4
-    # Moffstation - Start - New Effects!
+    # Moff Start - New Effects!
     - id: XenoArtifactFlashbang
       weight: 4
-    # Moffstation - End
+    # Moff End
 
 - type: entityTable
   id: XenoArtifactEffectsHandheldOnlyTable
@@ -150,13 +150,10 @@
       weight: 1
     - id: XenoArtifactDrill
       weight: 1
-
-- type: entityTable
-  id: XenoArtifactEffectsDefaultTable
-  table: !type:GroupSelector
-    children:
-    - id: XenoArtifactPhasing
-      weight: 10
+    # Moff Start - Moving to handheld-only table
+    - id: XenoArtifactSpeedUp
+      weight: 4
+    # Moff End
 
 - type: entity
   id: BaseXenoArtifactEffect
@@ -192,6 +189,10 @@
     components:
     - type: PointLight
     - type: RandomPointLight
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-visual
+  # Moff End
 
 - type: entity
   id: XenoArtifactBecomeRainbowLamp
@@ -203,6 +204,10 @@
     - type: PointLight
       radius: 3
     - type: RgbLightController
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-visual
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
@@ -263,16 +268,18 @@
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactPhasing
-  description: Metaphysical displacement # Moffstation - Obfuscate xenoarcheology
+  description: Becomes phased
   components:
   - type: XAERemoveCollision
+  # Moff Start - Dynamic description
   - type: XAELocalizedDescription
-    description: moff-artifact-effect-hint-debug
+    description: artifact-effect-hint-displacement
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactWandering
-  description: Metaphysical displacement # Moffstation - Obfuscate xenoarcheology
+  description: Starts to move sporadically
   components:
   - type: XAEApplyComponents
     components:
@@ -281,11 +288,15 @@
       maxSpeed: 20
       minStepCooldown: 1
       maxStepCooldown: 3
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-displacement
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactSolutionStorage
-  description: Internal chamber # Moffstation - Obfuscate xenoarcheology
+  description: Obtains ability of container for chemical solutions
   components:
   - type: XAEApplyComponents
     components:
@@ -312,22 +323,30 @@
       solution: beaker
       destroyOnEmpty: false
       utensil: None
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-storage
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactSpeedUp
-  description: Handheld utility augmentation # Moffstation - Obfuscate xenoarcheology
+  description: Improves holder movement speed
   components:
   - type: XAEApplyComponents
     components:
     - type: HeldSpeedModifier
       walkModifier: 1.2
       sprintModifier: 1.3
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-handheld-utility
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactDrill
-  description: Handheld utility augmentation # Moffstation - Obfuscate xenoarcheology
+  description: Obtains ability of drill
   components:
   - type: XAEApplyComponents
     components:
@@ -341,6 +360,10 @@
     - type: Tool
       qualities:
       - Slicing
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-handheld-utility
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect # todo - increment power, but only once per node
@@ -392,7 +415,7 @@
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactGhost
-  description: Cerebral influence # Moffstation - Obfuscate xenoarcheology
+  description: Becomes sentient
   components:
   - type: XAEApplyComponents
     components:
@@ -408,11 +431,15 @@
       mindRoles:
       - MindRoleGhostRoleFreeAgent
     - type: GhostTakeoverAvailable
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-mental
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactOmnitool
-  description: Handheld utility augmentation # Moffstation - Obfuscate xenoarcheology
+  description: Obtains ability of omnitool
   components:
   - type: XAEApplyComponents
     components:
@@ -455,11 +482,15 @@
       - behavior: Pulsing
         changeSound:
           path: /Audio/Items/change_drill.ogg
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-handheld-utility
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactEffectBadFeeling
-  description: Cerebral influence # Moffstation - Obfuscate xenoarcheology
+  description: Broadcasts sublime message
   components:
   - type: XAETelepathic
     messages:
@@ -485,11 +516,15 @@
     - badfeeling-artifact-drastic-4
     - badfeeling-artifact-drastic-5
     - badfeeling-artifact-drastic-6
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-mental
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactEffectGoodFeeling
-  description: Cerebral influence # Moffstation - Obfuscate xenoarcheology
+  description: Broadcasts sublime message
   components:
   - type: XAETelepathic
     messages:
@@ -514,11 +549,15 @@
     - goodfeeling-artifact-drastic-4
     - goodfeeling-artifact-drastic-5
     - goodfeeling-artifact-drastic-6
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-mental
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactEffectJunkSpawn
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Create recyclable junk
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -535,18 +574,26 @@
         - !type:NestedSelector
           tableId: AllPlushiesTable
           weight: 1
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactEffectLightFlicker
-  description: Electrical interference # Moffstation - Obfuscate xenoarcheology
+  description: Minor electromagnetic interference
   components:
   - type: XAELightFlicker
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-electrical-interference
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactPotassiumWave
-  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
+  description: Produces potassium
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -567,11 +614,15 @@
       canReact: false
     possibleChemicals:
     - Potassium
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-biochemical
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactFloraSpawn
-  description: Entity translocation # Moffstation - Obfuscate xenoarcheology
+  description: Produces flora
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -581,17 +632,21 @@
       deleteSpawnerAfterSpawn: false
       table: !type:NestedSelector
         tableId: FloraTreeTable
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-entity-translocation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactChemicalPuddle
-  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
+  description: Produces puddle of chemical mixture # todo: make description say what exact chemical is produced, maybe add mixes into possible chemicals
   components:
   - type: XAECreatePuddle
     chemAmount:
       min: 1
       max: 3
-    replaceDescription: false # Moffstation - Obfuscate xenoarcheology
+    replaceDescription: true
     chemicalSolution:
       maxVol: 500
       canReact: false
@@ -617,14 +672,18 @@
     - Sodium
     - Water
     - Sulfur
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-biochemical
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactThrowThingsAround
-  description: Environmental disruption # Moffstation - Obfuscate xenoarcheology
+  description: Minor implosion
   components:
   - type: XAEThrowThingsAround
-  # Moffstation - Start - Shader Effect
+  # Moff Start - Dynamic description + shader
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
     refreshOnReactivate: true
@@ -633,31 +692,42 @@
       deleteSpawnerAfterSpawn: false
       prototypes:
       - EffectShockwaveSonicBoom
-  # Moffstation - End
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-environment
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactColdWave
-  description: Endothermic action # Moffstation - Obfuscate xenoarcheology
+  description: Cools down surrounding gas
   components:
   - type: XAETemperature
     targetTemp: 50
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-energy
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactHeatWave
-  description: Exothermic action # Moffstation - Obfuscate xenoarcheology
+  description: Heats up surrounding gas greatly
   components:
   - type: XAETemperature
     targetTemp: 500
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-energy
+  # Moff End
+
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactFoamMild
-  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
+  description: Produces chemical foam # todo: separate in 1 for each chemical for description? actually sounds like a very good idea
   components:
   - type: XAEFoam
-    replaceDescription: false # Moffstation - Obfuscate xenoarcheology
+    replaceDescription: true
     reagents:
     - Oxygen
     - Plasma
@@ -670,11 +740,15 @@
     - VentCrud
     - WeldingFuel
     - JuiceThatMakesYouWeh
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-biochemical
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactRandomInstrumentSpawn
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Creates musical instrument
   components:
   - type: XenoArtifactNode
     maxDurability: 2
@@ -689,11 +763,15 @@
       deleteSpawnerAfterSpawn: false
       table: !type:NestedSelector
         tableId: RandomInstrumentTable
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactMonkeySpawn
-  description: Entity translocation # Moffstation - Obfuscate xenoarcheology
+  description: Summons primate # Moff - Slight retheming
   components:
   - type: XenoArtifactNode
     maxDurability: 3
@@ -712,11 +790,15 @@
           weight: 95
         - id: MobGorilla
           weight: 5
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-entity-translocation
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactRadioactive
-  description: Exothermic action # Moffstation - Obfuscate xenoarcheology
+  description: Becomes mildly radioactive
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -725,29 +807,41 @@
     - type: RadiationSource
       intensity: 1
       slope: 0.3
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-energy
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactChargeBattery
-  description: Exothermic action # Moffstation - Obfuscate xenoarcheology
+  description: Charges up batteries
   components:
   - type: XAEChargeBattery
   - type: XAETelepathic
     messages:
     - charge-artifact-popup
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-electrical-interference
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactKnock
-  description: Electrical interference # Moffstation - Obfuscate xenoarcheology
+  description: Mild electromagnetic interference
   components:
   - type: XAEKnock
   - type: XAELightFlicker
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-electrical-interference
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactMagnet
-  description: Magnetic waves # Moffstation - Obfuscate xenoarcheology
+  description: Create small gravity well
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -757,11 +851,15 @@
       maxRange: 3
       baseRadialAcceleration: 1
       baseTangentialAcceleration: 3
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-magnet
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactMagnetNegative
-  description: Magnetic waves # Moffstation - Obfuscate xenoarcheology
+  description: Create small gravity well
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -771,11 +869,15 @@
       maxRange: 3
       baseRadialAcceleration: -1
       baseTangentialAcceleration: -3
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-magnet
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactStealth
-  description: Visual distortions # Moffstation - Obfuscate xenoarcheology
+  description: Create light interference
   components:
   - type: XAEApplyComponents
     components:
@@ -784,11 +886,15 @@
     - type: StealthOnMove
       passiveVisibilityRate: -0.10
       movementVisibilityRate: 0.10
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-visual
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactRareMaterialSpawnSilver
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Create rare materials
   components:
   - type: XenoArtifactNode
     maxDurability: 4
@@ -807,11 +913,15 @@
         rolls: !type:ConstantNumberSelector
           value: 6
         prob: 0.7
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactRareMaterialSpawnPlasma
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Create plasma
   components:
   - type: XenoArtifactNode
     maxDurability: 4
@@ -830,11 +940,15 @@
         rolls: !type:ConstantNumberSelector
           value: 6
         prob: 0.3
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactRareMaterialSpawnGold
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Create gold
   components:
   - type: XenoArtifactNode
     maxDurability: 3
@@ -853,11 +967,15 @@
         rolls: !type:ConstantNumberSelector
           value: 6
         prob: 0.3
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactRareMaterialSpawnUranium
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Create uranium
   components:
   - type: XenoArtifactNode
     maxDurability: 4
@@ -876,11 +994,15 @@
         amount: !type:BinomialNumberSelector
           trials: 3
           chance: 0.3
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactAngryCarpSpawn
-  description: Entity translocation # Moffstation - Obfuscate xenoarcheology
+  description: Summon hostile fish # Moff - Slight retheming
   components:
   - type: XenoArtifactNode
     maxDurability: 3
@@ -897,11 +1019,15 @@
         children:
         - id: MobCarpMagic
         - id: MobCarpHolo
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-entity-translocation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactFaunaSpawn
-  description: Entity translocation # Moffstation - Obfuscate xenoarcheology
+  description: Summon friendly fauna # Moff - Slight retheming
   components:
   - type: XenoArtifactNode
     maxDurability: 4
@@ -937,52 +1063,50 @@
           amount: 1, 3
         - id: MobMonkeySyndicateAgent #so lucky
           prob: 0.03
-        # Moffstation - Start - Revert artifact mob change
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-entity-translocation
+  # Moff End
+
+- type: entity
+  parent: BaseXenoArtifactEffect
+  id: XenoArtifactHostileFaunaSpawn
+  description: Summon hostile fauna # Moff - Slight retheming
+  components:
+  - type: XenoArtifactNode
+    maxDurability: 4
+    maxDurabilityCanDecreaseBy:
+      min: 0
+      max: 3
+  - type: XAEApplyComponents
+    applyIfAlreadyHave: true
+    refreshOnReactivate: true
+    components:
+    - type: EntityTableSpawner
+      deleteSpawnerAfterSpawn: false
+      table: !type:GroupSelector
+        children:
         - id: MobAdultSlimesYellowAngry
         - id: MobAngryBee
+          # Moff Start - Bees deserve bee friends
           amount: !type:RangeNumberSelector #NOT THE BEES!
-            range: 1, 3
+            range: 2, 5
+          # Moff End
         - id: MobBearSpace
         - id: MobXenoRavager
         - id: MobTick
         - id: MobSpiderSpace
         - id: MobPurpleSnake
         - id: MobKangarooSpace
-        # Moffstation - End
-
-# Moffstation - Start - Revert artifact mob change
-#- type: entity
-#  id: XenoArtifactHostileFaunaSpawn
-#  parent: BaseXenoArtifactEffect
-#  description: Create hostile fauna
-#  components:
-#  - type: XenoArtifactNode
-#    maxDurability: 4
-#    maxDurabilityCanDecreaseBy:
-#      min: 0
-#      max: 3
-#  - type: XAEApplyComponents
-#    applyIfAlreadyHave: true
-#    refreshOnReactivate: true
-#    components:
-#    - type: EntityTableSpawner
-#      deleteSpawnerAfterSpawn: false
-#      table: !type:GroupSelector
-#        children:
-#        - id: MobAdultSlimesYellowAngry
-#        - id: MobAngryBee
-#        - id: MobBearSpace
-#        - id: MobXenoRavager
-#        - id: MobTick
-#        - id: MobSpiderSpace
-#        - id: MobPurpleSnake
-#        - id: MobKangarooSpace
-# Moffstation - End
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-entity-translocation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactCashSpawn
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Create money
   components:
   - type: XenoArtifactNode
     maxDurability: 2
@@ -1006,11 +1130,15 @@
           weight: 0.25
         - id: SpaceCash1000
           weight: 0.1
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactShatterWindows
-  description: Environmental disruption # Moffstation - Obfuscate xenoarcheology
+  description: Break windows
   components:
   - type: XenoArtifactNode
     maxDurability: 3
@@ -1025,11 +1153,15 @@
     damage:
       types:
         Structural: 200
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-environment
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactFoamGood
-  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
+  description: Creates wave of helpful foam
   components:
   - type: XenoArtifactNode
     maxDurability: 7
@@ -1037,7 +1169,7 @@
       min: 0
       max: 5
   - type: XAEFoam
-    replaceDescription: false # Moffstation - Obfuscate xenoarcheology
+    replaceDescription: true
     reagents:
     - Dermaline
     - Arithrazine
@@ -1046,16 +1178,20 @@
     - Kelotane
     - Dexalin
     - Omnizine
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-biochemical
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactFoamDangerous
-  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
+  description: Creates wave of harmful foam
   components:
   - type: XAEFoam
     minFoamAmount: 20
     maxFoamAmount: 30
-    replaceDescription: false # Moffstation - Obfuscate xenoarcheology
+    replaceDescription: true
     reagents:
     - Tritium
     - Plasma
@@ -1068,17 +1204,21 @@
     - ChloralHydrate
     - Mold
     - Amatoxin
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-biochemical
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactPuddleRare
-  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
+  description: Creates puddle of helpful chemicals
   components:
   - type: XAECreatePuddle
     chemAmount:
       min: 1
       max: 3
-    replaceDescription: false # Moffstation - Obfuscate xenoarcheology
+    replaceDescription: true
     chemicalSolution:
       maxVol: 500
       canReact: false
@@ -1098,11 +1238,15 @@
     - Desoxyephedrine
     - Pax
     - Siderlac
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-biochemical
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactAnomalySpawn
-  description: Environmental disruption # Moffstation - Obfuscate xenoarcheology
+  description: Creates anomaly
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -1113,29 +1257,41 @@
       table: !type:AllSelector
         children:
         - id: RandomAnomalySpawner
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-environment
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactIgnite
-  description: Exothermic action # Moffstation - Obfuscate xenoarcheology
+  description: Pyrokinesis
   components:
   - type: XAEIgnite
     range: 7
     fireStack:
       min: 3
       max: 6
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-energy
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactTeleport
-  description: Metaphysical displacement # Moffstation - Obfuscate xenoarcheology
+  description: Teleportation
   components:
   - type: XAERandomTeleportInvoker
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-displacement
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactEmp
-  description: Endothermic action # Moffstation - Obfuscate xenoarcheology
+  description: Dangerous electromagnetic interference
   components:
   - type: XenoArtifactNode
     maxDurability: 5
@@ -1143,34 +1299,50 @@
       min: 0
       max: 3
   - type: XAEEmpInArea
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-electrical-interference
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactPolyMonkey
-  description: Transmogrificational activity # Moffstation - Obfuscate xenoarcheology
+  description: Temporarily reshape flesh to fur
   components:
   - type: XAEPolymorph
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-polymorph
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactPolyLizard
-  description: Transmogrificational activity # Moffstation - Obfuscate xenoarcheology
+  description: Temporarily reshape flesh to scale
   components:
   - type: XAEPolymorph
     polymorphPrototypeName: ArtifactLizard
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-polymorph
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactPolyLuminous
-  description: Transmogrificational activity # Moffstation - Obfuscate xenoarcheology
+  description: Temporarily reshape flesh to light
   components:
   - type: XAEPolymorph
     polymorphPrototypeName: ArtifactLuminous
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-polymorph
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactRadioactiveStrong
-  description: Exothermic action # Moffstation - Obfuscate xenoarcheology
+  description: Becomes highly radioactive
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -1179,11 +1351,15 @@
     - type: RadiationSource
       intensity: 2
       slope: 0.3
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: moff-artifact-effect-hint-energy
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactMaterialSpawnGlass
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Create glass
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -1194,11 +1370,15 @@
       deleteSpawnerAfterSpawn: false
       table:
         id: SheetGlass
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactMaterialSpawnSteel
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Create steel
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -1209,11 +1389,15 @@
       deleteSpawnerAfterSpawn: false
       table:
         id: SheetSteel
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactMaterialSpawnPlastic
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Create plastic
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -1224,18 +1408,26 @@
       deleteSpawnerAfterSpawn: false
       table:
         id: SheetPlastic
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactPortal
-  description: Metaphysical displacement # Moffstation - Obfuscate xenoarcheology
+  description: Create short-living bluespace portal
   components:
   - type: XAEPortal
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-displacement
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactArtifactSpawn
-  description: Entity translocation # Moffstation - Obfuscate xenoarcheology
+  description: Create artifact
   components:
   - type: XenoArtifactNode
     maxDurability: 2
@@ -1250,22 +1442,30 @@
       deleteSpawnerAfterSpawn: false
       table: !type:NestedSelector
         tableId: RandomArtifactTable
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactShuffle
-  description: Metaphysical displacement # Moffstation - Obfuscate xenoarcheology
+  description: Switch places of sentient beings #not ALL beings, but oh well...
   components:
   - type: XAEShuffle
   - type: XAETelepathic
     range: 7.5
     messages:
     - shuffle-artifact-popup
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-displacement
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactHealAll
-  description: Biochemical disruption # Moffstation - Obfuscate xenoarcheology
+  description: Miraculous healing
   components:
   - type: XAEDamageInArea
     damageChance: 1
@@ -1281,6 +1481,10 @@
         Heat: -100
         Cold: -100
         Shock: -100
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-biochemical
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
@@ -1313,7 +1517,7 @@
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactExplosionScary
-  description: Environmental disruption # Moffstation - Obfuscate xenoarcheology
+  description: Small scale high-speed nuclear reaction
   components:
   - type: XAETriggerExplosives
   - type: Explosive
@@ -1324,11 +1528,15 @@
     maxIntensity: 1.5
     canCreateVacuum: false
     repeatable: true
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-environment
+  # Moff End
 
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactBoom
-  description: Environmental disruption # Moffstation - Obfuscate xenoarcheology
+  description: Explosion
   components:
   - type: XAETriggerExplosives
   - type: Explosive
@@ -1338,57 +1546,85 @@
     intensitySlope: 2.5
     maxIntensity: 50
     repeatable: true
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-environment
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactEffectCreationGasPlasma
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Expels plasma
   components:
   - type: XAECreateGas
     gases:
       Plasma: 300
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactEffectCreationGasTritium
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Expels tritium
   components:
   - type: XAECreateGas
     gases:
       Tritium: 300
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactEffectCreationGasAmmonia
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Expels ammonia
   components:
   - type: XAECreateGas
     gases:
       Ammonia: 300
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactEffectCreationGasFrezon
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Expels frezon
   components:
   - type: XAECreateGas
     gases:
       Frezon: 300
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactEffectCreationGasNitrousOxide
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Expels nitrous oxide
   components:
   - type: XAECreateGas
     gases:
       NitrousOxide: 300
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End
 
 - type: entity
   parent: BaseXenoArtifactEffect
   id: XenoArtifactEffectCreationGasCarbonDioxide
-  description: Matter creation # Moffstation - Obfuscate xenoarcheology
+  description: Expels carbon dioxide
   components:
   - type: XAECreateGas
     gases:
       CarbonDioxide: 300
+  # Moff Start - Dynamic description
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-creation
+  # Moff End

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -296,7 +296,7 @@
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactSolutionStorage
-  description: Obtains ability of container for chemical solutions
+  description: Obtains ability to contain chemical solutions # Moff - Slight retheming
   components:
   - type: XAEApplyComponents
     components:
@@ -346,7 +346,7 @@
 - type: entity
   parent: BaseOneTimeXenoArtifactEffect
   id: XenoArtifactDrill
-  description: Obtains ability of drill
+  description: Obtains the capabilities of a drill # Moff - Slight retheming
   components:
   - type: XAEApplyComponents
     components:

--- a/Resources/Prototypes/_Moffstation/XenoArch/effects.yml
+++ b/Resources/Prototypes/_Moffstation/XenoArch/effects.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: XenoArtifactFlashbang
   parent: BaseXenoArtifactEffect
-  description: Visual distortions
+  description: Emits disorienting flash
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -11,3 +11,5 @@
       deleteSpawnerAfterSpawn: false
       prototypes:
       - AdminInstantEffectFlashSound
+  - type: XAELocalizedDescription
+    description: artifact-effect-hint-visual


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Modified the artifact analysis console to behave as the following:
1. Locked nodes, or nodes that have not been activated, will hide their durability and provide a general hint to their effect.
2. Unlocked and Active nodes, or nodes that have been activated, will show their durability and give a more detailed report to their effect.

Additionally, reverted https://github.com/moff-station/moff-station-14/pull/716 as this change in the longterm was a nothingburger, and limits the potential of use of these nodes.

Finally, adjusted a few of our non-activated effect category hints, mainly to help further consolidate like thematic groups.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Going back to the main point of this pull request, previously we have operated with artifacts always hiding their effects, in contrast to upstream's take of always showing their effects. While This does achieve the goal of making xenoarch more dangerous and engaging to play with, as a result, a few key nodes (such as biochemical foam) lost out on a lot of potential, as there isn't a feasible way to identify what these nodes actually did for further non-scientific application. Additionally, while some nodes were inherently risky - many could often be metagamed by checking the durability of said node. Rather than reverting back to upstream's full disclosure method, losing out on the risk that science players enjoy, a check was put in place instead, allowing for this description and durability value to dynamically update based on criteria met. As a result, we preserve the mystique and risk of activating these artifacts for the first time, and have the clarity and understanding of them once we pass the threshold of interaction.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
Created custom component for our localized strings. Turns out, I don't need to build a whole new entity subtype - I can just  make a comp for this!

Check console.
Trigger artifact.
Check console again.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

https://github.com/user-attachments/assets/842ab6ab-939b-4914-99ed-e449e500c19e

_Artifact node data updating relative to activation status._

<img width="262" height="418" alt="image" src="https://github.com/user-attachments/assets/2be2985a-dc2b-496a-87c3-5d5382bcd3ab" />

_Prior to activation._

<img width="260" height="423" alt="image" src="https://github.com/user-attachments/assets/af2cb8e1-4153-4560-8abc-881da071ebc1" />

_After activation._

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces.
- [X] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl: Centronias, Nyxilath
- tweak: Artifact console effect reports now give more detail post-activation
- tweak: Artifact console durability reports now state 'Unknown' prior to activation
- fix: Speed-Artifacts are now moved to handheld-only
- tweak: Several artifact effect hints have been adjusted according to their thematics

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
