### PR TITLE
Gamerules count half of unreadied players

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -366,9 +366,15 @@ namespace Content.Server.GameTicking
         // Moffstation - Start - Player count calculated depending on cvar
         public int DynamicPlayerCount()
         {
-            return _cfg.GetCVar(MoffCCVars.GameRulesCountReadied)
-                ? ReadyPlayerCount()
-                : _playerManager.PlayerCount;
+            var unreadiedPlayerWeight = _cfg.GetCVar(MoffCCVars.GameRulesUnreadiedPlayerWeight);
+            if (unreadiedPlayerWeight == 0.0f)
+                return _playerManager.PlayerCount;
+
+            var readied = ReadyPlayerCount();
+            var unreadied = _playerManager.PlayerCount - readied;
+            var unreadiedWeighted = (int) Math.Ceiling(unreadied * unreadiedPlayerWeight);
+
+            return readied + unreadiedWeighted;
         }
         // Moffstation - End
 

--- a/Content.Shared/_Moffstation/CCVar/CCVars.Moff.cs
+++ b/Content.Shared/_Moffstation/CCVar/CCVars.Moff.cs
@@ -64,8 +64,8 @@ public sealed class MoffCCVars
     /// <summary>
     /// if true, the player count check for rules will be based on the number of players readied, versus the total number in the lobby.
     /// </summary>
-    public static readonly CVarDef<bool>
-        GameRulesCountReadied = CVarDef.Create("game.rules_count_readied", true, CVar.SERVERONLY);
+    public static readonly CVarDef<float>
+        GameRulesUnreadiedPlayerWeight = CVarDef.Create("game.unreadied_player_weight", 0.5f, CVar.SERVERONLY);
 
     /// <summary>
     /// Whether longspeech should be enabled


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Gamerules will count half of the unreadied players into the gamerule calculation

How much unreadied people count for can be adjusted via cvar

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Previously we tried going off of pure playercount, this went poorly, because unreadied people for one reason or another often do not actually join the game. This would end in the station getting gamemodes they definitely should not be getting.

Currently we use the vanilla system, which is that the gamemode is calulated based on the number of readied players at the start of the round. This is also not ideal, as you get many people who are latejoiners and will quickly filter within the opening period of the round. This restricts what gamemodes can occur based upon this preference.

This is to say, neither are an accurate representation of how many people will be in round. the gamemodes being selected aren't going to reflect the round's actual population.

This is the literal middleground, half of the unreadied players get counted. My hope is that this allows us to get some of the mid-pop gamemodes more often, without sending too many events to the station that are completely one-sided.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- tweak: All of the readied players, and half the unreadied players are counted in gamemode selection.

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
