### PR TITLE
Fix midround antag selection

### DIFF
--- a/Content.Server/_Moffstation/Antag/AntagSelectionSystem.Moffstation.cs
+++ b/Content.Server/_Moffstation/Antag/AntagSelectionSystem.Moffstation.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using Content.Server._Moffstation.Preferences;
 using Content.Server._Moffstation.Station;
 using Content.Shared.GameTicking.Components;
-using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -21,11 +20,19 @@ public sealed partial class AntagSelectionSystem
     private MoffCharacterPickerSystem MoffCharacterPicker => EntityManager.System<MoffCharacterPickerSystem>();
 
     /// <summary>
-    /// Every antag preference held by any of the player's active characters.
+    /// Every antag preference held by any of the player's active characters, or just the spawned
+    /// character's once one has been picked.
     /// </summary>
     public HashSet<ProtoId<AntagPrototype>> GetMoffEnabledAntagPreferences(ICommonSession session)
     {
         var result = new HashSet<ProtoId<AntagPrototype>>();
+
+        // If they've already spawned, get the prefs from the spawned profile
+        if (MoffCharacterPicker.GetSpawnedProfile(session.UserId) is { } spawned)
+        {
+            result.UnionWith(spawned.AntagPreferences);
+            return result;
+        }
 
         if (!_pref.TryGetCachedPreferences(session.UserId, out var prefs))
             return result;


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Midround selection now respects character preference.

Previously it would run under the assumption that your character will be spawned only after you are chosen for antag, so that it can select the correct character based on preferences. It didn't account for the player already having spawned, so for antags that get selected midround like sleeper agents, it could pick you if you had it turned on with another character.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugefix
## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: You will no longer role sleeper agent from having it selected on another character

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
