### PR TITLE
Fix ai dead sprites

### DIFF
--- a/Resources/Prototypes/_Moffstation/AppearanceCustomization/station_ai.yml
+++ b/Resources/Prototypes/_Moffstation/AppearanceCustomization/station_ai.yml
@@ -20,7 +20,7 @@
       sprite: _Moffstation/Mobs/Silicon/StationAi/station_ai.rsi
       state: ai_angryface
     Dead: &defaultdead
-      sprite: Mobs/Silicon/StationAi/StationAi/station_ai.rsi
+      sprite: Mobs/Silicon/station_ai.rsi
       state: ai_dead
 
 - type: stationAiCustomization


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
Ai dead sprites were showing an error on moffstation sprites that used the default dead sprite, this fixes it

## Why / Balance
not having error sprites is good

## Test Plan / Technical Details
Open game
Make ai, inhabit it
Wait till the AI dies in mysterious and inexplicable circumstances
Verify sprite works

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Ais now no longer show an error sprite while dead

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
