### PR TITLE
[Bugfix] Job priority display will properly red-out icons

### DIFF
--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -166,6 +166,8 @@ public sealed partial class LobbyUIController : UIController, IOnStateEntered<Lo
         if (PreviewPanel == null)
             return;
 
+        PreviewPanel.RefreshMoffJobGrid(); // Moff - Multi-character selection
+
         // Get selected character, load it, then set it
         var character = _preferencesManager.Preferences?.SelectedCharacter;
 

--- a/Content.Client/_Moffstation/Lobby/UI/LobbyCharacterPreviewPanel.MultiCharacter.cs
+++ b/Content.Client/_Moffstation/Lobby/UI/LobbyCharacterPreviewPanel.MultiCharacter.cs
@@ -272,7 +272,7 @@ public sealed partial class LobbyCharacterPreviewPanel
 
         foreach (var (slot, profile) in prefs.Characters)
         {
-            if (profile != null && profile.JobPriorities.ContainsKey(job))
+            if (profile?.JobPriorities.ContainsKey(job) == true)
                 result[slot] = profile;
         }
 

--- a/Content.Client/_Moffstation/Lobby/UI/LobbyCharacterPreviewPanel.MultiCharacter.cs
+++ b/Content.Client/_Moffstation/Lobby/UI/LobbyCharacterPreviewPanel.MultiCharacter.cs
@@ -161,7 +161,8 @@ public sealed partial class LobbyCharacterPreviewPanel
             var icon = new MoffUI.DraggableJobIcon(job, () => _moffPriorityLock.Pressed, _ => CreateMoffJobTooltip(job));
 
             // A job no character will take can never be assigned, however it is prioritised.
-            if (GetMoffProfilesForJob(job.ID).Count == 0)
+            var jobProfiles = GetMoffProfilesForJob(job.ID);
+            if (jobProfiles.Count == 0 || jobProfiles.All(p => !_moffSelection.IsSlotEnabled(p.Key)))
                 icon.Modulate = Color.Salmon;
 
             foreach (var priority in Enum.GetValues<JobPriority>())
@@ -272,8 +273,8 @@ public sealed partial class LobbyCharacterPreviewPanel
 
         foreach (var (slot, profile) in prefs.Characters)
         {
-            if (profile is HumanoidCharacterProfile humanoid && humanoid.JobPriorities.ContainsKey(job))
-                result[slot] = humanoid;
+            if (profile != null && profile.JobPriorities.ContainsKey(job))
+                result[slot] = profile;
         }
 
         return result;

--- a/Content.Client/_Moffstation/Lobby/UI/LobbyCharacterPreviewPanel.MultiCharacter.cs
+++ b/Content.Client/_Moffstation/Lobby/UI/LobbyCharacterPreviewPanel.MultiCharacter.cs
@@ -161,8 +161,7 @@ public sealed partial class LobbyCharacterPreviewPanel
             var icon = new MoffUI.DraggableJobIcon(job, () => _moffPriorityLock.Pressed, _ => CreateMoffJobTooltip(job));
 
             // A job no character will take can never be assigned, however it is prioritised.
-            var jobProfiles = GetMoffProfilesForJob(job.ID);
-            if (jobProfiles.Count == 0 || jobProfiles.All(p => !_moffSelection.IsSlotEnabled(p.Key)))
+            if (GetMoffProfilesForJob(job.ID).All(p => !_moffSelection.IsSlotEnabled(p.Key)))
                 icon.Modulate = Color.Salmon;
 
             foreach (var priority in Enum.GetValues<JobPriority>())


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
The priority list is supposed to "red-out" jobs which you are unable to roll.
previously, as long as you had a character with "yes" on a job, it wouldn't red out even if all the characters with yes were inactive.

This fixes that, making it easier to tell what jobs you have enabled for the round.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfix
## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: The job priority list will now properly "red-out" jobs which you don't have selected by active characters.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
