### PR TITLE
Stop mesons from working while in the user's pocket

### DIFF
--- a/Content.Client/SubFloor/TrayScannerSystem.cs
+++ b/Content.Client/SubFloor/TrayScannerSystem.cs
@@ -1,3 +1,4 @@
+using Content.Client.Hands.Systems;
 using Content.Client.Items;
 using Content.Client.Items.UI;
 using Content.Client.Message;
@@ -33,6 +34,8 @@ public sealed partial class TrayScannerSystem : SharedTrayScannerSystem
     [Dependency] private EntityQuery<TrayScannerComponent> _trayScannerQuery = default!;
     [Dependency] private EntityQuery<SubFloorHideComponent> _subFloorHideQuery = default!;
 
+    [Dependency] private HandsSystem _hands = default!; // Moff
+
     private const string TRayAnimationKey = "trays";
     private const double AnimationLength = 0.3;
 
@@ -67,10 +70,15 @@ public sealed partial class TrayScannerSystem : SharedTrayScannerSystem
         // API is extremely skrungly. If this ever shows up on dottrace ping me and laugh.
         var canSee = false;
 
-        foreach (var item in _inventory.GetHandOrInventoryEntities(player.Value, SlotFlags.POCKET | SlotFlags.EYES)) // Funky change - check eyes
+        foreach (var item in _inventory.GetHandOrInventoryEntities(player.Value)) // Moff - Meson goggles get T-ray functionality
         {
-            if (!_trayScannerQuery.TryGetComponent(item, out var scanner) || !scanner.Enabled)
+            // Moff start - T-ray scanning works in slots defineable in yaml, rather than hardcoded for the t-ray scanner tool
+            if (!_trayScannerQuery.TryGetComponent(item, out var scanner) ||
+                !scanner.Enabled ||
+                !(_inventory.InSlotWithAnyFlags(item, scanner.RequiredSlots)
+                  || _hands.IsHeld(item, out _) && scanner.FunctionsInHand))
                 continue;
+            // Moff end
 
             range = MathF.Max(scanner.Range, range);
             mode = scanner.Mode;

--- a/Content.Shared/SubFloor/TrayScannerComponent.cs
+++ b/Content.Shared/SubFloor/TrayScannerComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Inventory;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes; // Funky change
@@ -56,6 +57,17 @@ public sealed partial class TrayScannerComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier? SoundOff;
+
+    // Moff start - Mesons get t-ray functionality. These defaults preserve the T-ray scanner tool's behavior.
+    /// The slots in which this component functions. For example, the T-Ray scanner works even while it's in the user's
+    /// pocket while Mesons only work while in the user's eyes slot.
+    [DataField]
+    public SlotFlags RequiredSlots = SlotFlags.POCKET;
+
+    /// If true, this component functions while being held, regardless of <see cref="RequiredSlots"/>.
+    [DataField]
+    public bool FunctionsInHand = true;
+    // Moff end
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -72,6 +72,8 @@
   # Moff start - Funky welding
   - type: TrayScanner
     range: 10
+    requiredSlots: [ EYES ]
+    functionsInHand: false
     toggleAction: ActionToggleTrayScanner
     soundOn:
       path: /Audio/Items/flashlight_on.ogg


### PR DESCRIPTION
https://discord.com/channels/1322447119252062260/1540897123644739684

<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug https://discord.com/channels/1322447119252062260/1540897123644739684

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
devmap
possess Urist
put on a jumpsuit
put on mesons
note they're not functioning
turn them on
note they function
take them off
note they don't work in your hand
put them in pocket
note they don't work in your pocket
put them on your face
note they work

Similar thing but verifying that t-rays work in pocket and hand while active still

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

`urist-with-mesons-in-his-pocket-but-no-tray-effect.webp`

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Engineering / Meson goggles no longer continue providing their T-Ray effect while enabled and in your pocket. They must be worn on the face to function.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
