### PR TITLE
Hypereutactic-Blade Delay Bug Fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -295,7 +295,6 @@
   description: Syndicate Command Interns thought that having one blade on the energy sword was not enough. This can be stored in pockets.
   components:
   - type: ItemToggle
-    predictable: false # Moffstation Change - Fixes the hum not working, but introduces minor amt of clientside latency on activation (barely noticable, mainly affects 'feel). Upstream PR #38070 fixes this, so when it is merged w/o conflicts, this line can be removed.
     onUse: false # wielding events control it instead
     onActivate: true # Moffstation Change - Allows it to turned on while on the ground to see the cool sprite. Mainly for items this parents from.
     soundActivate:


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
In the past the item had a small delay to get around a constantly increasing hum sfx. This was fixed on upstream so the bandaid is no longer needed here. Makes the weapon feel smoother.

## Why / Balance


## Test Plan / Technical Details
Deleted 1 line of code.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Hypereutactic Blade bugfix!

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
