### PR TITLE
Remove Jumpsuit Displacements for Female Humans

### DIFF
--- a/Resources/Prototypes/Body/Species/human.yml
+++ b/Resources/Prototypes/Body/Species/human.yml
@@ -55,13 +55,15 @@
   categories: [ HideSpawnMenu ]
   name: human appearance
   components:
-  - type: Inventory
-    femaleDisplacements:
-      jumpsuit:
-        sizeMaps:
-          32:
-            sprite: Mobs/Species/Human/displacement.rsi
-            state: jumpsuit-female
+# Moff start - remove female displacement maps
+#  - type: Inventory
+#    femaleDisplacements:
+#      jumpsuit:
+#        sizeMaps:
+#          32:
+#            sprite: Mobs/Species/Human/displacement.rsi
+#            state: jumpsuit-female
+# Moff end
   - type: InitialBody
     organs:
       Torso: OrganHumanTorso


### PR DESCRIPTION
## About the PR
Removes the displacement jumpsuits worn on female humans recieve.

## Why / Balance
Interferes with markings as those don't get displaced in the same way that jumpsuits do, so sometimes you can see part of the marking appear where the pixel ended up getting displaced when it should be fully transparent. Also
<img width="819" height="109" alt="image" src="https://github.com/user-attachments/assets/5895c406-c45a-42db-ba0f-d0abffe87f6c" />


## Test Plan / Technical Details
It works, the pixels are no longer displaced. Dwarves already don't use the female displacement maps anyways so those didn't need to be changed.

## Media
<img width="250" height="324" alt="image" src="https://github.com/user-attachments/assets/658c314f-2c7a-420f-8e6b-d75cb71cd4f3" />


## Requirements
- [X] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces.
- [X] I have thoroughly tested my changes in-game to ensure they function properly.

## Changelog
:cl:
- remove: Removed human female jumpsuit displacements
