### PR TITLE
Increase Spray Painter Capacity

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
@@ -13,7 +13,7 @@
     FlashlightLantern: 5
     ClothingHandsGlovesColorYellowBudget: 3
     SprayPainter: 3
-    SprayPainterAmmo: 5
+    SprayPainterAmmo: 2 # Moff - decrease amount of spray painter ammo
   # Some engineer forgot to take the multitool out the youtool when working on it, happens.
   contrabandInventory:
     Multitool: 1

--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -86,6 +86,7 @@
   description: A cartridge of highly compressed paint, commonly used in spray painters.
   components:
   - type: SprayPainterAmmo
+    charges: 50 # Moff - increase charges from 15 to 50
   - type: Sprite
     sprite: Objects/Tools/spray_painter.rsi
     state: ammo

--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -47,8 +47,8 @@
   - type: StaticPrice
     price: 40
   - type: LimitedCharges
-    maxCharges: 15
-    lastCharges: 15
+    maxCharges: 50 # Moff - increase charges from 15 to 50
+    lastCharges: 50 # Moff - increase charges from 15 to 50
   - type: PhysicalComposition
     materialComposition:
       Steel: 100


### PR DESCRIPTION
## About the PR
A yaml microbalance. Increases the Spray Painter to use 50 charges rather than 15 charges. The YouTool now only holds 2 cans of compressed paint rather than 5.

## Why / Balance
15 charges is not nearly enough for any large project, considering removing decals takes a charge. You're required to fill basically half of your bag full of paint - plus it's pretty unreasonable to ask Cargo to print you insane amounts of compressed paint. Of course you still should have to rely on Cargo/Sci/Engi to get more paint so the YouTool's paint stock has been lowered.

## Test Plan / Technical Details
Painted a bunch of decals, restocked the spray painter. Checked the YouTool to see if the changes were made.

## Media
<img width="661" height="481" alt="image" src="https://github.com/user-attachments/assets/c2dda746-df98-4bc3-8a6e-e7c523e19efb" />
<img width="182" height="65" alt="image" src="https://github.com/user-attachments/assets/007f84c3-16cf-428d-b29b-b9cc95d15555" />
<img width="323" height="136" alt="image" src="https://github.com/user-attachments/assets/496e15a0-1989-4fc6-a4b1-80cf925cba66" />


## Requirements
- [X] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces.
- [X] I have thoroughly tested my changes in-game to ensure they function properly.

## Changelog
:cl:
- tweak: Spray painter capacity increased from 15 to 50
- tweak: YouTool now only has 2 cans of compressed paint