### PR TITLE
EMP Hardbomb Balance Changes

### DIFF
--- a/Resources/Locale/en-US/_Moffstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Moffstation/store/uplink-catalog.ftl
@@ -31,4 +31,4 @@ uplink-clothing-rocket-skates-desc = An experimental prototype from Lumens Techn
 
 # Explosives
 uplink-exploding-syndicate-emp-bomb-name = Syndicate EMP Bomb
-uplink-exploding-syndicate-emp-bomb-desc = A big, anchored bomb that emits an almost station-wide disabling EMP pulse if not defused in time. Disables electronics for exactly 3 minutes. Has an adjustable fuse.
+uplink-exploding-syndicate-emp-bomb-desc = An anchored bomb that emits a very large disabling EMP pulse if not defused in time. Disables electronics for exactly 3 minutes. Has an adjustable fuse.

--- a/Resources/Prototypes/_Moffstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Moffstation/Catalog/uplink_catalog.yml
@@ -77,10 +77,10 @@
   description: uplink-exploding-syndicate-emp-bomb-desc
   productEntity: SyndicateEmpBomb
   cost:
-    Telecrystal: 8
+    Telecrystal: 6
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 3
   categories:
   - UplinkExplosives
   restockTime: 600
@@ -224,10 +224,10 @@
   description: uplink-exploding-syndicate-emp-bomb-desc
   productEntity: SyndicateEmpBomb
   cost:
-    Telecrystal: 8
+    Telecrystal: 6
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 3
   categories:
   - UplinkExplosives
   conditions:

--- a/Resources/Prototypes/_Moffstation/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Structures/Machines/bombs.yml
@@ -27,7 +27,7 @@
   - type: EmpOnTrigger
     keysIn:
     - timer
-    range: 60
+    range: 45
     energyConsumption: 1000000
     disableDuration: 180
   - type: DeleteOnTrigger


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
TC - 8 to 6
Demolition size - 60 tiles to 45 (to have parity w/ ss13)

## Why / Balance
Besides the parity issues I believe the bomb size was too large considering the fact that it could shut off the AI and force it to need to be reset - it now needs to be placed a bit closer.

Also if you saw this PR before no you didn't. My github was tripping and I just decided to redo it.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- tweak: The EMP hardbomb had its size and price slightly reduced.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
