### PR TITLE
[Fix] Spraybottled Avali players for taking too many survival boxes, AGAIN

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -223,6 +223,7 @@
         - id: EmergencyMedipen
         - id: Flare
         - id: FoodSnackNutribrick
+        - id: DrinkWaterBottleFull # Moff
   - type: Sprite
     layers:
     - state: internals
@@ -243,6 +244,7 @@
         - id: EmergencyMedipen
         - id: Flare
         - id: FoodSnackNutribrick
+        - id: DrinkWaterBottleFull # Moff
   - type: Sprite
     layers:
     - state: internals

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -208,6 +208,7 @@
 # Intended for nukies (or similar syndicate operatives).
 # Contains food because we don't want to force nukies to go get lunch in the middle of a mission.
 # Not enough space left to fit the water bottle (syndie gas mask is 1x2), but that's not a problem since the nukies have a whole bar on the nukie planet.
+# Moff Note - Our syndie gas mask is 1x1 instead, so operatives get to have their water bottles. Rejoice!
 - type: entity
   parent: BoxCardboard
   id: BoxSurvivalSyndicate

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -121,6 +121,7 @@
   loadouts:
   - EmergencyNitrogen
   - EmergencyOxygen
+  - EmergencyOxygenAvali # Moff
   - LoadoutSpeciesVoxNitrogen
 
 # nitrogen or oxygen tank, depending on what your species needs
@@ -688,7 +689,7 @@
   loadouts:
   - EmergencyNitrogenClown
   - EmergencyOxygenClown
-  - EmergencyOxygenClownAmmonia # Moffstation - Allow avali to drink ammonia
+  - EmergencyOxygenClownAvali # Moff
   - LoadoutSpeciesVoxNitrogen
 
 - type: loadoutGroup
@@ -1169,7 +1170,7 @@
   loadouts:
   - EmergencyNitrogenExtended
   - EmergencyOxygenExtended
-  - EmergencyOxygenExtendedAmmonia # Moffstation - Allow avali to drink ammonia
+  - EmergencyOxygenExtendedAvali # Moff
   - LoadoutSpeciesVoxNitrogen
 
 # Science
@@ -1579,7 +1580,7 @@
   loadouts:
   - EmergencyNitrogenSecurity
   - EmergencyOxygenSecurity
-  - EmergencyOxygenSecurityAmmonia # Moffstation - Allow avali to drink ammonia
+  - EmergencyOxygenSecurityAvali # Moff
   - LoadoutSpeciesVoxNitrogen
 
 # Wildcards
@@ -1670,6 +1671,7 @@
   loadouts:
   - EmergencyNitrogenExtendedAntag
   - EmergencyOxygenExtendedAntag
+  - EmergencyOxygenExtendedAntagAvali # Moff
   - LoadoutSpeciesVoxNitrogen
 
 - type: loadoutGroup
@@ -1680,7 +1682,7 @@
   loadouts:
   - EmergencyNitrogenSyndicate
   - EmergencyOxygenSyndicate
-  - EmergencyOxygenSyndicateAmmonia # Moffstation - Allow avali to drink ammonia
+  - EmergencyOxygenSyndicateAvali # Moff
   - LoadoutSpeciesVoxNitrogen
 
 - type: loadoutGroup
@@ -1691,6 +1693,7 @@
   loadouts:
   - EmergencyNitrogenMilitaryDouble
   - EmergencyOxygenMilitaryDouble
+  - EmergencyOxygenMilitaryDoubleAvali # Moff
 
 - type: loadoutGroup
   id: GroupSpeciesBreathTool

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
@@ -40,7 +40,7 @@
   loadouts:
   - EmergencyNitrogenMedical
   - EmergencyOxygenMedical
-  - EmergencyOxygenMedicalAmmonia # Moffstation - Allow avali to drink ammonia
+  - EmergencyOxygenMedicalAvali # Moff
   - LoadoutSpeciesVoxNitrogen
 
 # Chief Medical Officer

--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -20,7 +20,7 @@
     - Reptilian
     - Vulpkanin
     # Moffstation - Begin
-    - Avali
+    # - Avali # Moff note: Do not add Avali to this list; they have a unique identifier 'EffectSpeciesAvali'
     - Gray
     - Resomi
     - Thaven

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -45,8 +45,8 @@
   prefRoles:
   - GenericTeamAntagonist # For antag ban purposes
   roleLoadout:
-  - JobNukeops
   - RoleSurvivalNukie
+  - JobNukeops
   components:
   - type: NukeOperative
   - type: NpcFactionMember

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -45,8 +45,8 @@
   prefRoles:
   - GenericTeamAntagonist # For antag ban purposes
   roleLoadout:
-  - RoleSurvivalNukie
   - JobNukeops
+  - RoleSurvivalNukie
   components:
   - type: NukeOperative
   - type: NpcFactionMember

--- a/Resources/Prototypes/_Moffstation/Catalog/Fills/Backpacks/AntagStarterGear/operative_backpacks.yml
+++ b/Resources/Prototypes/_Moffstation/Catalog/Fills/Backpacks/AntagStarterGear/operative_backpacks.yml
@@ -5,13 +5,14 @@
   name: operative backpack
   description: An explosion-proof backpack for holding various tactical goods. # Moff - Nukies -> Gorlex
   components:
-  - type: StorageFill
-    contents:
-      - id: BoxSurvivalSyndicate
-      - id: WeaponPistolViper
-      - id: PinpointerSyndicateNuclear
-      - id: DeathAcidifierImplanter
-
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: BoxSurvivalSyndicate # TODO: fix nukie loadouts; they should get their contents dynamically!
+        - id: WeaponPistolViper
+        - id: PinpointerSyndicateNuclear
+        - id: DeathAcidifierImplanter
 
 - type: entity
   parent: ClothingBackpackSyndicate
@@ -19,19 +20,20 @@
   name: operative medic backpack
   description: A backpack for holding extra medical supplies.
   components:
-  - type: StorageFill
-    contents:
-      - id: SyndiHypo
-      - id: BoxSurvivalSyndicate
-      - id: SawAdvanced
-      - id: Cautery
-      - id: CombatKnife
-      - id: WeaponPistolViper
-      - id: PinpointerSyndicateNuclear
-      - id: HandheldHealthAnalyzer
-      - id: CombatMedipen
-      - id: DeathAcidifierImplanter
-
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: SyndiHypo
+        - id: BoxSurvivalSyndicate # TODO: fix nukie loadouts; they should get their contents dynamically!
+        - id: SawAdvanced
+        - id: Cautery
+        - id: CombatKnife
+        - id: WeaponPistolViper
+        - id: PinpointerSyndicateNuclear
+        - id: HandheldHealthAnalyzer
+        - id: CombatMedipen
+        - id: DeathAcidifierImplanter
 
 # Satchel
 - type: entity
@@ -40,13 +42,14 @@
   name: operative satchel
   description: A robust, explosion-proof satchel for holding various tactical goods. # Moff - Nukies -> Gorlex
   components:
-  - type: StorageFill
-    contents:
-      - id: BoxSurvivalSyndicate
-      - id: WeaponPistolViper
-      - id: PinpointerSyndicateNuclear
-      - id: DeathAcidifierImplanter
-
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: BoxSurvivalSyndicate # TODO: fix nukie loadouts; they should get their contents dynamically!
+        - id: WeaponPistolViper
+        - id: PinpointerSyndicateNuclear
+        - id: DeathAcidifierImplanter
 
 - type: entity
   parent: ClothingBackpackSatchelSyndicate
@@ -54,19 +57,20 @@
   name: operative medic satchel
   description: A satchel for holding extra medical supplies.
   components:
-  - type: StorageFill
-    contents:
-      - id: SyndiHypo
-      - id: BoxSurvivalSyndicate
-      - id: SawAdvanced
-      - id: Cautery
-      - id: CombatKnife
-      - id: WeaponPistolViper
-      - id: PinpointerSyndicateNuclear
-      - id: HandheldHealthAnalyzer
-      - id: CombatMedipen
-      - id: DeathAcidifierImplanter
-
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: SyndiHypo
+        - id: BoxSurvivalSyndicate # TODO: fix nukie loadouts; they should get their contents dynamically!
+        - id: SawAdvanced
+        - id: Cautery
+        - id: CombatKnife
+        - id: WeaponPistolViper
+        - id: PinpointerSyndicateNuclear
+        - id: HandheldHealthAnalyzer
+        - id: CombatMedipen
+        - id: DeathAcidifierImplanter
 
 # Duffel
 - type: entity
@@ -74,13 +78,14 @@
   id: ClothingBackpackDuffelSyndicateOperative
   name: operative duffelbag
   components:
-  - type: StorageFill
-    contents:
-      - id: BoxSurvivalSyndicate
-      - id: WeaponPistolViper
-      - id: PinpointerSyndicateNuclear
-      - id: DeathAcidifierImplanter
-
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: BoxSurvivalSyndicate # TODO: fix nukie loadouts; they should get their contents dynamically!
+        - id: WeaponPistolViper
+        - id: PinpointerSyndicateNuclear
+        - id: DeathAcidifierImplanter
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateMedicalBundle
@@ -88,15 +93,17 @@
   name: operative medic duffelbag
   description: A large duffel bag for holding extra medical supplies.
   components:
-  - type: StorageFill
-    contents:
-      - id: SyndiHypo
-      - id: BoxSurvivalSyndicate
-      - id: SawAdvanced
-      - id: Cautery
-      - id: CombatKnife
-      - id: WeaponPistolViper
-      - id: PinpointerSyndicateNuclear
-      - id: HandheldHealthAnalyzer
-      - id: CombatMedipen
-      - id: DeathAcidifierImplanter
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: SyndiHypo
+        - id: BoxSurvivalSyndicate # TODO: fix nukie loadouts; they should get their contents dynamically!
+        - id: SawAdvanced
+        - id: Cautery
+        - id: CombatKnife
+        - id: WeaponPistolViper
+        - id: PinpointerSyndicateNuclear
+        - id: HandheldHealthAnalyzer
+        - id: CombatMedipen
+        - id: DeathAcidifierImplanter

--- a/Resources/Prototypes/_Moffstation/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_Moffstation/Catalog/Fills/Boxes/emergency.yml
@@ -1,138 +1,33 @@
+# Deluxe
 - type: entity
-  parent: BoxSurvivalEmpty
-  id: BoxSurvivalAmmonia
-  name: survival box
-  description: It's a box with basic internals inside.
-  suffix: Standard, Ammonia
+  parent: BoxSurvivalDeluxeExtended
+  id: BoxSurvivalDeluxeExtendedAmmonia
+  suffix: Ammonia
   components:
-  - type: StorageFill
-    contents:
-    - id: ClothingMaskBreath
-    - id: EmergencyOxygenTankFilled
-    - id: EmergencyMedipen
-    - id: Flare
-    - id: BookHowToSurvive 
-    - id: DrinkAmmoniaBottleFull
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: emergencytank
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: ClothingMaskBreath
+        - id: ExtendedEmergencyOxygenTankFilled
+        - id: EmergencyMedipen
+        - id: Flare
+        - id: FoodSnackNutribrick
+        - id: DrinkAmmoniaBottleFull
 
+# Syndicate
 - type: entity
-  parent: BoxSurvivalEmpty 
-  id: BoxSurvivalEngineeringAmmonia
-  name: extended-capacity survival box 
-  description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
-  suffix: Extended, Ammonia
-  components:
-  - type: StorageFill
-    contents:
-    - id: ClothingMaskGas 
-    - id: ExtendedEmergencyOxygenTankFilled
-    - id: EmergencyMedipen
-    - id: Flare
-    - id: BookHowToSurvive 
-    - id: DrinkAmmoniaBottleFull
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: extendedtank
-
-- type: entity
-  parent: BoxSurvivalEmpty
-  id: BoxSurvivalSecurityAmmonia
-  name: survival box
-  description: It's a box with basic internals inside.
-  suffix: Security, Ammonia
-  components:
-  - type: StorageFill
-    contents:
-    - id: ClothingMaskGasSecurity
-    - id: EmergencyOxygenTankFilled
-    - id: EmergencyMedipen
-    - id: Flare
-    - id: BookHowToSurvive
-    - id: DrinkAmmoniaBottleFull
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: emergencytank
-
-- type: entity
-  parent: BoxSurvivalEmpty
-  id: BoxSurvivalMedicalAmmonia
-  name: survival box
-  description: It's a box with basic internals inside.
-  suffix: Medical, Ammonia
-  components:
-  - type: StorageFill
-    contents:
-    - id: ClothingMaskBreathMedical
-    - id: EmergencyOxygenTankFilled
-    - id: EmergencyMedipen
-    - id: Flare
-    - id: BookHowToSurvive
-    - id: DrinkAmmoniaBottleFull
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: emergencytank
-
-- type: entity
-  parent: BoxSurvivalEmpty
-  id: BoxHugAmmonia
-  name: box of hugs
-  description: A special box for sensitive people.
-  suffix: Emergency, Ammonia
-  components:
-  - type: Sprite
-    layers:
-    - state: box_hug
-    - state: heart
-  - type: Item
-    heldPrefix: hug
-  - type: StorageFill
-    contents:
-    - id: ClothingMaskClown
-    - id: EmergencyFunnyOxygenTankFilled
-    - id: EmergencyMedipen
-    - id: Flare
-    - id: BookHowToSurvive
-    - id: DrinkAmmoniaBottleFull
-  - type: Tag
-    tags:
-    - BoxHug
-
-- type: entity
-  parent: BoxSurvivalEmpty
-  id: BoxMimeAmmonia
-  suffix: Mime, Emergency, Ammonia
-  components:
-  - type: StorageFill
-    contents:
-    - id: ClothingMaskMime
-    - id: EmergencyOxygenTankFilled
-    - id: EmergencyMedipen
-    - id: Flare
-    - id: BookHowToSurvive
-    - id: DrinkAmmoniaBottleFull
-
-- type: entity
-  parent: BoxSurvivalEmpty
+  parent: BoxSurvivalSyndicate
   id: BoxSurvivalSyndicateAmmonia
-  name: extended-capacity survival box
-  description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
-  suffix: Syndicate, Ammonia
+  suffix: Ammonia
   components:
-  - type: StorageFill
-    contents:
-    - id: ClothingMaskGasSyndicate
-    - id: ExtendedEmergencyOxygenTankFilled
-    - id: EmergencyMedipen
-    - id: Flare
-    - id: BookHowToSurvive
-    - id: DrinkAmmoniaBottleFull
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: extendedtank
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: ClothingMaskGasSyndicate
+        - id: ExtendedEmergencyOxygenTankFilled
+        - id: EmergencyMedipen
+        - id: Flare
+        - id: FoodSnackNutribrick
+        - id: DrinkAmmoniaBottleFull

--- a/Resources/Prototypes/_Moffstation/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/_Moffstation/Loadouts/Miscellaneous/survival.yml
@@ -62,70 +62,73 @@
 
 # Basic Survival Box
 - type: loadout
-  id: EmergencyAmmonia
+  id: EmergencyOxygenAvali
   effects:
   - !type:GroupLoadoutEffect
     proto: EffectSpeciesAvali
   storage:
     back:
-    - BoxSurvivalAmmonia
+    - BoxSurvival
 
 # Clown
 - type: loadout
-  id: EmergencyOxygenClownAmmonia
+  id: EmergencyOxygenClownAvali
   effects:
   - !type:GroupLoadoutEffect
     proto: EffectSpeciesAvali
   storage:
     back:
-    - BoxHugAmmonia
-
-# Mime
-- type: loadoutEffectGroup
-  id: EffectSpeciesAvaliMime
-  effects:
-  - !type:SpeciesLoadoutEffect
-    species:
-    - Avali
-
-- type: loadout
-  id: EmergencyOxygenMimeAmmonia
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: EffectSpeciesAvaliMime
-  storage:
-    back:
-    - BoxMimeAmmonia
+    - BoxSurvivalHug
 
 # Engineering / Extended
 - type: loadout
-  id: EmergencyOxygenExtendedAmmonia
+  id: EmergencyOxygenExtendedAvali
   effects:
   - !type:GroupLoadoutEffect
     proto: EffectSpeciesAvali
   storage:
     back:
-    - BoxSurvivalEngineeringAmmonia
+    - BoxSurvivalEngineering
+
+# Deluxe
+- type: loadout
+  id: EmergencyOxygenExtendedAntagAvali
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: OxygenBreather
+  storage:
+    back:
+    - BoxSurvivalDeluxeExtended
 
 # Medical
 - type: loadout
-  id: EmergencyOxygenMedicalAmmonia
+  id: EmergencyOxygenMedicalAvali
   effects:
   - !type:GroupLoadoutEffect
     proto: EffectSpeciesAvali
   storage:
     back:
-    - BoxSurvivalMedicalAmmonia
+    - BoxSurvivalMedical
+
+# Military
+- type: loadout
+  id: EmergencyOxygenMilitaryDoubleAvali
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: EffectSpeciesAvali
+  storage:
+    back:
+    - BoxSurvivalMilitaryDouble
 
 # Security
 - type: loadout
-  id: EmergencyOxygenSecurityAmmonia
+  id: EmergencyOxygenSecurityAvali
   effects:
   - !type:GroupLoadoutEffect
     proto: EffectSpeciesAvali
   storage:
     back:
-    - BoxSurvivalSecurityAmmonia
+    - BoxSurvivalSecurity
 
 # Stowaway
 - type: loadout
@@ -172,7 +175,7 @@
 
 # Syndicate
 - type: loadout
-  id: EmergencyOxygenSyndicateAmmonia
+  id: EmergencyOxygenSyndicateAvali
   effects:
   - !type:GroupLoadoutEffect
     proto: EffectSpeciesAvali

--- a/Resources/ServerInfo/_Moffstation/Guidebook/Mobs/Avali.xml
+++ b/Resources/ServerInfo/_Moffstation/Guidebook/Mobs/Avali.xml
@@ -4,17 +4,15 @@
   <Box>
     <GuideEntityEmbed Entity="MobAvali" Scale="2" Caption="Avali"/>
   </Box>
-  
+
   ## Ammonia
 
   Avali are humanoid creatures comparable to feathered raptors. To withstand the freezing conditions of their home world of Avalon, their biology is much different to many other humanoid species. For example, to prevent their blood from freezing on their homeworld, Avali blood consists largely of ammonia, making the consumption of the chemical essential for their hydration (with water barely hydrating them at all!)
-  While ammonia may be hard to come by outside of chemistry, Avali crew members are equipped with a dedicated bottle in their survival box.
 
   <Box>
     <GuideEntityEmbed Entity="DrinkAmmoniaBottleFull" Scale="4" Caption="Ammonia Bottle"/>
-    <GuideEntityEmbed Entity="BoxSurvivalAmmonia" Scale="4" Caption="Avali Survival Box"/>
   </Box>
-  In case there is no chemist to refill your bottle, an Avali can resort to space cleaner for their hydration needs, made easily available from janitorial. Avali can also drink diethylamine as an ammonia-based alcoholic beverage.
+  In case there is no chemist or bartender, an Avali can resort to space cleaner for their hydration needs, made easily available from janitorial. Avali can also drink diethylamine as an ammonia-based alcoholic beverage.
 
   ## Emp / Ion Storm Weakness
 
@@ -22,7 +20,7 @@
 
   <Box>
     <GuideEntityEmbed Entity="EmpGrenade" Scale="4" Caption="EMP Grenade"/>
-    <GuideEntityEmbed Entity="EmpImplanter" Scale="4" Caption="EMP Implanter"/> 
+    <GuideEntityEmbed Entity="EmpImplanter" Scale="4" Caption="EMP Implanter"/>
   </Box>
 
   When in the radius of an EMP blast, an Avali will become stunned for a brief duration, falling over, dropping anything they are holding and becoming temporarily blind while affected. These side effects will subside, but the process can be quite painful for some.


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Fixed loadouts where Avali would spawn with two survival boxes.

Also moved operative bags from using `StorageFill` to `EntityTableContainerFill` while trying to troubleshoot a secondary issue.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Similar to https://github.com/moff-station/moff-station-14/pull/1592 , removed Avali from the OxygenBreather loadout group, and readjusted our loadouts accordingly.

Left a note in OxygenBreather to help prevent future issues.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
Load a round as an avali as a doctor, engineer, security officer, or clown.
Verify there is only one survival box.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces.
- [X] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Avali now spawn with the correct number of survival boxes. Again.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->