### PR TITLE
Enhancements to AAC quickspeak

### DIFF
--- a/Content.Client/_Moffstation/AacTablet/UI/AacPhraseSearchTab.xaml
+++ b/Content.Client/_Moffstation/AacTablet/UI/AacPhraseSearchTab.xaml
@@ -2,8 +2,9 @@
                        HorizontalExpand="True"
                        VerticalExpand="True"
                        Orientation="Vertical">
-    <controls:LineEdit Name="SearchText"
-                       HorizontalExpand="True" />
+    <controls:HistoryLineEdit Name="SearchText"
+                              PlaceHolder="{controls:Loc 'aac-window-search-hint'}"
+                              HorizontalExpand="True" />
     <controls:ScrollContainer HorizontalExpand="True"
                               VerticalExpand="True">
         <controls:BoxContainer HorizontalExpand="True"

--- a/Content.Client/_Moffstation/AacTablet/UI/AacPhraseSearchTab.xaml.cs
+++ b/Content.Client/_Moffstation/AacTablet/UI/AacPhraseSearchTab.xaml.cs
@@ -33,10 +33,10 @@ public sealed partial class AacPhraseSearchTab : BoxContainer
     {
         var width = this.GetControlOfType<AacWindow>(true).FirstOrDefault()?.MinWidth ?? 540;
         Content.Children.Clear();
-        _firstPhrase = null;
-        foreach (var group in _aacTablet.SearchPhrases(args.Text))
+        var (shortest, searchPhrases) = _aacTablet.SearchPhrases(args.Text);
+        _firstPhrase = shortest?.ID;
+        foreach (var group in searchPhrases)
         {
-            _firstPhrase ??= group.Phrases.First();
             Content.Children.Add(AacPhraseButtonsGroup.Create(group, OnPressed, (int)width));
         }
     }
@@ -49,6 +49,7 @@ public sealed partial class AacPhraseSearchTab : BoxContainer
         }
 
         SearchText.Clear();
+        Content.Children.Clear();
     }
 
     private void OnPressed(ProtoId<QuickPhrasePrototype> phrase)

--- a/Content.Shared/_Moffstation/AACTablet/AacTabletSystem.cs
+++ b/Content.Shared/_Moffstation/AACTablet/AacTabletSystem.cs
@@ -37,21 +37,31 @@ public sealed partial class AacTabletSystem : EntitySystem
     public IEnumerable<AacTabletPhraseTab> GetPhrases() => _phraseTabs;
 
     /// Returns all <see cref="QuickPhrasePrototype"/>s which contain <paramref name="search"/> in their localized text.
-    public IEnumerable<AacTabletPhraseGroup> SearchPhrases(string search)
+    public (QuickPhrasePrototype? shortestMatch, IEnumerable<AacTabletPhraseGroup> allMatches) SearchPhrases(
+        string search
+    )
     {
-        var matches = search.Length switch
-        {
-            // Fail fast
-            0 => [],
-            // Small search strings match way too much, so do exact matches
-            < 3 => _prototypeManager.EnumeratePrototypes<QuickPhrasePrototype>()
-                .Where(it => it.LocalizedText.Equals(search, StringComparison.OrdinalIgnoreCase)),
-            _ => _prototypeManager.EnumeratePrototypes<QuickPhrasePrototype>()
-                .Where(it => it.LocalizedText.Contains(search, StringComparison.OrdinalIgnoreCase)),
-        };
-        return matches.GroupBy(it => it.Group)
+        if (search.Length == 0)
+            return (null, []);
+
+        var matches = (
+                search.Length switch
+                {
+                    0 => throw new Exception("Unreachable"),
+                    // Small search strings match way too much, so do exact matches
+                    < 3 => _prototypeManager.EnumeratePrototypes<QuickPhrasePrototype>()
+                        .Where(it => it.LocalizedText.Equals(search, StringComparison.OrdinalIgnoreCase)),
+                    _ => _prototypeManager.EnumeratePrototypes<QuickPhrasePrototype>()
+                        .Where(it => it.LocalizedText.Contains(search, StringComparison.OrdinalIgnoreCase)),
+                }
+            ).OrderBy(it => it.LocalizedText)
+            .ToList();
+        var shortest = matches.MinBy(it => it.LocalizedText.Length);
+        var allMatches = matches.GroupBy(it => it.Group)
             .Select(it => AacTabletPhraseGroup.Create(it.Key, it))
             .OrderBy(it => it.Name);
+
+        return (shortest, allMatches);
     }
 
     private void PopulateCaches()

--- a/Resources/Locale/en-US/deltav/phrases/uncategorized.ftl
+++ b/Resources/Locale/en-US/deltav/phrases/uncategorized.ftl
@@ -1,5 +1,7 @@
 aac-window-footer-flavor = Nanosoft: Helping you find the right words!
 
+aac-window-search-hint = Search for phrases, then press enter to speak a matching phrase
+
 phrase-group-status = Status
 phrase-group-manners = Manners
 phrase-group-numbers = Numbers


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
AAC tablet quickspeak now
- has "hint" text that describes how to use the search
- has history, so you can use `enter` to speak phrases and then use up and down arrows to navigate through previous spoken phrases
- will speak the phrase that's shortest, which I suppose means is most similar to the searched text. It's not really clear that this is what it does, but it should hopefully be a little bit smarter to use

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Useability good.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
devmap
aac tablet
smash the buttons

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

https://github.com/user-attachments/assets/c1e045d3-1647-4092-9ed5-c8a3da334efc


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- tweak: AAC tablets will now speak the shortest phrase matching the entered text on the search tab.
- add: AAC tablets now have memory on the search tab, meaning you can navigate through previously spoken phrases with the same controls as the chat box (defaults to arrow keys).
- tweak: AAC tablets now have a little bit of help text to describe how to use the search tab's quick speaking capability.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
