### PR TITLE
Permit scurrets to emote

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
@@ -146,6 +146,7 @@
     - CanPilot
     - VimPilot
     - AnomalyHost
+  - type: Emoting
 
 # Spawnable scurrets have a random name and colour.
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
@@ -146,7 +146,7 @@
     - CanPilot
     - VimPilot
     - AnomalyHost
-  - type: Emoting
+  - type: Emoting # Moff
 
 # Spawnable scurrets have a random name and colour.
 


### PR DESCRIPTION
<!--
You are making this pull request for the Moffstation fork of Space Station 14.

Please be sure to follow general guidelines for upstream PRs, but also be sure to follow the Moffstation guidelines.
Guidelines: https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md
-->

## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Player-controllable things, especially sapients, should all be able to emote in a roleplaying game.

## Test Plan / Technical Details
<!-- How did you go about testing the changes you made? For complex changes include some technical details on how to understand the code-->
devmap
spawn scurret
possess it
`@do a little shimmy to indicate that you can emote`

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="250" height="158" alt="image" src="https://github.com/user-attachments/assets/d0c4fb7d-94ac-4bfa-b9a3-4a3091ebfc58" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [x] I have properly sectioned my changes into fork namespaces.
- [x] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Scurrets of all varieties can now emote, e.g. using "@".

<!-- Changelog Changes go above here, these are the templates
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
