### PR TITLE
Derelict Cyborg´s Departmental Radio fix

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -264,6 +264,20 @@
       - BorgModuleEngineering
     hasMindState: borg_e # Moffstation - Early merge of Borg RSI fix
     noMindState: borg_e_r # Moffstation - Early merge of Borg RSI fix
+  # Moffstation - Start - department radio was missing on derelict borgs, gave this one Engineering comms
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Binary
+    - Common
+    - Engineering
+    - Science
+  - type: ActiveRadio
+    channels:
+    - Binary
+    - Common
+    - Engineering
+    - Science
+  # Moffstation - End
 
 - type: entity
   parent: BaseBorgChassisDerelict
@@ -299,6 +313,20 @@
       - BorgModuleJanitor
     hasMindState: borg_e # Moffstation - Early merge of Borg RSI fix
     noMindState: borg_e_r # Moffstation - Early merge of Borg RSI fix
+  # Moffstation - Start - department radio was missing on derelict borgs, gave this one Service comms
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Binary
+    - Common
+    - Service
+    - Science
+  - type: ActiveRadio
+    channels:
+    - Binary
+    - Common
+    - Service
+    - Science
+# Moffstation - End
 
 - type: entity
   parent: BaseBorgChassisDerelict
@@ -341,6 +369,20 @@
   - type: ShowHealthIcons
     damageContainers:
     - Biological
+  # Moffstation - start - department radio was missing on derelict borgs, gave this one Medical comms
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Binary
+    - Common
+    - Medical
+    - Science
+  - type: ActiveRadio
+    channels:
+    - Binary
+    - Common
+    - Medical
+    - Science
+  # Moffstation - End
 
 - type: entity
   parent: BaseBorgChassisDerelict
@@ -378,6 +420,20 @@
       - BorgModuleCargo
     hasMindState: borg_e # Moffstation - Early merge of Borg RSI fix
     noMindState: borg_e_r # Moffstation - Early merge of Borg RSI fix
+  # Moffstation - Start - department radio was missing on derelict borgs, gave this one cargo comms
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Binary
+    - Common
+    - Supply
+    - Science
+  - type: ActiveRadio
+    channels:
+    - Binary
+    - Common
+    - Supply
+    - Science
+  # Moffstation - End
   # Moffstation - Start - Salvage Borg Resprite
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.5

--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -113,6 +113,19 @@
       - BorgModuleService
     hasMindState: borg_e
     noMindState: borg_e_r
+  #department radio was missing on derelict borgs
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Binary
+    - Common
+    - Service
+    - Science
+  - type: ActiveRadio
+    channels:
+    - Binary
+    - Common
+    - Service
+    - Science
 
   #Station Ai Shell
 - type: entity


### PR DESCRIPTION
## About the PR
Gave Derelict Cyborgs Their Departmental Radio Back

## Why / Balance
Derlict Borgs Did not Recive their  Radio Channels
(Excluding the derelict syndicat assault borg wich doesnt get Syndicat comms)
## Test Plan / Technical Details
`BorgSwitchableTypeSystem.SelectBorgModule` is never trigger for Borgs hineriting `BaseBorgChassisDerelict` so i added explicit Intrinnsic Radio Transimmter and Active Radio componets to the chassies
Tested by Spawning every Derelict Borg And confirming working comms
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Moffstation Contributing Guidelines](https://github.com/moff-station/moff-station-14/blob/master/CONTRIBUTING.md).
- [X] I have properly sectioned my changes into fork namespaces.
- [X] I have thoroughly tested my changes in-game to ensure they function properly.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Changelog entries go below the :cl:-->
:cl:
- fix: Fixed Derelict Cyborgs not getting their Departmental Radio´s

<!-- Changelog Changes go above here, these are the templates
-->
