### PR TITLE
Remove Russian Accent Word Replacements

### DIFF
--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -377,17 +377,19 @@
     accent-german-words-10-2: accent-german-words-replace-10
     accent-german-words-11: accent-german-words-replace-11
 
-- type: accent
-  id: russian
-  wordReplacements:
-    accent-russian-words-1: accent-russian-words-replace-1
-    accent-russian-words-2: accent-russian-words-replace-2
-    accent-russian-words-3: accent-russian-words-replace-3
-    accent-russian-words-3-2: accent-russian-words-replace-3
-    accent-russian-words-3-3: accent-russian-words-replace-3
-    accent-russian-words-4: accent-russian-words-replace-4
-    accent-russian-words-5: accent-russian-words-replace-5
-    accent-russian-words-6: accent-russian-words-replace-6
+# Moff start - remove russian accent word replacements
+#- type: accent
+#  id: russian
+#  wordReplacements:
+#    accent-russian-words-1: accent-russian-words-replace-1
+#    accent-russian-words-2: accent-russian-words-replace-2
+#    accent-russian-words-3: accent-russian-words-replace-3
+#    accent-russian-words-3-2: accent-russian-words-replace-3
+#    accent-russian-words-3-3: accent-russian-words-replace-3
+#    accent-russian-words-4: accent-russian-words-replace-4
+#    accent-russian-words-5: accent-russian-words-replace-5
+#    accent-russian-words-6: accent-russian-words-replace-6
+# Moff end
 
 - type: accent
   id: skeleton


### PR DESCRIPTION
## About the PR
Removes the word replacements used in the russian accent. As follows, they were...
No -> Nyet
Yes -> Da
Grandma -> Babushka
Friend -> Comrade
Cheers -> Na zdorovje

~~Sorry no more tiny micro-PRs today this is the last one~~

## Why / Balance
None of the other accents have word replacements like this anymore that change English words to Other-Language Words. Also a few players who play characters with the accent trait complain about it. It's possible these word replacements are only left in because Russian is not an accent trait upstream and is only used for a single gimmick item, but on Moff we have it selectable as a trait.

## Test Plan / Technical Details
Created a new character with the russian accent trait. Tried all the words. They did not get replaced.

## Media
<img width="283" height="190" alt="image" src="https://github.com/user-attachments/assets/a50e4371-e096-4547-b6cb-5d2312da59a7" />

## Requirements
- [X] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces.
- [X] I have thoroughly tested my changes in-game to ensure they function properly.

## Changelog
- remove: Removed word replacements from the Russian accent
