### PR TITLE
[bugfix] Antag weight fixes

### DIFF
--- a/Resources/Prototypes/_Impstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/events.yml
@@ -1,7 +1,7 @@
 # eeeplet
 - type: entity
   id: EeepSpawn
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule # Moff - ghost roles are NOT weighted
   components:
   - type: StationEvent
     weight: 3.5
@@ -33,7 +33,7 @@
 
 - type: entity
   id: TouristSpawn #three tourists
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule # Moff - ghost roles are NOT weighted
   components:
   - type: StationEvent
     weight: 2

--- a/Resources/Prototypes/_Impstation/GameRules/replicator_event.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/replicator_event.yml
@@ -3,7 +3,7 @@
 # the original Bingle PR can be found here: https://github.com/Goob-Station/Goob-Station/pull/1519
 - type: entity
   id: ReplicatorSpawn
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule # Moff - ghost roles are NOT weighted
   components:
   - type: StationEvent
     earliestStart: 20

--- a/Resources/Prototypes/_Moffstation/GameRules/delivery_service.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/delivery_service.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule
   id: PizzaDeliverySpawn
   components:
   - type: RuleGrids

--- a/Resources/Prototypes/_Moffstation/GameRules/ert.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/ert.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule
   id: ERTGeneral
   components:
   - type: StationEvent
@@ -32,7 +32,7 @@
     - ERTGeneralEnroller
 
 - type: entity # 4 soldiers in a large transport
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule
   id: ERTSecTransport
   components:
   - type: StationEvent
@@ -59,7 +59,7 @@
     - ERTGeneralEnroller
 
 - type: entity # 8 soldiers in a large transport
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule
   id: ERTSecLargeTransport
   components:
   - type: StationEvent
@@ -94,7 +94,7 @@
     - ERTGeneralEnroller
 
 - type: entity # 4 soldiers in a small dropship
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule
   id: ERTSecDropship
   components:
   - type: StationEvent
@@ -121,7 +121,7 @@
     - ERTGeneralEnroller
 
 - type: entity # 8 soldiers in a small dropship
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule
   id: ERTSecLargeDropship
   components:
   - type: StationEvent
@@ -156,7 +156,7 @@
     - ERTGeneralEnroller
 
 - type: entity
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule
   id: ERTJani
   components:
   - type: StationEvent
@@ -180,7 +180,7 @@
     - ERTGeneralEnroller
 
 - type: entity
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule
   id: ERTMed
   components:
   - type: StationEvent
@@ -208,7 +208,7 @@
     - ERTGeneralEnroller
 
 - type: entity
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule
   id: ERTEngi
   components:
   - type: StationEvent
@@ -234,7 +234,7 @@
     - ERTGeneralEnroller
 
 - type: entity
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule
   id: ERTCBURNDropship
   components:
   - type: StationEvent
@@ -256,7 +256,7 @@
     - ERTGeneralEnroller
 
 - type: entity
-  parent: BaseGameRule
+  parent: BaseAntagGhostRoleRule
   id: ERTDeathSquadDropship
   components:
   - type: LoadMapRule

--- a/Resources/Prototypes/_Moffstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/events.yml
@@ -110,7 +110,7 @@
 
 # Pirate corsair
 - type: entity
-  parent: BasePiratesRule
+  parent: [ BasePiratesRule, BaseUnweightedAntagRule ]
   id: PirateCorsairSpawn
   components:
   - type: StationEvent
@@ -154,7 +154,7 @@
 
 # Syndicate soldier spawn
 - type: entity
-  parent: BaseTraitorRule
+  parent: [ BaseTraitorRule, BaseUnweightedAntagRule ]
   id: SyndieVentSoldierSpawn
   components:
   - type: StationEvent

--- a/Resources/Prototypes/_Moffstation/GameRules/listening_outpost.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/listening_outpost.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: BaseGameRule
+  parent: BaseUnweightedAntagRule
   id: BaseSyndicateListeningOutpost
   components:
   - type: ListeningOutpostRule

--- a/Resources/Prototypes/_Moffstation/GameRules/listening_outpost.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/listening_outpost.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: BaseUnweightedAntagRule
+  parent: BaseGameRule
   id: BaseSyndicateListeningOutpost
   components:
   - type: ListeningOutpostRule
@@ -28,7 +28,7 @@
       proto: SyndicateSpy
 
 - type: entity
-  parent: BaseSyndicateListeningOutpost
+  parent: [ BaseSyndicateListeningOutpost, BaseUnweightedAntagRule ]
   id: SyndicateListeningOutpostSpawn
   components:
   - type: StationEvent

--- a/Resources/Prototypes/_Moffstation/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/unknown_shuttles.yml
@@ -1,6 +1,6 @@
 # Man o' War
 - type: entity
-  parent: BaseUnknownShuttleAnnouncedRule
+  parent: [ BaseUnknownShuttleAnnouncedRule, BaseUnweightedAntagRule ]
   id: UnknownShuttleManOWar
   components:
   - type: StationEvent
@@ -33,7 +33,7 @@
 
 # Instigator
 - type: entity
-  parent: BaseUnknownShuttleRule
+  parent: [ BaseUnknownShuttleRule, BaseUnweightedAntagRule ]
   id: UnknownShuttleInstigator
   components:
   - type: StationEvent
@@ -99,7 +99,7 @@
 
 # Syndicate evac pod
 - type: entity
-  parent: BaseUnknownShuttleRule
+  parent: [ BaseUnknownShuttleRule, BaseUnweightedAntagRule ]
   id: UnknownShuttleSyndieEvacPod
   components:
   - type: StationEvent


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Some ghost roles were adding antag weight when they shouldnt. this fixes that

In the future we should be diligent about making sure we give ghost roles the weight exception, because otherwise you get non-antag player with a billion antag weight
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
buxfix
## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Fixed certain ghostroles providing antag weight

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
